### PR TITLE
Filter invalid roster entries in baseball roster tool

### DIFF
--- a/workers/baseball-espn-mcp/src/mcp/sdk-agent.ts
+++ b/workers/baseball-espn-mcp/src/mcp/sdk-agent.ts
@@ -424,20 +424,25 @@ export function createBaseballMcpServer(ctx: McpContext): McpServer {
         );
 
         const rosterEntries = roster?.roster?.entries ?? [];
-        const rosterPlayers = rosterEntries.map((entry) => {
-          const player = entry?.playerPoolEntry?.player ?? entry?.player;
-          return {
-            playerId: player?.id,
-            name: player?.fullName ?? player?.name,
-            proTeamId: player?.proTeamId,
-            proTeamAbbrev: player?.proTeamAbbreviation,
-            primaryPositionId: player?.defaultPositionId,
-            lineupSlotId: entry?.lineupSlotId,
-            lineupSlot: entry?.lineupSlot,
-            injuryStatus: player?.injuryStatus,
-            status: player?.status,
-          };
-        });
+        const rosterPlayers = rosterEntries
+          .map((entry) => {
+            const player = entry?.playerPoolEntry?.player ?? entry?.player;
+            if (!player || (!player.id && !player.fullName && !player.name)) {
+              return null;
+            }
+            return {
+              playerId: player.id,
+              name: player.fullName ?? player.name,
+              proTeamId: player.proTeamId,
+              proTeamAbbrev: player.proTeamAbbreviation,
+              primaryPositionId: player.defaultPositionId,
+              lineupSlotId: entry?.lineupSlotId,
+              lineupSlot: entry?.lineupSlot,
+              injuryStatus: player.injuryStatus,
+              status: player.status,
+            };
+          })
+          .filter((player): player is NonNullable<typeof player> => player !== null);
         const resolvedTeamId = normalizedArgs.teamId ?? roster?.id?.toString();
         const rosterSummary = roster
           ? {


### PR DESCRIPTION
### Motivation
- Prevent a potential runtime error and avoid returning objects with all-undefined fields when neither `playerPoolEntry.player` nor `entry.player` is present. 
- Improve type safety because `RosterEntry` has optional properties and the mapping previously did not validate required player identifiers.

### Description
- Update `workers/baseball-espn-mcp/src/mcp/sdk-agent.ts` to map `roster.roster.entries` and return `null` for entries where `player` is missing or lacks `id`, `fullName`, and `name`.
- Map remaining entries to a cleaned player object using direct properties for `playerId`, `name`, `proTeamId`, `proTeamAbbrev`, `primaryPositionId`, `lineupSlotId`, `lineupSlot`, `injuryStatus`, and `status`.
- Filter out `null` values with a type guard so the final `rosterPlayers` array contains only valid, non-null entries.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bc91259bc8333a1a558496e9910a3)