### PR TITLE
fix: improve ESPN credential error visibility and diagnostics

### DIFF
--- a/openai/lib/tools/tools.ts
+++ b/openai/lib/tools/tools.ts
@@ -89,9 +89,9 @@ export const getTools = () => {
     !!mcpConfig.server_url &&
     !!mcpConfig.server_label;
 
-  // Debug logging for MCP auth troubleshooting
+  // Debug logging for MCP auth troubleshooting (avoid logging token metadata for security)
   console.log(`[MCP Config] Platform: ${selectedPlatform}, Authenticated: ${isAuthenticated}, Server URL: ${mcpConfig.server_url ? 'set' : 'NOT SET'}, Should enable: ${shouldEnableMcp}`);
-  console.log(`[MCP Auth] User ID: ${clerkUserId ? 'present' : 'MISSING'}, Token: ${clerkToken ? `present (${clerkToken.length} chars)` : 'MISSING'}`);
+  console.log(`[MCP Auth] User ID: ${clerkUserId ? 'present' : 'MISSING'}, Token: ${clerkToken ? 'present' : 'MISSING'}`);
 
   if (!mcpGloballyDisabled && mcpEnabled && shouldEnableMcp) {
     // Validate MCP server URL

--- a/openai/lib/tools/tools.ts
+++ b/openai/lib/tools/tools.ts
@@ -89,6 +89,10 @@ export const getTools = () => {
     !!mcpConfig.server_url &&
     !!mcpConfig.server_label;
 
+  // Debug logging for MCP auth troubleshooting
+  console.log(`[MCP Config] Platform: ${selectedPlatform}, Authenticated: ${isAuthenticated}, Server URL: ${mcpConfig.server_url ? 'set' : 'NOT SET'}, Should enable: ${shouldEnableMcp}`);
+  console.log(`[MCP Auth] User ID: ${clerkUserId ? 'present' : 'MISSING'}, Token: ${clerkToken ? `present (${clerkToken.length} chars)` : 'MISSING'}`);
+
   if (!mcpGloballyDisabled && mcpEnabled && shouldEnableMcp) {
     // Validate MCP server URL
     if (
@@ -107,6 +111,7 @@ export const getTools = () => {
         "Token:",
         !!clerkToken
       );
+      console.warn("[WARN] MCP calls may fail - user should refresh the page to get a fresh token");
       // Still proceed - some MCP servers might not require auth
     }
 

--- a/workers/baseball-espn-mcp/src/espn.ts
+++ b/workers/baseball-espn-mcp/src/espn.ts
@@ -106,7 +106,6 @@ export class EspnApiClient {
         throw new Error(`ESPN_ACCESS_DENIED: Access denied to baseball league ${leagueId}. Make sure you're a member of this league.`);
       }
 
-      const errorText = await response.text();
       throw new Error(`ESPN_API_ERROR: ESPN returned error ${response.status}. Please try again.`);
     }
 

--- a/workers/baseball-espn-mcp/src/espn.ts
+++ b/workers/baseball-espn-mcp/src/espn.ts
@@ -18,7 +18,7 @@ export class EspnApiClient {
 
   async fetchLeague(leagueId: string, year: number = 2025, view: string = 'mSettings', clerkUserId?: string): Promise<EspnLeagueResponse> {
     const url = `${this.baseUrl}/games/flb/seasons/${year}/segments/0/leagues/${leagueId}?view=${view}`;
-    
+
     const headers: Record<string, string> = {
       'User-Agent': 'baseball-espn-mcp/1.0',
       'Accept': 'application/json',
@@ -26,39 +26,38 @@ export class EspnApiClient {
       'X-Fantasy-Platform': 'kona-web-2.0.0'
     };
 
-    // Try to get user-specific ESPN credentials first
-    let credentials: EspnCredentials | null = null;
-    if (clerkUserId && this.authHeader) {
-      credentials = await this.getEspnCredentialsForUser(clerkUserId);
-    }
-
-    // Add authentication cookies if available
-    if (credentials) {
+    // Get ESPN credentials from auth-worker (required for private leagues)
+    if (clerkUserId && clerkUserId !== 'anonymous' && this.authHeader) {
+      const credentials = await this.getEspnCredentialsForUser(clerkUserId);
       headers['Cookie'] = `SWID=${credentials.swid}; espn_s2=${credentials.s2}`;
+    } else if (!clerkUserId || clerkUserId === 'anonymous') {
+      console.warn('⚠️ No user ID provided - attempting unauthenticated ESPN request');
+    } else if (!this.authHeader) {
+      console.warn('⚠️ No auth header provided - attempting unauthenticated ESPN request');
     }
 
     const response = await fetch(url, {
       headers,
       cf: { cacheEverything: false }
     });
-    
+
     if (!response.ok) {
       // Handle ESPN-specific error codes
       if (response.status === 401) {
-        throw new Error('ESPN authentication failed - check auth-worker credentials');
+        throw new Error('ESPN_COOKIES_EXPIRED: Your ESPN cookies may have expired. Please update them in Settings > ESPN Authentication.');
       }
       if (response.status === 429) {
-        throw new Error('ESPN rate limit exceeded - please retry later');
+        throw new Error('ESPN_RATE_LIMIT: ESPN rate limit exceeded. Please wait a moment and try again.');
       }
       if (response.status === 404) {
-        throw new Error(`League ${leagueId} not found or not accessible`);
+        throw new Error(`ESPN_NOT_FOUND: Baseball league ${leagueId} not found. Please check the league ID.`);
       }
       if (response.status === 403) {
-        throw new Error(`Access denied to league ${leagueId} - may require authentication`);
+        throw new Error(`ESPN_ACCESS_DENIED: Access denied to baseball league ${leagueId}. This league may be private - make sure your ESPN credentials are set up in Settings.`);
       }
-      
+
       const errorText = await response.text();
-      throw new Error(`ESPN API error ${response.status}: ${errorText}`);
+      throw new Error(`ESPN_API_ERROR: ESPN returned error ${response.status}. Please try again.`);
     }
 
     return await response.json();
@@ -69,7 +68,7 @@ export class EspnApiClient {
     if (week) {
       url += `&scoringPeriodId=${week}`;
     }
-    
+
     const headers: Record<string, string> = {
       'User-Agent': 'baseball-espn-mcp/1.0',
       'Accept': 'application/json',
@@ -77,40 +76,38 @@ export class EspnApiClient {
       'X-Fantasy-Platform': 'kona-web-2.0.0'
     };
 
-    // Get user credentials for roster data (typically requires authentication)
-    let credentials: EspnCredentials | null = null;
-    if (clerkUserId && this.authHeader) {
-      credentials = await this.getEspnCredentialsForUser(clerkUserId);
+    // Authentication required for roster data
+    if (!clerkUserId || clerkUserId === 'anonymous') {
+      throw new Error('ESPN_AUTH_REQUIRED: User authentication required for roster data. Please sign in and try again.');
+    }
+    if (!this.authHeader) {
+      throw new Error('ESPN_AUTH_REQUIRED: Authorization header missing. Please refresh the page and try again.');
     }
 
-    // Authentication required for roster data
-    if (credentials) {
-      headers['Cookie'] = `SWID=${credentials.swid}; espn_s2=${credentials.s2}`;
-    } else {
-      throw new Error('ESPN authentication required for roster data - please provide ESPN credentials');
-    }
+    const credentials = await this.getEspnCredentialsForUser(clerkUserId);
+    headers['Cookie'] = `SWID=${credentials.swid}; espn_s2=${credentials.s2}`;
 
     const response = await fetch(url, {
       headers,
       cf: { cacheEverything: false }
     });
-    
+
     if (!response.ok) {
       if (response.status === 401) {
-        throw new Error('ESPN authentication failed - check auth-worker credentials');
+        throw new Error('ESPN_COOKIES_EXPIRED: Your ESPN cookies may have expired. Please update them in Settings > ESPN Authentication.');
       }
       if (response.status === 429) {
-        throw new Error('ESPN rate limit exceeded - please retry later');
+        throw new Error('ESPN_RATE_LIMIT: ESPN rate limit exceeded. Please wait a moment and try again.');
       }
       if (response.status === 404) {
-        throw new Error(`League ${leagueId} or team ${teamId} not found`);
+        throw new Error(`ESPN_NOT_FOUND: Baseball league ${leagueId} or team ${teamId} not found.`);
       }
       if (response.status === 403) {
-        throw new Error(`Access denied to league ${leagueId} roster data`);
+        throw new Error(`ESPN_ACCESS_DENIED: Access denied to baseball league ${leagueId}. Make sure you're a member of this league.`);
       }
-      
+
       const errorText = await response.text();
-      throw new Error(`ESPN API error ${response.status}: ${errorText}`);
+      throw new Error(`ESPN_API_ERROR: ESPN returned error ${response.status}. Please try again.`);
     }
 
     const data = await response.json() as EspnRosterResponse;
@@ -134,50 +131,51 @@ export class EspnApiClient {
 
   /**
    * Get ESPN credentials from auth-worker
+   * Throws errors with specific messages instead of returning null silently
    */
-  private async getEspnCredentialsForUser(clerkUserId: string): Promise<EspnCredentials | null> {
-    try {
-      // HTTP call to auth worker for credentials (stateless pattern)
-      const authWorkerUrl = this.env.AUTH_WORKER_URL || 'http://localhost:8786';
-      const url = `${authWorkerUrl}/credentials/espn?raw=true`;
-      
-      console.log(`🔑 Fetching ESPN credentials for user ${clerkUserId} from ${url}`);
-      
-      const response = await fetch(url, {
-        method: 'GET',
-        headers: {
-          'X-Clerk-User-ID': clerkUserId,
-          'Content-Type': 'application/json',
-          ...(this.authHeader ? { 'Authorization': this.authHeader } : {})
-        }
-      });
-      
-      console.log(`📡 Auth-worker response: ${response.status} ${response.statusText}`);
-      
-      if (response.status === 404) {
-        console.log('ℹ️ No ESPN credentials found for user');
-        return null;
+  private async getEspnCredentialsForUser(clerkUserId: string): Promise<EspnCredentials> {
+    // HTTP call to auth worker for credentials (stateless pattern)
+    const authWorkerUrl = this.env.AUTH_WORKER_URL || 'http://localhost:8786';
+    const url = `${authWorkerUrl}/credentials/espn?raw=true`;
+
+    console.log(`🔑 Fetching ESPN credentials for user ${clerkUserId} from ${url}`);
+    console.log(`🔑 Auth header present: ${!!this.authHeader}`);
+
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'X-Clerk-User-ID': clerkUserId,
+        'Content-Type': 'application/json',
+        ...(this.authHeader ? { 'Authorization': this.authHeader } : {})
       }
-      
-      if (!response.ok) {
-        console.error(`❌ Auth-worker error: ${response.status} ${response.statusText}`);
-        const errorData = await response.json().catch(() => ({})) as { error?: string };
-        throw new Error(`Auth-worker error: ${errorData.error || response.statusText}`);
-      }
-      
-      const data = await response.json() as { success?: boolean; credentials?: EspnCredentials };
-      
-      if (!data.success || !data.credentials) {
-        console.error('❌ Invalid response from auth-worker:', data);
-        throw new Error('Invalid credentials response from auth-worker');
-      }
-      
-      console.log('✅ Successfully retrieved ESPN credentials');
-      return data.credentials;
-      
-    } catch (error) {
-      console.error('❌ Failed to fetch credentials from auth-worker:', error);
-      return null;
+    });
+
+    console.log(`📡 Auth-worker response: ${response.status} ${response.statusText}`);
+
+    if (response.status === 404) {
+      console.log('ℹ️ No ESPN credentials found for user');
+      throw new Error('ESPN_CREDENTIALS_NOT_FOUND: Please set up your ESPN credentials in Settings. Go to Settings > ESPN Authentication to add your espn_s2 and SWID cookies.');
     }
+
+    if (response.status === 401) {
+      console.error('❌ Auth-worker rejected token');
+      throw new Error('ESPN_AUTH_TOKEN_INVALID: Your session has expired. Please refresh the page and try again.');
+    }
+
+    if (!response.ok) {
+      console.error(`❌ Auth-worker error: ${response.status} ${response.statusText}`);
+      const errorData = await response.json().catch(() => ({})) as { error?: string };
+      throw new Error(`ESPN_AUTH_WORKER_ERROR: Unable to retrieve credentials (${response.status}). Please try again.`);
+    }
+
+    const data = await response.json() as { success?: boolean; credentials?: EspnCredentials };
+
+    if (!data.success || !data.credentials) {
+      console.error('❌ Invalid response from auth-worker:', data);
+      throw new Error('ESPN_CREDENTIALS_INVALID: Received invalid credentials from server. Please re-enter your ESPN credentials in Settings.');
+    }
+
+    console.log('✅ Successfully retrieved ESPN credentials');
+    return data.credentials;
   }
 }

--- a/workers/baseball-espn-mcp/src/mcp/agent.ts
+++ b/workers/baseball-espn-mcp/src/mcp/agent.ts
@@ -49,10 +49,15 @@ export class McpAgent {
     }
 
     try {
-      // Extract Clerk user ID from headers or fallback to anonymous
-      const clerkUserId = request.headers.get('X-Clerk-User-ID') ||
+      // Extract Clerk user ID from headers (preferred) or fallback to anonymous
+      const clerkUserIdHeader = request.headers.get('X-Clerk-User-ID');
+      const authHeader = request.headers.get('Authorization');
+      const clerkUserId = clerkUserIdHeader ||
                          new URL(request.url).searchParams.get('clerkUserId') ||
                          'anonymous';
+
+      // Debug logging for auth issues
+      console.log(`[MCP Baseball Auth] User ID header: ${clerkUserIdHeader ? 'present' : 'MISSING'}, Auth header: ${authHeader ? 'present' : 'MISSING'}, Resolved userId: ${clerkUserId}`);
 
       const url = new URL(request.url);
 

--- a/workers/football-espn-mcp/src/espn-football-client.ts
+++ b/workers/football-espn-mcp/src/espn-football-client.ts
@@ -32,15 +32,14 @@ export class EspnFootballApiClient {
       'X-Fantasy-Platform': 'kona-web-2.0.0'
     };
 
-    // Get ESPN credentials from auth-worker
-    let credentials: EspnCredentials | null = null;
-    if (clerkUserId && this.authHeader) {
-      credentials = await this.getEspnCredentialsForUser(clerkUserId);
-    }
-
-    // Add authentication cookies if available
-    if (credentials) {
+    // Get ESPN credentials from auth-worker (required for private leagues)
+    if (clerkUserId && clerkUserId !== 'anonymous' && this.authHeader) {
+      const credentials = await this.getEspnCredentialsForUser(clerkUserId);
       headers['Cookie'] = `SWID=${credentials.swid}; espn_s2=${credentials.s2}`;
+    } else if (!clerkUserId || clerkUserId === 'anonymous') {
+      console.warn('⚠️ No user ID provided - attempting unauthenticated ESPN request');
+    } else if (!this.authHeader) {
+      console.warn('⚠️ No auth header provided - attempting unauthenticated ESPN request');
     }
 
     const response = await fetch(url, {
@@ -51,20 +50,20 @@ export class EspnFootballApiClient {
     if (!response.ok) {
       // Handle ESPN-specific error codes for football
       if (response.status === 401) {
-        throw new Error('ESPN authentication failed - check auth-worker credentials');
+        throw new Error('ESPN_COOKIES_EXPIRED: Your ESPN cookies may have expired. Please update them in Settings > ESPN Authentication.');
       }
       if (response.status === 429) {
-        throw new Error('ESPN rate limit exceeded - please retry later');
+        throw new Error('ESPN_RATE_LIMIT: ESPN rate limit exceeded. Please wait a moment and try again.');
       }
       if (response.status === 404) {
-        throw new Error(`Football league ${leagueId} not found or not accessible`);
+        throw new Error(`ESPN_NOT_FOUND: Football league ${leagueId} not found. Please check the league ID.`);
       }
       if (response.status === 403) {
-        throw new Error(`Access denied to football league ${leagueId} - may require authentication`);
+        throw new Error(`ESPN_ACCESS_DENIED: Access denied to football league ${leagueId}. This league may be private - make sure your ESPN credentials are set up in Settings.`);
       }
 
       const errorText = await response.text();
-      throw new Error(`ESPN Football API error ${response.status}: ${errorText}`);
+      throw new Error(`ESPN_API_ERROR: ESPN returned error ${response.status}. Please try again.`);
     }
 
     return await response.json();
@@ -83,18 +82,16 @@ export class EspnFootballApiClient {
       'X-Fantasy-Platform': 'kona-web-2.0.0'
     };
 
-    // Get user credentials for team data
-    let credentials: EspnCredentials | null = null;
-    if (clerkUserId && this.authHeader) {
-      credentials = await this.getEspnCredentialsForUser(clerkUserId);
+    // Authentication required for team data
+    if (!clerkUserId || clerkUserId === 'anonymous') {
+      throw new Error('ESPN_AUTH_REQUIRED: User authentication required for team data. Please sign in and try again.');
+    }
+    if (!this.authHeader) {
+      throw new Error('ESPN_AUTH_REQUIRED: Authorization header missing. Please refresh the page and try again.');
     }
 
-    // Authentication required for team data
-    if (credentials) {
-      headers['Cookie'] = `SWID=${credentials.swid}; espn_s2=${credentials.s2}`;
-    } else {
-      throw new Error('ESPN authentication required for team data - please provide ESPN credentials');
-    }
+    const credentials = await this.getEspnCredentialsForUser(clerkUserId);
+    headers['Cookie'] = `SWID=${credentials.swid}; espn_s2=${credentials.s2}`;
 
     const response = await fetch(url, {
       headers,
@@ -103,20 +100,20 @@ export class EspnFootballApiClient {
 
     if (!response.ok) {
       if (response.status === 401) {
-        throw new Error('ESPN authentication failed - check auth-worker credentials');
+        throw new Error('ESPN_COOKIES_EXPIRED: Your ESPN cookies may have expired. Please update them in Settings > ESPN Authentication.');
       }
       if (response.status === 429) {
-        throw new Error('ESPN rate limit exceeded - please retry later');
+        throw new Error('ESPN_RATE_LIMIT: ESPN rate limit exceeded. Please wait a moment and try again.');
       }
       if (response.status === 404) {
-        throw new Error(`Football league ${leagueId} or team ${teamId} not found`);
+        throw new Error(`ESPN_NOT_FOUND: Football league ${leagueId} or team ${teamId} not found.`);
       }
       if (response.status === 403) {
-        throw new Error(`Access denied to football league ${leagueId} team data`);
+        throw new Error(`ESPN_ACCESS_DENIED: Access denied to football league ${leagueId}. Make sure you're a member of this league.`);
       }
 
       const errorText = await response.text();
-      throw new Error(`ESPN Football API error ${response.status}: ${errorText}`);
+      throw new Error(`ESPN_API_ERROR: ESPN returned error ${response.status}. Please try again.`);
     }
 
     const data = await response.json() as EspnFootballTeamResponse;
@@ -151,14 +148,14 @@ export class EspnFootballApiClient {
       'X-Fantasy-Platform': 'kona-web-2.0.0'
     };
 
-    // Get user credentials
-    let credentials: EspnCredentials | null = null;
-    if (clerkUserId && this.authHeader) {
-      credentials = await this.getEspnCredentialsForUser(clerkUserId);
-    }
-
-    if (credentials) {
+    // Get user credentials for matchup data
+    if (clerkUserId && clerkUserId !== 'anonymous' && this.authHeader) {
+      const credentials = await this.getEspnCredentialsForUser(clerkUserId);
       headers['Cookie'] = `SWID=${credentials.swid}; espn_s2=${credentials.s2}`;
+    } else if (!clerkUserId || clerkUserId === 'anonymous') {
+      console.warn('⚠️ No user ID provided - attempting unauthenticated ESPN matchup request');
+    } else if (!this.authHeader) {
+      console.warn('⚠️ No auth header provided - attempting unauthenticated ESPN matchup request');
     }
 
     const response = await fetch(url, {
@@ -168,20 +165,20 @@ export class EspnFootballApiClient {
 
     if (!response.ok) {
       if (response.status === 401) {
-        throw new Error('ESPN authentication failed - check auth-worker credentials');
+        throw new Error('ESPN_COOKIES_EXPIRED: Your ESPN cookies may have expired. Please update them in Settings > ESPN Authentication.');
       }
       if (response.status === 429) {
-        throw new Error('ESPN rate limit exceeded - please retry later');
+        throw new Error('ESPN_RATE_LIMIT: ESPN rate limit exceeded. Please wait a moment and try again.');
       }
       if (response.status === 404) {
-        throw new Error(`Football league ${leagueId} not found`);
+        throw new Error(`ESPN_NOT_FOUND: Football league ${leagueId} not found. Please check the league ID.`);
       }
       if (response.status === 403) {
-        throw new Error(`Access denied to football league ${leagueId} matchup data`);
+        throw new Error(`ESPN_ACCESS_DENIED: Access denied to football league ${leagueId} matchup data. Make sure your ESPN credentials are set up in Settings.`);
       }
 
       const errorText = await response.text();
-      throw new Error(`ESPN Football API error ${response.status}: ${errorText}`);
+      throw new Error(`ESPN_API_ERROR: ESPN returned error ${response.status}. Please try again.`);
     }
 
     return await response.json();
@@ -197,14 +194,14 @@ export class EspnFootballApiClient {
       'X-Fantasy-Platform': 'kona-web-2.0.0'
     };
 
-    // Get user credentials
-    let credentials: EspnCredentials | null = null;
-    if (clerkUserId && this.authHeader) {
-      credentials = await this.getEspnCredentialsForUser(clerkUserId);
-    }
-
-    if (credentials) {
+    // Get user credentials for standings data
+    if (clerkUserId && clerkUserId !== 'anonymous' && this.authHeader) {
+      const credentials = await this.getEspnCredentialsForUser(clerkUserId);
       headers['Cookie'] = `SWID=${credentials.swid}; espn_s2=${credentials.s2}`;
+    } else if (!clerkUserId || clerkUserId === 'anonymous') {
+      console.warn('⚠️ No user ID provided - attempting unauthenticated ESPN standings request');
+    } else if (!this.authHeader) {
+      console.warn('⚠️ No auth header provided - attempting unauthenticated ESPN standings request');
     }
 
     const response = await fetch(url, {
@@ -214,20 +211,20 @@ export class EspnFootballApiClient {
 
     if (!response.ok) {
       if (response.status === 401) {
-        throw new Error('ESPN authentication failed - check auth-worker credentials');
+        throw new Error('ESPN_COOKIES_EXPIRED: Your ESPN cookies may have expired. Please update them in Settings > ESPN Authentication.');
       }
       if (response.status === 429) {
-        throw new Error('ESPN rate limit exceeded - please retry later');
+        throw new Error('ESPN_RATE_LIMIT: ESPN rate limit exceeded. Please wait a moment and try again.');
       }
       if (response.status === 404) {
-        throw new Error(`Football league ${leagueId} not found`);
+        throw new Error(`ESPN_NOT_FOUND: Football league ${leagueId} not found. Please check the league ID.`);
       }
       if (response.status === 403) {
-        throw new Error(`Access denied to football league ${leagueId} standings`);
+        throw new Error(`ESPN_ACCESS_DENIED: Access denied to football league ${leagueId} standings. Make sure your ESPN credentials are set up in Settings.`);
       }
 
       const errorText = await response.text();
-      throw new Error(`ESPN Football API error ${response.status}: ${errorText}`);
+      throw new Error(`ESPN_API_ERROR: ESPN returned error ${response.status}. Please try again.`);
     }
 
     return await response.json();
@@ -235,50 +232,51 @@ export class EspnFootballApiClient {
 
   /**
    * Get ESPN credentials from auth-worker
+   * Throws errors with specific messages instead of returning null silently
    */
-  private async getEspnCredentialsForUser(clerkUserId: string): Promise<EspnCredentials | null> {
-    try {
-      // HTTP call to auth worker for credentials (stateless pattern)
-      const authWorkerUrl = this.env.AUTH_WORKER_URL || 'http://localhost:8786';
-      const url = `${authWorkerUrl}/credentials/espn?raw=true`;
+  private async getEspnCredentialsForUser(clerkUserId: string): Promise<EspnCredentials> {
+    // HTTP call to auth worker for credentials (stateless pattern)
+    const authWorkerUrl = this.env.AUTH_WORKER_URL || 'http://localhost:8786';
+    const url = `${authWorkerUrl}/credentials/espn?raw=true`;
 
-      console.log(`🔑 Fetching ESPN credentials for user ${clerkUserId} from ${url}`);
+    console.log(`🔑 Fetching ESPN credentials for user ${clerkUserId} from ${url}`);
+    console.log(`🔑 Auth header present: ${!!this.authHeader}`);
 
-      const response = await fetch(url, {
-        method: 'GET',
-        headers: {
-          'X-Clerk-User-ID': clerkUserId,
-          'Content-Type': 'application/json',
-          ...(this.authHeader ? { 'Authorization': this.authHeader } : {})
-        }
-      });
-
-      console.log(`📡 Auth-worker response: ${response.status} ${response.statusText}`);
-
-      if (response.status === 404) {
-        console.log('ℹ️ No ESPN credentials found for user');
-        return null;
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'X-Clerk-User-ID': clerkUserId,
+        'Content-Type': 'application/json',
+        ...(this.authHeader ? { 'Authorization': this.authHeader } : {})
       }
+    });
 
-      if (!response.ok) {
-        console.error(`❌ Auth-worker error: ${response.status} ${response.statusText}`);
-        const errorData = await response.json().catch(() => ({})) as { error?: string };
-        throw new Error(`Auth-worker error: ${errorData.error || response.statusText}`);
-      }
+    console.log(`📡 Auth-worker response: ${response.status} ${response.statusText}`);
 
-      const data = await response.json() as { success?: boolean; credentials?: EspnCredentials };
-
-      if (!data.success || !data.credentials) {
-        console.error('❌ Invalid response from auth-worker:', data);
-        throw new Error('Invalid credentials response from auth-worker');
-      }
-
-      console.log('✅ Successfully retrieved ESPN credentials');
-      return data.credentials;
-
-    } catch (error) {
-      console.error('❌ Failed to fetch credentials from auth-worker:', error);
-      return null;
+    if (response.status === 404) {
+      console.log('ℹ️ No ESPN credentials found for user');
+      throw new Error('ESPN_CREDENTIALS_NOT_FOUND: Please set up your ESPN credentials in Settings. Go to Settings > ESPN Authentication to add your espn_s2 and SWID cookies.');
     }
+
+    if (response.status === 401) {
+      console.error('❌ Auth-worker rejected token');
+      throw new Error('ESPN_AUTH_TOKEN_INVALID: Your session has expired. Please refresh the page and try again.');
+    }
+
+    if (!response.ok) {
+      console.error(`❌ Auth-worker error: ${response.status} ${response.statusText}`);
+      const errorData = await response.json().catch(() => ({})) as { error?: string };
+      throw new Error(`ESPN_AUTH_WORKER_ERROR: Unable to retrieve credentials (${response.status}). Please try again.`);
+    }
+
+    const data = await response.json() as { success?: boolean; credentials?: EspnCredentials };
+
+    if (!data.success || !data.credentials) {
+      console.error('❌ Invalid response from auth-worker:', data);
+      throw new Error('ESPN_CREDENTIALS_INVALID: Received invalid credentials from server. Please re-enter your ESPN credentials in Settings.');
+    }
+
+    console.log('✅ Successfully retrieved ESPN credentials');
+    return data.credentials;
   }
 }

--- a/workers/football-espn-mcp/src/espn-football-client.ts
+++ b/workers/football-espn-mcp/src/espn-football-client.ts
@@ -32,14 +32,12 @@ export class EspnFootballApiClient {
       'X-Fantasy-Platform': 'kona-web-2.0.0'
     };
 
-    // Get ESPN credentials from auth-worker (required for private leagues)
+    // Get ESPN credentials from auth-worker (optional - public leagues work without)
     if (clerkUserId && clerkUserId !== 'anonymous' && this.authHeader) {
       const credentials = await this.getEspnCredentialsForUser(clerkUserId);
-      headers['Cookie'] = `SWID=${credentials.swid}; espn_s2=${credentials.s2}`;
-    } else if (!clerkUserId || clerkUserId === 'anonymous') {
-      console.warn('⚠️ No user ID provided - attempting unauthenticated ESPN request');
-    } else if (!this.authHeader) {
-      console.warn('⚠️ No auth header provided - attempting unauthenticated ESPN request');
+      if (credentials) {
+        headers['Cookie'] = `SWID=${credentials.swid}; espn_s2=${credentials.s2}`;
+      }
     }
 
     const response = await fetch(url, {
@@ -62,7 +60,6 @@ export class EspnFootballApiClient {
         throw new Error(`ESPN_ACCESS_DENIED: Access denied to football league ${leagueId}. This league may be private - make sure your ESPN credentials are set up in Settings.`);
       }
 
-      const errorText = await response.text();
       throw new Error(`ESPN_API_ERROR: ESPN returned error ${response.status}. Please try again.`);
     }
 
@@ -91,6 +88,9 @@ export class EspnFootballApiClient {
     }
 
     const credentials = await this.getEspnCredentialsForUser(clerkUserId);
+    if (!credentials) {
+      throw new Error('ESPN_CREDENTIALS_NOT_FOUND: Please set up your ESPN credentials in Settings. Go to Settings > ESPN Authentication to add your espn_s2 and SWID cookies.');
+    }
     headers['Cookie'] = `SWID=${credentials.swid}; espn_s2=${credentials.s2}`;
 
     const response = await fetch(url, {
@@ -148,14 +148,12 @@ export class EspnFootballApiClient {
       'X-Fantasy-Platform': 'kona-web-2.0.0'
     };
 
-    // Get user credentials for matchup data
+    // Get user credentials for matchup data (optional - public leagues work without)
     if (clerkUserId && clerkUserId !== 'anonymous' && this.authHeader) {
       const credentials = await this.getEspnCredentialsForUser(clerkUserId);
-      headers['Cookie'] = `SWID=${credentials.swid}; espn_s2=${credentials.s2}`;
-    } else if (!clerkUserId || clerkUserId === 'anonymous') {
-      console.warn('⚠️ No user ID provided - attempting unauthenticated ESPN matchup request');
-    } else if (!this.authHeader) {
-      console.warn('⚠️ No auth header provided - attempting unauthenticated ESPN matchup request');
+      if (credentials) {
+        headers['Cookie'] = `SWID=${credentials.swid}; espn_s2=${credentials.s2}`;
+      }
     }
 
     const response = await fetch(url, {
@@ -194,14 +192,12 @@ export class EspnFootballApiClient {
       'X-Fantasy-Platform': 'kona-web-2.0.0'
     };
 
-    // Get user credentials for standings data
+    // Get user credentials for standings data (optional - public leagues work without)
     if (clerkUserId && clerkUserId !== 'anonymous' && this.authHeader) {
       const credentials = await this.getEspnCredentialsForUser(clerkUserId);
-      headers['Cookie'] = `SWID=${credentials.swid}; espn_s2=${credentials.s2}`;
-    } else if (!clerkUserId || clerkUserId === 'anonymous') {
-      console.warn('⚠️ No user ID provided - attempting unauthenticated ESPN standings request');
-    } else if (!this.authHeader) {
-      console.warn('⚠️ No auth header provided - attempting unauthenticated ESPN standings request');
+      if (credentials) {
+        headers['Cookie'] = `SWID=${credentials.swid}; espn_s2=${credentials.s2}`;
+      }
     }
 
     const response = await fetch(url, {
@@ -232,14 +228,20 @@ export class EspnFootballApiClient {
 
   /**
    * Get ESPN credentials from auth-worker
-   * Throws errors with specific messages instead of returning null silently
+   * Returns null if credentials not found (allows public league access)
+   * Throws specific errors for auth failures and other issues
    */
-  private async getEspnCredentialsForUser(clerkUserId: string): Promise<EspnCredentials> {
-    // HTTP call to auth worker for credentials (stateless pattern)
+  private async getEspnCredentialsForUser(clerkUserId: string): Promise<EspnCredentials | null> {
+    // Validate AUTH_WORKER_URL in production
+    const isProd = this.env.ENVIRONMENT === 'production' || this.env.NODE_ENV === 'production';
+    if (!this.env.AUTH_WORKER_URL && isProd) {
+      throw new Error('ESPN_CONFIG_ERROR: AUTH_WORKER_URL not configured. Please contact support.');
+    }
+
     const authWorkerUrl = this.env.AUTH_WORKER_URL || 'http://localhost:8786';
     const url = `${authWorkerUrl}/credentials/espn?raw=true`;
 
-    console.log(`🔑 Fetching ESPN credentials for user ${clerkUserId} from ${url}`);
+    console.log(`🔑 Fetching ESPN credentials for user ${clerkUserId}`);
     console.log(`🔑 Auth header present: ${!!this.authHeader}`);
 
     const response = await fetch(url, {
@@ -253,9 +255,10 @@ export class EspnFootballApiClient {
 
     console.log(`📡 Auth-worker response: ${response.status} ${response.statusText}`);
 
+    // 404 = no credentials found - return null to allow public league access
     if (response.status === 404) {
-      console.log('ℹ️ No ESPN credentials found for user');
-      throw new Error('ESPN_CREDENTIALS_NOT_FOUND: Please set up your ESPN credentials in Settings. Go to Settings > ESPN Authentication to add your espn_s2 and SWID cookies.');
+      console.log('ℹ️ No ESPN credentials found for user - proceeding without auth');
+      return null;
     }
 
     if (response.status === 401) {
@@ -265,7 +268,6 @@ export class EspnFootballApiClient {
 
     if (!response.ok) {
       console.error(`❌ Auth-worker error: ${response.status} ${response.statusText}`);
-      const errorData = await response.json().catch(() => ({})) as { error?: string };
       throw new Error(`ESPN_AUTH_WORKER_ERROR: Unable to retrieve credentials (${response.status}). Please try again.`);
     }
 

--- a/workers/football-espn-mcp/src/espn-football-client.ts
+++ b/workers/football-espn-mcp/src/espn-football-client.ts
@@ -112,7 +112,6 @@ export class EspnFootballApiClient {
         throw new Error(`ESPN_ACCESS_DENIED: Access denied to football league ${leagueId}. Make sure you're a member of this league.`);
       }
 
-      const errorText = await response.text();
       throw new Error(`ESPN_API_ERROR: ESPN returned error ${response.status}. Please try again.`);
     }
 
@@ -175,7 +174,6 @@ export class EspnFootballApiClient {
         throw new Error(`ESPN_ACCESS_DENIED: Access denied to football league ${leagueId} matchup data. Make sure your ESPN credentials are set up in Settings.`);
       }
 
-      const errorText = await response.text();
       throw new Error(`ESPN_API_ERROR: ESPN returned error ${response.status}. Please try again.`);
     }
 
@@ -219,7 +217,6 @@ export class EspnFootballApiClient {
         throw new Error(`ESPN_ACCESS_DENIED: Access denied to football league ${leagueId} standings. Make sure your ESPN credentials are set up in Settings.`);
       }
 
-      const errorText = await response.text();
       throw new Error(`ESPN_API_ERROR: ESPN returned error ${response.status}. Please try again.`);
     }
 

--- a/workers/football-espn-mcp/src/mcp/football-agent.ts
+++ b/workers/football-espn-mcp/src/mcp/football-agent.ts
@@ -51,9 +51,14 @@ export class FootballMcpAgent {
 
     try {
       // Extract Clerk user ID from headers (preferred) or fallback to anonymous
-      const clerkUserId = request.headers.get('X-Clerk-User-ID') ||
+      const clerkUserIdHeader = request.headers.get('X-Clerk-User-ID');
+      const authHeader = request.headers.get('Authorization');
+      const clerkUserId = clerkUserIdHeader ||
                          new URL(request.url).searchParams.get('clerkUserId') ||
                          'anonymous';
+
+      // Debug logging for auth issues
+      console.log(`[MCP Football Auth] User ID header: ${clerkUserIdHeader ? 'present' : 'MISSING'}, Auth header: ${authHeader ? 'present' : 'MISSING'}, Resolved userId: ${clerkUserId}`);
 
       const url = new URL(request.url);
 


### PR DESCRIPTION
- Add auth header logging in football-agent for debugging MCP auth issues
- Replace silent null returns with descriptive error codes (ESPN_CREDENTIALS_NOT_FOUND, ESPN_COOKIES_EXPIRED, etc.)
- Add diagnostic logging to tools.ts to surface auth header status
- Standardize error messages to give actionable user guidance

This helps diagnose issues where users see generic "authentication issue" errors
by surfacing specific error codes that indicate:
- Missing ESPN credentials vs expired cookies
- Missing auth headers vs expired tokens
- Access denied vs network errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds auth debug logging and explicit ESPN error codes, enforces auth for roster/team endpoints, and refactors credential retrieval with clearer failures.
> 
> - **MCP/Tools**
>   - Add auth/debug logs in `openai/lib/tools/tools.ts` to surface platform, auth, and token presence; warn when tokens missing.
>   - Include Clerk headers in MCP tool config when available.
> - **Baseball MCP (`workers/baseball-espn-mcp`)**
>   - `espn.ts`:
>     - Optional credentials for public league fetches; enforce auth for `fetchRoster` with clear errors (`ESPN_AUTH_REQUIRED`, `ESPN_CREDENTIALS_NOT_FOUND`).
>     - Standardize ESPN response errors with explicit codes (`ESPN_COOKIES_EXPIRED`, `ESPN_RATE_LIMIT`, `ESPN_NOT_FOUND`, `ESPN_ACCESS_DENIED`, `ESPN_API_ERROR`).
>     - Refactor credential retrieval to validate prod config, handle `404` as no creds, and throw specific errors (`ESPN_AUTH_TOKEN_INVALID`, `ESPN_AUTH_WORKER_ERROR`, `ESPN_CREDENTIALS_INVALID`).
>   - `mcp/agent.ts`:
>     - Log auth header/user ID presence for troubleshooting; no protocol changes.
> - **Football MCP (`workers/football-espn-mcp`)**
>   - `espn-football-client.ts`:
>     - Optional creds for public endpoints; require auth for `fetchTeam` with specific errors.
>     - Align error messages/codes across league/team/matchups/standings.
>     - Refactor credential retrieval with prod config validation and explicit failure codes (same as baseball).
>   - `mcp/football-agent.ts`:
>     - Add auth debug logging of headers/user ID; keep JSON-RPC behavior unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9fe8f6398188076ab5fbe6ff9b7bc77fa852df83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->