### PR TITLE
Tighten baseball roster typings and clean roster tool response

### DIFF
--- a/workers/baseball-espn-mcp/src/espn.ts
+++ b/workers/baseball-espn-mcp/src/espn.ts
@@ -62,7 +62,7 @@ export class EspnApiClient {
     return await response.json();
   }
 
-  async fetchRoster(leagueId: string, teamId: string, year: number = 2025, week?: number, clerkUserId?: string): Promise<EspnTeam> {
+  async fetchRoster(leagueId: string, teamId: string | undefined, year: number = 2025, week?: number, clerkUserId?: string): Promise<EspnTeam> {
     let url = `${this.baseUrl}/games/flb/seasons/${year}/segments/0/leagues/${leagueId}?view=mRoster`;
     if (week) {
       url += `&scoringPeriodId=${week}`;
@@ -102,7 +102,7 @@ export class EspnApiClient {
         throw new Error('ESPN_RATE_LIMIT: ESPN rate limit exceeded. Please wait a moment and try again.');
       }
       if (response.status === 404) {
-        throw new Error(`ESPN_NOT_FOUND: Baseball league ${leagueId} or team ${teamId} not found.`);
+        throw new Error(`ESPN_NOT_FOUND: Baseball league ${leagueId} or team ${teamId ?? 'unknown'} not found.`);
       }
       if (response.status === 403) {
         throw new Error(`ESPN_ACCESS_DENIED: Access denied to baseball league ${leagueId}. Make sure you're a member of this league.`);

--- a/workers/baseball-espn-mcp/src/mcp/sdk-agent.ts
+++ b/workers/baseball-espn-mcp/src/mcp/sdk-agent.ts
@@ -439,6 +439,14 @@ export function createBaseballMcpServer(ctx: McpContext): McpServer {
           };
         });
         const resolvedTeamId = normalizedArgs.teamId ?? roster?.id?.toString();
+        const rosterSummary = roster
+          ? {
+              id: roster.id,
+              abbrev: roster.abbrev,
+              location: roster.location,
+              nickname: roster.nickname,
+            }
+          : null;
 
         logTool({
           request_id: requestId,
@@ -456,7 +464,7 @@ export function createBaseballMcpServer(ctx: McpContext): McpServer {
               text: JSON.stringify(
                 {
                   success: true,
-                  data: roster,
+                  data: rosterSummary,
                   roster: rosterPlayers,
                   leagueId: normalizedArgs.leagueId,
                   teamId: resolvedTeamId,

--- a/workers/baseball-espn-mcp/src/mcp/sdk-agent.ts
+++ b/workers/baseball-espn-mcp/src/mcp/sdk-agent.ts
@@ -417,11 +417,28 @@ export function createBaseballMcpServer(ctx: McpContext): McpServer {
 
         const roster = await espnClient.fetchRoster(
           normalizedArgs.leagueId,
-          normalizedArgs.teamId!,
-          parseInt(normalizedArgs.seasonId),
+          normalizedArgs.teamId,
+          parseInt(normalizedArgs.seasonId, 10),
           undefined,
           clerkUserId
         );
+
+        const rosterEntries = roster?.roster?.entries ?? [];
+        const rosterPlayers = rosterEntries.map((entry) => {
+          const player = entry?.playerPoolEntry?.player ?? entry?.player;
+          return {
+            playerId: player?.id,
+            name: player?.fullName ?? player?.name,
+            proTeamId: player?.proTeamId,
+            proTeamAbbrev: player?.proTeamAbbreviation,
+            primaryPositionId: player?.defaultPositionId,
+            lineupSlotId: entry?.lineupSlotId,
+            lineupSlot: entry?.lineupSlot,
+            injuryStatus: player?.injuryStatus,
+            status: player?.status,
+          };
+        });
+        const resolvedTeamId = normalizedArgs.teamId ?? roster?.id?.toString();
 
         logTool({
           request_id: requestId,
@@ -440,9 +457,10 @@ export function createBaseballMcpServer(ctx: McpContext): McpServer {
                 {
                   success: true,
                   data: roster,
+                  roster: rosterPlayers,
                   leagueId: normalizedArgs.leagueId,
-                  teamId: normalizedArgs.teamId,
-                  year: parseInt(normalizedArgs.seasonId),
+                  teamId: resolvedTeamId,
+                  year: parseInt(normalizedArgs.seasonId, 10),
                 },
                 null,
                 2

--- a/workers/baseball-espn-mcp/src/types/espn.ts
+++ b/workers/baseball-espn-mcp/src/types/espn.ts
@@ -89,30 +89,23 @@ export interface EspnTeam {
   };
 }
 
+export interface EspnPlayer {
+  id?: number;
+  fullName?: string;
+  name?: string;
+  proTeamId?: number;
+  proTeamAbbreviation?: string;
+  defaultPositionId?: number;
+  injuryStatus?: string;
+  status?: string;
+}
+
 export interface RosterEntry {
   lineupSlotId?: number;
   lineupSlot?: string;
-  player?: {
-    id?: number;
-    fullName?: string;
-    name?: string;
-    proTeamId?: number;
-    proTeamAbbreviation?: string;
-    defaultPositionId?: number;
-    injuryStatus?: string;
-    status?: string;
-  };
+  player?: EspnPlayer;
   playerPoolEntry?: {
-    player?: {
-      id?: number;
-      fullName?: string;
-      name?: string;
-      proTeamId?: number;
-      proTeamAbbreviation?: string;
-      defaultPositionId?: number;
-      injuryStatus?: string;
-      status?: string;
-    };
+    player?: EspnPlayer;
   };
 }
 

--- a/workers/baseball-espn-mcp/src/types/espn.ts
+++ b/workers/baseball-espn-mcp/src/types/espn.ts
@@ -85,7 +85,34 @@ export interface EspnTeam {
   location: string;
   nickname: string;
   roster?: {
-    entries: any[];
+    entries: RosterEntry[];
+  };
+}
+
+export interface RosterEntry {
+  lineupSlotId?: number;
+  lineupSlot?: string;
+  player?: {
+    id?: number;
+    fullName?: string;
+    name?: string;
+    proTeamId?: number;
+    proTeamAbbreviation?: string;
+    defaultPositionId?: number;
+    injuryStatus?: string;
+    status?: string;
+  };
+  playerPoolEntry?: {
+    player?: {
+      id?: number;
+      fullName?: string;
+      name?: string;
+      proTeamId?: number;
+      proTeamAbbreviation?: string;
+      defaultPositionId?: number;
+      injuryStatus?: string;
+      status?: string;
+    };
   };
 }
 


### PR DESCRIPTION
### Motivation
- Improve type safety for ESPN roster data and address code-review feedback about `any[]`, `parseInt` usage, and response duplication.

### Description
- Add a `RosterEntry` interface and replace `any[]` with `RosterEntry[]` for `EspnTeam.roster.entries` in `workers/baseball-espn-mcp/src/types/espn.ts` to restore static typing.
- Make `fetchRoster` accept an optional `teamId` and improve the 404 error message to include `teamId ?? 'unknown'` so missing team IDs are clearer (ESPN client changes in `workers/baseball-espn-mcp/src/espn.ts`).
- Remove the non-null assertion for `teamId`, compute a simplified `rosterPlayers` list from `roster?.roster?.entries`, add `resolvedTeamId`, and stop returning the duplicated raw `rosterEntries` in the tool response in `workers/baseball-espn-mcp/src/mcp/sdk-agent.ts`.
- Add explicit radix `10` to `parseInt` calls for `seasonId` conversions to follow best practices.

### Testing
- No automated tests were run (`not run (not requested)`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bb25f494c8333ab44e9a38313bae9)