### PR TITLE
Improve baseball roster tool output

### DIFF
--- a/workers/baseball-espn-mcp/src/espn.ts
+++ b/workers/baseball-espn-mcp/src/espn.ts
@@ -62,7 +62,7 @@ export class EspnApiClient {
     return await response.json();
   }
 
-  async fetchRoster(leagueId: string, teamId: string, year: number = 2025, week?: number, clerkUserId?: string): Promise<EspnTeam> {
+  async fetchRoster(leagueId: string, teamId: string | undefined, year: number = 2025, week?: number, clerkUserId?: string): Promise<EspnTeam> {
     let url = `${this.baseUrl}/games/flb/seasons/${year}/segments/0/leagues/${leagueId}?view=mRoster`;
     if (week) {
       url += `&scoringPeriodId=${week}`;
@@ -102,7 +102,7 @@ export class EspnApiClient {
         throw new Error('ESPN_RATE_LIMIT: ESPN rate limit exceeded. Please wait a moment and try again.');
       }
       if (response.status === 404) {
-        throw new Error(`ESPN_NOT_FOUND: Baseball league ${leagueId} or team ${teamId} not found.`);
+        throw new Error(`ESPN_NOT_FOUND: Baseball league ${leagueId} or team ${teamId ?? 'unknown'} not found.`);
       }
       if (response.status === 403) {
         throw new Error(`ESPN_ACCESS_DENIED: Access denied to baseball league ${leagueId}. Make sure you're a member of this league.`);


### PR DESCRIPTION
### Motivation
- Provide a simpler shape for clients to consume roster data by exposing the roster entries array directly. 
- Fail fast with a clear message when no `teamId` can be resolved to guide users to select a team. 

### Description
- Add an explicit check for `normalizedArgs.teamId` and throw a descriptive `Error` when it is missing. 
- Use `normalizedArgs.teamId` directly when calling `espnClient.fetchRoster`. 
- Extract `rosterEntries` as `roster?.roster?.entries ?? []` and include it in the JSON response payload alongside the original `data` field. 

### Testing
- No automated tests were run (reason: not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bb25f494c8333ab44e9a38313bae9)