### PR TITLE
fix: implement JSON-RPC 2.0 protocol for MCP workers

### DIFF
--- a/workers/baseball-espn-mcp/src/mcp/agent.ts
+++ b/workers/baseball-espn-mcp/src/mcp/agent.ts
@@ -15,6 +15,25 @@ export interface McpResponse {
   isError?: boolean;
 }
 
+// JSON-RPC 2.0 types for MCP protocol
+interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  method: string;
+  params?: Record<string, any>;
+  id?: string | number | null;
+}
+
+interface JsonRpcResponse {
+  jsonrpc: "2.0";
+  result?: any;
+  error?: {
+    code: number;
+    message: string;
+    data?: any;
+  };
+  id: string | number | null;
+}
+
 export class McpAgent {
   constructor() {}
 
@@ -22,7 +41,7 @@ export class McpAgent {
     const corsHeaders = {
       'Access-Control-Allow-Origin': '*',
       'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-      'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-Clerk-User-ID',
     };
 
     if (request.method === 'OPTIONS') {
@@ -31,44 +50,45 @@ export class McpAgent {
 
     try {
       // Extract Clerk user ID from headers or fallback to anonymous
-      const clerkUserId = request.headers.get('X-Clerk-User-ID') || 
+      const clerkUserId = request.headers.get('X-Clerk-User-ID') ||
                          new URL(request.url).searchParams.get('clerkUserId') ||
                          'anonymous';
 
       const url = new URL(request.url);
-      
+
       // Strip /baseball prefix if present (custom domain routing)
       let pathname = url.pathname;
       if (pathname.startsWith('/baseball')) {
         pathname = pathname.slice(9) || '/';
       }
-      
-      // Handle MCP endpoints
+
+      // Legacy REST endpoints (for backwards compatibility with direct testing)
       if (pathname === '/mcp/tools/list') {
-        return this.handleToolsList(clerkUserId, corsHeaders);
-      }
-      
-      if (pathname === '/mcp/tools/call') {
-        return this.handleToolCall(request, clerkUserId, corsHeaders, env);
-      }
-      
-      if (pathname === '/mcp') {
-        return this.handleMcpRoot(corsHeaders);
+        return this.handleToolsListLegacy(clerkUserId, corsHeaders);
       }
 
-      return new Response('Not Found', { 
-        status: 404, 
-        headers: corsHeaders 
+      if (pathname === '/mcp/tools/call') {
+        return this.handleToolCallLegacy(request, clerkUserId, corsHeaders, env);
+      }
+
+      // Main MCP endpoint - handles JSON-RPC 2.0 protocol (required by OpenAI)
+      if (pathname === '/mcp') {
+        return this.handleJsonRpc(request, clerkUserId, corsHeaders, env);
+      }
+
+      return new Response('Not Found', {
+        status: 404,
+        headers: corsHeaders
       });
 
     } catch (error) {
       console.error('MCP Agent error:', error);
-      
+
       if (error instanceof Response) {
         return error;
       }
 
-      return new Response(JSON.stringify({ 
+      return new Response(JSON.stringify({
         error: 'Internal server error',
         message: error instanceof Error ? error.message : 'Unknown error'
       }), {
@@ -78,23 +98,175 @@ export class McpAgent {
     }
   }
 
-  private async handleMcpRoot(corsHeaders: Record<string, string>): Promise<Response> {
-    return new Response(JSON.stringify({
-      name: 'Fantasy Sports MCP Server',
-      version: '4.0.0',
-      description: 'Open access MCP server for fantasy sports data',
+  /**
+   * Handle JSON-RPC 2.0 requests (MCP Streamable HTTP transport)
+   * This is the protocol OpenAI's Responses API uses for MCP tools
+   */
+  private async handleJsonRpc(request: Request, clerkUserId: string, corsHeaders: Record<string, string>, env: Env): Promise<Response> {
+    // GET requests return server info (for discovery)
+    if (request.method === 'GET') {
+      return new Response(JSON.stringify({
+        name: 'fantasy-baseball-mcp',
+        version: '4.0.0',
+        description: 'ESPN Fantasy Baseball MCP Server',
+        capabilities: {
+          tools: true,
+          resources: false,
+          prompts: false
+        }
+      }), {
+        headers: { 'Content-Type': 'application/json', ...corsHeaders }
+      });
+    }
+
+    // POST requests are JSON-RPC 2.0
+    let rpcRequest: JsonRpcRequest;
+    try {
+      rpcRequest = await request.json() as JsonRpcRequest;
+      console.log(`[MCP] JSON-RPC request: method=${rpcRequest.method}, id=${rpcRequest.id}`);
+    } catch (e) {
+      return this.jsonRpcError(-32700, 'Parse error: Invalid JSON', null, corsHeaders);
+    }
+
+    // Validate JSON-RPC format
+    if (rpcRequest.jsonrpc !== '2.0') {
+      return this.jsonRpcError(-32600, 'Invalid Request: jsonrpc must be "2.0"', rpcRequest.id ?? null, corsHeaders);
+    }
+
+    const authHeader = request.headers.get('Authorization');
+
+    // Route to appropriate handler based on method
+    switch (rpcRequest.method) {
+      case 'initialize':
+        return this.handleInitialize(rpcRequest, corsHeaders);
+
+      case 'tools/list':
+        return this.handleToolsList(rpcRequest, corsHeaders);
+
+      case 'tools/call':
+        return this.handleToolsCall(rpcRequest, clerkUserId, env, authHeader, corsHeaders);
+
+      case 'ping':
+        return this.jsonRpcSuccess({}, rpcRequest.id ?? null, corsHeaders);
+
+      default:
+        return this.jsonRpcError(-32601, `Method not found: ${rpcRequest.method}`, rpcRequest.id ?? null, corsHeaders);
+    }
+  }
+
+  /**
+   * Handle MCP initialize request
+   */
+  private handleInitialize(rpcRequest: JsonRpcRequest, corsHeaders: Record<string, string>): Response {
+    const result = {
+      protocolVersion: '2024-11-05',
+      serverInfo: {
+        name: 'fantasy-baseball-mcp',
+        version: '4.0.0'
+      },
       capabilities: {
-        tools: true,
-        resources: false,
-        prompts: false
+        tools: {}
       }
-    }), {
+    };
+    return this.jsonRpcSuccess(result, rpcRequest.id ?? null, corsHeaders);
+  }
+
+  /**
+   * Handle tools/list JSON-RPC method
+   */
+  private handleToolsList(rpcRequest: JsonRpcRequest, corsHeaders: Record<string, string>): Response {
+    const tools = this.getToolDefinitions();
+    return this.jsonRpcSuccess({ tools }, rpcRequest.id ?? null, corsHeaders);
+  }
+
+  /**
+   * Handle tools/call JSON-RPC method
+   */
+  private async handleToolsCall(
+    rpcRequest: JsonRpcRequest,
+    clerkUserId: string,
+    env: Env,
+    authHeader: string | null,
+    corsHeaders: Record<string, string>
+  ): Promise<Response> {
+    const params = rpcRequest.params || {};
+    const toolName = params.name;
+    const toolArgs = params.arguments || {};
+
+    if (!toolName) {
+      return this.jsonRpcError(-32602, 'Invalid params: missing tool name', rpcRequest.id ?? null, corsHeaders);
+    }
+
+    console.log(`[MCP] Executing tool: ${toolName} with args:`, JSON.stringify(toolArgs));
+
+    try {
+      const result = await this.executeTool(toolName, toolArgs, clerkUserId, env, authHeader);
+
+      // MCP tools/call response format
+      const callResult = {
+        content: [
+          {
+            type: 'text',
+            text: typeof result.content === 'string' ? result.content : JSON.stringify(result.content)
+          }
+        ],
+        isError: result.isError || false
+      };
+
+      return this.jsonRpcSuccess(callResult, rpcRequest.id ?? null, corsHeaders);
+    } catch (error) {
+      console.error(`[MCP] Tool execution error for ${toolName}:`, error);
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+
+      // Return error as tool result (not JSON-RPC error) so OpenAI can handle it gracefully
+      const errorResult = {
+        content: [
+          {
+            type: 'text',
+            text: `Tool execution failed: ${errorMessage}`
+          }
+        ],
+        isError: true
+      };
+
+      return this.jsonRpcSuccess(errorResult, rpcRequest.id ?? null, corsHeaders);
+    }
+  }
+
+  /**
+   * Create a JSON-RPC 2.0 success response
+   */
+  private jsonRpcSuccess(result: any, id: string | number | null, corsHeaders: Record<string, string>): Response {
+    const response: JsonRpcResponse = {
+      jsonrpc: '2.0',
+      result,
+      id
+    };
+    return new Response(JSON.stringify(response), {
       headers: { 'Content-Type': 'application/json', ...corsHeaders }
     });
   }
 
-  private async handleToolsList(_clerkUserId: string, corsHeaders: Record<string, string>): Promise<Response> {
-    const tools = [
+  /**
+   * Create a JSON-RPC 2.0 error response
+   */
+  private jsonRpcError(code: number, message: string, id: string | number | null, corsHeaders: Record<string, string>): Response {
+    const response: JsonRpcResponse = {
+      jsonrpc: '2.0',
+      error: { code, message },
+      id
+    };
+    return new Response(JSON.stringify(response), {
+      status: 200, // JSON-RPC errors still return 200 HTTP status
+      headers: { 'Content-Type': 'application/json', ...corsHeaders }
+    });
+  }
+
+  /**
+   * Get tool definitions in MCP format
+   */
+  private getToolDefinitions() {
+    return [
       {
         name: 'get_espn_league_info',
         description: 'Get ESPN fantasy league information',
@@ -141,13 +313,22 @@ export class McpAgent {
         }
       }
     ];
+  }
 
+  /**
+   * Legacy REST endpoint for tools list (backwards compatibility with curl testing)
+   */
+  private handleToolsListLegacy(_clerkUserId: string, corsHeaders: Record<string, string>): Response {
+    const tools = this.getToolDefinitions();
     return new Response(JSON.stringify({ tools }), {
       headers: { 'Content-Type': 'application/json', ...corsHeaders }
     });
   }
 
-  private async handleToolCall(request: Request, clerkUserId: string, corsHeaders: Record<string, string>, env: Env): Promise<Response> {
+  /**
+   * Legacy REST endpoint for tool calls (backwards compatibility)
+   */
+  private async handleToolCallLegacy(request: Request, clerkUserId: string, corsHeaders: Record<string, string>, env: Env): Promise<Response> {
     const { tool, arguments: args } = await request.json() as McpToolCall;
 
     try {

--- a/workers/football-espn-mcp/src/mcp/football-agent.ts
+++ b/workers/football-espn-mcp/src/mcp/football-agent.ts
@@ -16,6 +16,25 @@ export interface McpResponse {
   isError?: boolean;
 }
 
+// JSON-RPC 2.0 types for MCP protocol
+interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  method: string;
+  params?: Record<string, any>;
+  id?: string | number | null;
+}
+
+interface JsonRpcResponse {
+  jsonrpc: "2.0";
+  result?: any;
+  error?: {
+    code: number;
+    message: string;
+    data?: any;
+  };
+  id: string | number | null;
+}
+
 export class FootballMcpAgent {
   constructor() {}
 
@@ -23,7 +42,7 @@ export class FootballMcpAgent {
     const corsHeaders = {
       'Access-Control-Allow-Origin': '*',
       'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-      'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-Clerk-User-ID',
     };
 
     if (request.method === 'OPTIONS') {
@@ -32,44 +51,45 @@ export class FootballMcpAgent {
 
     try {
       // Extract Clerk user ID from headers (preferred) or fallback to anonymous
-      const clerkUserId = request.headers.get('X-Clerk-User-ID') || 
+      const clerkUserId = request.headers.get('X-Clerk-User-ID') ||
                          new URL(request.url).searchParams.get('clerkUserId') ||
                          'anonymous';
 
       const url = new URL(request.url);
-      
+
       // Strip /football prefix if present (custom domain routing)
       let pathname = url.pathname;
       if (pathname.startsWith('/football')) {
         pathname = pathname.slice(9) || '/';
       }
-      
-      // Handle MCP endpoints
+
+      // Legacy REST endpoints (for backwards compatibility with direct testing)
       if (pathname === '/mcp/tools/list') {
-        return this.handleToolsList(clerkUserId, corsHeaders);
-      }
-      
-      if (pathname === '/mcp/tools/call') {
-        return this.handleToolCall(request, clerkUserId, corsHeaders, env);
-      }
-      
-      if (pathname === '/mcp') {
-        return this.handleMcpRoot(corsHeaders);
+        return this.handleToolsListLegacy(clerkUserId, corsHeaders);
       }
 
-      return new Response('Not Found', { 
-        status: 404, 
-        headers: corsHeaders 
+      if (pathname === '/mcp/tools/call') {
+        return this.handleToolCallLegacy(request, clerkUserId, corsHeaders, env);
+      }
+
+      // Main MCP endpoint - handles JSON-RPC 2.0 protocol (required by OpenAI)
+      if (pathname === '/mcp') {
+        return this.handleJsonRpc(request, clerkUserId, corsHeaders, env);
+      }
+
+      return new Response('Not Found', {
+        status: 404,
+        headers: corsHeaders
       });
 
     } catch (error) {
       console.error('Football MCP Agent error:', error);
-      
+
       if (error instanceof Response) {
         return error;
       }
 
-      return new Response(JSON.stringify({ 
+      return new Response(JSON.stringify({
         error: 'Internal server error',
         message: error instanceof Error ? error.message : 'Unknown error'
       }), {
@@ -79,24 +99,175 @@ export class FootballMcpAgent {
     }
   }
 
-  private async handleMcpRoot(corsHeaders: Record<string, string>): Promise<Response> {
-    return new Response(JSON.stringify({
-      name: 'ESPN Fantasy Football MCP Server',
-      version: '1.0.0',
-      description: 'Open access MCP server for ESPN fantasy football data',
-      sport: 'football',
+  /**
+   * Handle JSON-RPC 2.0 requests (MCP Streamable HTTP transport)
+   * This is the protocol OpenAI's Responses API uses for MCP tools
+   */
+  private async handleJsonRpc(request: Request, clerkUserId: string, corsHeaders: Record<string, string>, env: Env): Promise<Response> {
+    // GET requests return server info (for discovery)
+    if (request.method === 'GET') {
+      return new Response(JSON.stringify({
+        name: 'fantasy-football-mcp',
+        version: '1.0.0',
+        description: 'ESPN Fantasy Football MCP Server',
+        capabilities: {
+          tools: true,
+          resources: false,
+          prompts: false
+        }
+      }), {
+        headers: { 'Content-Type': 'application/json', ...corsHeaders }
+      });
+    }
+
+    // POST requests are JSON-RPC 2.0
+    let rpcRequest: JsonRpcRequest;
+    try {
+      rpcRequest = await request.json() as JsonRpcRequest;
+      console.log(`[MCP Football] JSON-RPC request: method=${rpcRequest.method}, id=${rpcRequest.id}`);
+    } catch (e) {
+      return this.jsonRpcError(-32700, 'Parse error: Invalid JSON', null, corsHeaders);
+    }
+
+    // Validate JSON-RPC format
+    if (rpcRequest.jsonrpc !== '2.0') {
+      return this.jsonRpcError(-32600, 'Invalid Request: jsonrpc must be "2.0"', rpcRequest.id ?? null, corsHeaders);
+    }
+
+    const authHeader = request.headers.get('Authorization');
+
+    // Route to appropriate handler based on method
+    switch (rpcRequest.method) {
+      case 'initialize':
+        return this.handleInitialize(rpcRequest, corsHeaders);
+
+      case 'tools/list':
+        return this.handleToolsList(rpcRequest, corsHeaders);
+
+      case 'tools/call':
+        return this.handleToolsCall(rpcRequest, clerkUserId, env, authHeader, corsHeaders);
+
+      case 'ping':
+        return this.jsonRpcSuccess({}, rpcRequest.id ?? null, corsHeaders);
+
+      default:
+        return this.jsonRpcError(-32601, `Method not found: ${rpcRequest.method}`, rpcRequest.id ?? null, corsHeaders);
+    }
+  }
+
+  /**
+   * Handle MCP initialize request
+   */
+  private handleInitialize(rpcRequest: JsonRpcRequest, corsHeaders: Record<string, string>): Response {
+    const result = {
+      protocolVersion: '2024-11-05',
+      serverInfo: {
+        name: 'fantasy-football-mcp',
+        version: '1.0.0'
+      },
       capabilities: {
-        tools: true,
-        resources: false,
-        prompts: false
+        tools: {}
       }
-    }), {
+    };
+    return this.jsonRpcSuccess(result, rpcRequest.id ?? null, corsHeaders);
+  }
+
+  /**
+   * Handle tools/list JSON-RPC method
+   */
+  private handleToolsList(rpcRequest: JsonRpcRequest, corsHeaders: Record<string, string>): Response {
+    const tools = this.getToolDefinitions();
+    return this.jsonRpcSuccess({ tools }, rpcRequest.id ?? null, corsHeaders);
+  }
+
+  /**
+   * Handle tools/call JSON-RPC method
+   */
+  private async handleToolsCall(
+    rpcRequest: JsonRpcRequest,
+    clerkUserId: string,
+    env: Env,
+    authHeader: string | null,
+    corsHeaders: Record<string, string>
+  ): Promise<Response> {
+    const params = rpcRequest.params || {};
+    const toolName = params.name;
+    const toolArgs = params.arguments || {};
+
+    if (!toolName) {
+      return this.jsonRpcError(-32602, 'Invalid params: missing tool name', rpcRequest.id ?? null, corsHeaders);
+    }
+
+    console.log(`[MCP Football] Executing tool: ${toolName} with args:`, JSON.stringify(toolArgs));
+
+    try {
+      const result = await this.executeTool(toolName, toolArgs, clerkUserId, env, authHeader);
+
+      // MCP tools/call response format
+      const callResult = {
+        content: [
+          {
+            type: 'text',
+            text: typeof result.content === 'string' ? result.content : JSON.stringify(result.content)
+          }
+        ],
+        isError: result.isError || false
+      };
+
+      return this.jsonRpcSuccess(callResult, rpcRequest.id ?? null, corsHeaders);
+    } catch (error) {
+      console.error(`[MCP Football] Tool execution error for ${toolName}:`, error);
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+
+      // Return error as tool result (not JSON-RPC error) so OpenAI can handle it gracefully
+      const errorResult = {
+        content: [
+          {
+            type: 'text',
+            text: `Tool execution failed: ${errorMessage}`
+          }
+        ],
+        isError: true
+      };
+
+      return this.jsonRpcSuccess(errorResult, rpcRequest.id ?? null, corsHeaders);
+    }
+  }
+
+  /**
+   * Create a JSON-RPC 2.0 success response
+   */
+  private jsonRpcSuccess(result: any, id: string | number | null, corsHeaders: Record<string, string>): Response {
+    const response: JsonRpcResponse = {
+      jsonrpc: '2.0',
+      result,
+      id
+    };
+    return new Response(JSON.stringify(response), {
       headers: { 'Content-Type': 'application/json', ...corsHeaders }
     });
   }
 
-  private async handleToolsList(_clerkUserId: string, corsHeaders: Record<string, string>): Promise<Response> {
-    const tools = [
+  /**
+   * Create a JSON-RPC 2.0 error response
+   */
+  private jsonRpcError(code: number, message: string, id: string | number | null, corsHeaders: Record<string, string>): Response {
+    const response: JsonRpcResponse = {
+      jsonrpc: '2.0',
+      error: { code, message },
+      id
+    };
+    return new Response(JSON.stringify(response), {
+      status: 200, // JSON-RPC errors still return 200 HTTP status
+      headers: { 'Content-Type': 'application/json', ...corsHeaders }
+    });
+  }
+
+  /**
+   * Get tool definitions in MCP format
+   */
+  private getToolDefinitions() {
+    return [
       {
         name: 'get_espn_football_league_info',
         description: 'Get ESPN fantasy football league information',
@@ -156,19 +327,28 @@ export class FootballMcpAgent {
         }
       }
     ];
+  }
 
+  /**
+   * Legacy REST endpoint for tools list (backwards compatibility with curl testing)
+   */
+  private handleToolsListLegacy(_clerkUserId: string, corsHeaders: Record<string, string>): Response {
+    const tools = this.getToolDefinitions();
     return new Response(JSON.stringify({ tools }), {
       headers: { 'Content-Type': 'application/json', ...corsHeaders }
     });
   }
 
-  private async handleToolCall(request: Request, clerkUserId: string, corsHeaders: Record<string, string>, env: Env): Promise<Response> {
+  /**
+   * Legacy REST endpoint for tool calls (backwards compatibility)
+   */
+  private async handleToolCallLegacy(request: Request, clerkUserId: string, corsHeaders: Record<string, string>, env: Env): Promise<Response> {
     const { tool, arguments: args } = await request.json() as McpToolCall;
 
     try {
       const authHeader = request.headers.get('Authorization');
       const result = await this.executeTool(tool, args, clerkUserId, env, authHeader);
-      
+
       return new Response(JSON.stringify({
         content: result.content,
         isError: result.isError || false
@@ -178,7 +358,7 @@ export class FootballMcpAgent {
 
     } catch (error) {
       console.error(`Football tool execution error for ${tool}:`, error);
-      
+
       return new Response(JSON.stringify({
         content: `Football tool execution failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
         isError: true
@@ -193,16 +373,16 @@ export class FootballMcpAgent {
     switch (tool) {
       case 'get_espn_football_league_info':
         return this.getEspnFootballLeagueInfo(args, clerkUserId, env, authHeader);
-      
+
       case 'get_espn_football_team':
         return this.getEspnFootballTeam(args, clerkUserId, env, authHeader);
-      
+
       case 'get_espn_football_matchups':
         return this.getEspnFootballMatchups(args, clerkUserId, env, authHeader);
-        
+
       case 'get_espn_football_standings':
         return this.getEspnFootballStandings(args, clerkUserId, env, authHeader);
-      
+
       default:
         throw new Error(`Unknown football tool: ${tool}`);
     }
@@ -211,7 +391,7 @@ export class FootballMcpAgent {
   private async getEspnFootballLeagueInfo(args: Record<string, any>, clerkUserId: string, env: Env, authHeader?: string | null): Promise<McpResponse> {
     try {
       const footballClient = new EspnFootballApiClient(env, { authHeader });
-      
+
       const { leagueId, seasonId = new Date().getFullYear().toString() } = args;
       const league = await footballClient.fetchLeague(leagueId, parseInt(seasonId), 'mSettings', clerkUserId);
 
@@ -246,7 +426,7 @@ export class FootballMcpAgent {
   private async getEspnFootballTeam(args: Record<string, any>, clerkUserId: string, env: Env, authHeader?: string | null): Promise<McpResponse> {
     try {
       const footballClient = new EspnFootballApiClient(env, { authHeader });
-      
+
       const { leagueId, teamId, seasonId = new Date().getFullYear().toString(), week } = args;
       const teamData = await footballClient.fetchTeam(leagueId, teamId, parseInt(seasonId), week, clerkUserId);
 
@@ -271,7 +451,7 @@ export class FootballMcpAgent {
   private async getEspnFootballMatchups(args: Record<string, any>, clerkUserId: string, env: Env, authHeader?: string | null): Promise<McpResponse> {
     try {
       const footballClient = new EspnFootballApiClient(env, { authHeader });
-      
+
       const { leagueId, week, seasonId = new Date().getFullYear().toString() } = args;
       const matchups = await footballClient.fetchMatchups(leagueId, week, parseInt(seasonId), clerkUserId);
 
@@ -296,7 +476,7 @@ export class FootballMcpAgent {
   private async getEspnFootballStandings(args: Record<string, any>, clerkUserId: string, env: Env, authHeader?: string | null): Promise<McpResponse> {
     try {
       const footballClient = new EspnFootballApiClient(env, { authHeader });
-      
+
       const { leagueId, seasonId = new Date().getFullYear().toString() } = args;
       const standings = await footballClient.fetchStandings(leagueId, parseInt(seasonId), clerkUserId);
 

--- a/workers/football-espn-mcp/src/mcp/football-agent.ts
+++ b/workers/football-espn-mcp/src/mcp/football-agent.ts
@@ -123,7 +123,12 @@ export class FootballMcpAgent {
     // POST requests are JSON-RPC 2.0
     let rpcRequest: JsonRpcRequest;
     try {
-      rpcRequest = await request.json() as JsonRpcRequest;
+      const payload = await request.json();
+      // Validate payload structure before type assertion
+      if (!payload || typeof payload !== 'object' || typeof payload.method !== 'string') {
+        return this.jsonRpcError(-32600, 'Invalid Request: Malformed request payload', payload?.id ?? null, corsHeaders);
+      }
+      rpcRequest = payload as JsonRpcRequest;
       console.log(`[MCP Football] JSON-RPC request: method=${rpcRequest.method}, id=${rpcRequest.id}`);
     } catch (e) {
       return this.jsonRpcError(-32700, 'Parse error: Invalid JSON', null, corsHeaders);
@@ -194,8 +199,14 @@ export class FootballMcpAgent {
     const toolName = params.name;
     const toolArgs = params.arguments || {};
 
-    if (!toolName) {
-      return this.jsonRpcError(-32602, 'Invalid params: missing tool name', rpcRequest.id ?? null, corsHeaders);
+    // Validate tool name is a non-empty string
+    if (typeof toolName !== 'string' || !toolName) {
+      return this.jsonRpcError(-32602, 'Invalid params: missing or invalid tool name', rpcRequest.id ?? null, corsHeaders);
+    }
+
+    // Validate arguments is an object (not array, null, or primitive)
+    if (typeof toolArgs !== 'object' || toolArgs === null || Array.isArray(toolArgs)) {
+      return this.jsonRpcError(-32602, 'Invalid params: "arguments" must be an object', rpcRequest.id ?? null, corsHeaders);
     }
 
     console.log(`[MCP Football] Executing tool: ${toolName} with args:`, JSON.stringify(toolArgs));
@@ -343,11 +354,38 @@ export class FootballMcpAgent {
    * Legacy REST endpoint for tool calls (backwards compatibility)
    */
   private async handleToolCallLegacy(request: Request, clerkUserId: string, corsHeaders: Record<string, string>, env: Env): Promise<Response> {
-    const { tool, arguments: args } = await request.json() as McpToolCall;
+    // Parse and validate request body
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return new Response(JSON.stringify({ content: 'Invalid JSON in request body', isError: true }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json', ...corsHeaders }
+      });
+    }
+
+    // Validate body structure
+    if (typeof body !== 'object' || body === null || typeof (body as any).tool !== 'string') {
+      return new Response(JSON.stringify({ content: 'Invalid request body: missing or invalid "tool" field', isError: true }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json', ...corsHeaders }
+      });
+    }
+
+    const { tool, arguments: args } = body as McpToolCall;
+
+    // Validate arguments if provided
+    if (args !== undefined && (typeof args !== 'object' || args === null || Array.isArray(args))) {
+      return new Response(JSON.stringify({ content: 'Invalid arguments: must be an object', isError: true }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json', ...corsHeaders }
+      });
+    }
 
     try {
       const authHeader = request.headers.get('Authorization');
-      const result = await this.executeTool(tool, args, clerkUserId, env, authHeader);
+      const result = await this.executeTool(tool, args || {}, clerkUserId, env, authHeader);
 
       return new Response(JSON.stringify({
         content: result.content,


### PR DESCRIPTION
OpenAI's Responses API MCP integration uses JSON-RPC 2.0 protocol, not REST endpoints. The workers were returning server metadata instead of proper JSON-RPC responses, causing 424 (Failed Dependency) errors when OpenAI tried to list tools.

Changes:
- Add JSON-RPC 2.0 request/response handling at /mcp endpoint
- Implement initialize, tools/list, tools/call, and ping methods
- Keep legacy REST endpoints for backwards compatibility
- Both baseball and football MCP workers updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch MCP workers to JSON-RPC 2.0 at `/mcp` with initialize/tools.list/tools.call/ping, add strict validation and discovery, and retain legacy REST endpoints.
> 
> - **MCP JSON-RPC integration**:
>   - Implement JSON-RPC 2.0 handling at `GET/POST /mcp` in `workers/baseball-espn-mcp/src/mcp/agent.ts` and `workers/football-espn-mcp/src/mcp/football-agent.ts`.
>   - Add methods: `initialize`, `tools/list`, `tools/call`, `ping`; plus helpers `jsonRpcSuccess`/`jsonRpcError` and request validation.
>   - Return discovery metadata on `GET /mcp`; JSON-RPC-compliant responses on POST (including tool call result formatting).
> - **Legacy compatibility**:
>   - Preserve REST endpoints as `handleToolsListLegacy` and `handleToolCallLegacy` with input validation.
> - **Tooling**:
>   - Centralize and expose MCP `tools` definitions for baseball and football.
>   - Ensure auth header propagation and Clerk user handling; add `X-Clerk-User-ID` to CORS.
> - **Routing/infra**:
>   - Normalize path prefixes (`/baseball`, `/football`) before routing.
>   - Standardize error handling and status codes for JSON-RPC (errors still return HTTP 200).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit edbc907fa2049770d6ab0efccc05b97f50263b0c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->