### PR TITLE
Add debug logging to credential retrieval for troubleshooting

### DIFF
--- a/workers/auth-worker/src/index.ts
+++ b/workers/auth-worker/src/index.ts
@@ -270,6 +270,8 @@ export default {
       if (pathname === '/credentials/espn') {
         // Extract Clerk User ID from header
         const { userId: clerkUserId, error: authError } = await getVerifiedUserId(request, env);
+        console.log(`🔐 [auth-worker] /credentials/espn - Verified user: ${clerkUserId || 'null'}, authError: ${authError || 'none'}`);
+
         if (!clerkUserId) {
           return new Response(JSON.stringify({
             error: 'Authentication required',
@@ -321,7 +323,9 @@ export default {
 
           if (getRawCredentials) {
             // Return actual credentials for sport workers
-            console.log(`🔍 [auth-worker] GET credentials for user: ${clerkUserId}`);
+            console.log(`🔍 [auth-worker] GET raw credentials for user: ${clerkUserId}`);
+            console.log(`🔍 [auth-worker] Authorization header present: ${!!request.headers.get('Authorization')}`);
+            console.log(`🔍 [auth-worker] X-Clerk-User-ID header: ${request.headers.get('X-Clerk-User-ID')}`);
             const credentials = await storage.getCredentials(clerkUserId);
 
             if (!credentials) {

--- a/workers/auth-worker/src/supabase-storage.ts
+++ b/workers/auth-worker/src/supabase-storage.ts
@@ -82,7 +82,12 @@ export class EspnSupabaseStorage {
    */
   async getCredentials(clerkUserId: string): Promise<EspnCredentials | null> {
     try {
-      if (!clerkUserId) return null;
+      if (!clerkUserId) {
+        console.log('[supabase-storage] getCredentials: no clerkUserId provided');
+        return null;
+      }
+
+      console.log(`[supabase-storage] getCredentials: fetching for user ${clerkUserId}`);
 
       const { data, error } = await this.supabase
         .from('espn_credentials')
@@ -90,7 +95,22 @@ export class EspnSupabaseStorage {
         .eq('clerk_user_id', clerkUserId)
         .single();
 
-      if (error || !data) return null;
+      if (error) {
+        console.log(`[supabase-storage] getCredentials error:`, error.code, error.message);
+        return null;
+      }
+
+      if (!data) {
+        console.log(`[supabase-storage] getCredentials: no data returned`);
+        return null;
+      }
+
+      console.log(`[supabase-storage] getCredentials: found data, swid length=${data.swid?.length || 0}, s2 length=${data.s2?.length || 0}`);
+
+      if (!data.swid || !data.s2) {
+        console.log(`[supabase-storage] getCredentials: swid or s2 is empty/null`);
+        return null;
+      }
 
       return {
         swid: data.swid,
@@ -107,7 +127,12 @@ export class EspnSupabaseStorage {
    */
   async getCredentialMetadata(clerkUserId: string): Promise<{ hasCredentials: boolean; email?: string; lastUpdated?: string } | null> {
     try {
-      if (!clerkUserId) return null;
+      if (!clerkUserId) {
+        console.log('[supabase-storage] getCredentialMetadata: no clerkUserId provided');
+        return null;
+      }
+
+      console.log(`[supabase-storage] getCredentialMetadata: checking for user ${clerkUserId}`);
 
       const { data, error } = await this.supabase
         .from('espn_credentials')
@@ -115,9 +140,17 @@ export class EspnSupabaseStorage {
         .eq('clerk_user_id', clerkUserId)
         .single();
 
-      if (error || !data) {
+      if (error) {
+        console.log(`[supabase-storage] getCredentialMetadata error:`, error.code, error.message);
         return { hasCredentials: false };
       }
+
+      if (!data) {
+        console.log(`[supabase-storage] getCredentialMetadata: no data returned`);
+        return { hasCredentials: false };
+      }
+
+      console.log(`[supabase-storage] getCredentialMetadata: found record, email=${data.email || 'none'}, updated_at=${data.updated_at}`);
 
       return {
         hasCredentials: true,


### PR DESCRIPTION
Adds detailed logging to auth-worker credential operations to help
diagnose why auto-pull is failing with CREDENTIALS_MISSING despite
credentials existing in Supabase. Logs show:
- Verified user ID from JWT
- Supabase query results for metadata and raw credentials
- Whether swid/s2 values are null or empty