### PR TITLE
feat: Sleeper Phase 2 — get_free_agents, KV player cache, transaction enrichment

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,10 @@ Follow Keep a Changelog; SemVer applies.
 - Sleeper username-based onboarding with historical season discovery (up to 5 years)
 - New `sleeper-client` Cloudflare Worker
 - `sleeper_connections` and `sleeper_leagues` database tables
+- **Sleeper Phase 2**: `get_free_agents` for Sleeper NFL and NBA through unified gateway
+- **Sleeper Phase 2**: KV-backed player index cache (`SLEEPER_PLAYERS_CACHE`) with 24h TTL and in-memory fallback
+- **Sleeper Phase 2**: Sleeper transactions now enriched with player name, position, and team from KV cache
+- **Sleeper Phase 2**: `get_free_agents` gateway schema updated to accept `platform: "sleeper"` alongside ESPN and Yahoo
 
 ### MCP
 - **Added**: OpenAI `toolInvocation` status messages on all 7 MCP tools — ChatGPT now shows contextual status text (e.g., "Fetching standings…") instead of generic "Called tool" while tools run.

--- a/docs/CONNECTOR-DOCS.md
+++ b/docs/CONNECTOR-DOCS.md
@@ -81,6 +81,15 @@ These are intentionally short and “directory reviewer friendly”.
    - “Who are the best available free agents in my league right now?”
    - “Show best available QBs in my league.”
 
+5. **Transactions**
+   - “Show recent transactions in my default league.”
+   - “Show week 8 transactions for ESPN football league 12345678 in 2025.”
+   - “Show recent Yahoo transactions for league 423.l.193847 in 2025 (adds/drops/trades).”
+
+For Yahoo in v1, avoid requesting `type=waiver` and avoid relying on explicit `week` filtering:
+- Yahoo ignores explicit `week` and always uses a recent 14-day timestamp window.
+- Yahoo `type=waiver` filtering is intentionally unsupported in v1.
+
 ## Troubleshooting
 
 - **“Authentication required” / “token expired”**: re-run the client’s connect flow (Gemini CLI: `/mcp auth flaim`; Claude/ChatGPT: click Connect and approve).

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,7 +2,7 @@
 
 Facts that should stay in sync with the codebase.
 
-Last updated: 2026-02-23
+Last updated: 2026-02-24
 
 ## Current Delivery Phase
 
@@ -59,7 +59,7 @@ Sleeper tool coverage (Phase 1): `get_league_info`, `get_standings`, `get_roster
 - Structured eval logs implemented across all 5 workers.
 - Artifact layout is trace-scoped in `flaim-eval`.
 - Acceptance tooling exists (`npm run accept`, `npm run presubmit`).
-- Latest full eval run (`2026-02-19T13-39-48Z`) completed `9/9`, `0` errored.
+- Latest full eval run (`2026-02-24T00-56-48Z`) completed `17/17`, `0` errored.
 - Latest acceptance + presubmit for that run are `PASS`.
 - All MCP tools have complete annotation set (`readOnlyHint`, `openWorldHint`, `destructiveHint`).
 - All MCP tools have OpenAI `toolInvocation` status metadata (`invoking`/`invoked` messages).

--- a/docs/dev/2026-02-22-ios-app-research.md
+++ b/docs/dev/2026-02-22-ios-app-research.md
@@ -1,14 +1,15 @@
 # iOS App Research: On-Device Foundation Models + Flaim MCP
 
 **Date:** 2026-02-22
+**Last verified:** 2026-02-24
 **Status:** Research complete, not started
-**Decision:** Worth pursuing as a fun/learning project with App Store distribution upside. Not a priority over directory submissions or draft-season marketing.
+**Decision (updated):** Proceed only with a timeboxed spike. Do not commit to MVP until the spike passes explicit go/no-go criteria.
 
 ---
 
 ## Summary
 
-Investigated building a native iOS app that wraps Flaim's MCP gateway using Apple's on-device Foundation Models framework (~3B parameter LLM with tool calling). All key technical claims from the initial deep-research report were independently verified. The approach is technically feasible but has significant constraints that shape the product design.
+Investigated building a native iOS app that wraps Flaim's MCP gateway using Apple's on-device Foundation Models framework (~3B parameter LLM with tool calling). The approach is technically feasible but has significant constraints that shape the product design.
 
 **Primary motivation:** App Store distribution as a discoverability channel (not AI superiority over Claude/ChatGPT).
 
@@ -45,6 +46,12 @@ Investigated building a native iOS app that wraps Flaim's MCP gateway using Appl
 - ~7 GB storage required for on-device models
 - Auto-enabled since iOS 18.3 (opt-out, not opt-in)
 - Available in 16+ languages; not available in China mainland
+
+### Corrections From Independent Verification
+
+- The App Store fantasy + AI category is **not** greenfield. There is existing competition (for example, WalterPicks and RotoBot).
+- Repository stars and "last pushed" metrics are point-in-time snapshots and should not be used as durable decision inputs.
+- The strongest durable technical constraints remain token budget, device/region availability, and solo-maintenance cost.
 
 ---
 
@@ -87,7 +94,7 @@ The motivation is **discoverability**, not on-device AI superiority.
 App Store advantages:
 - You control the submission
 - Search is powerful ("fantasy football AI", "fantasy assistant")
-- The "AI-powered fantasy copilot" category is novel — no direct competition
+- Direct distribution channel independent of connector directory approval timelines
 - Ratings/reviews create a flywheel
 - **Draft season (Aug-Sep)** is when fantasy app downloads spike massively
 
@@ -100,7 +107,7 @@ The app doesn't need to be better than Claude/ChatGPT. It needs to:
 
 ## AnyLanguageModel: Fallback Strategy
 
-[AnyLanguageModel](https://github.com/mattt/AnyLanguageModel) (779 stars, MIT, by Matt Thompson / Hugging Face) provides an API-compatible drop-in replacement for Foundation Models with support for multiple backends:
+[AnyLanguageModel](https://github.com/mattt/AnyLanguageModel) (MIT, by Matt Thompson) provides an API-compatible drop-in replacement for Foundation Models with support for multiple backends:
 
 - **On-device:** Foundation Models (A17 Pro+), Core ML, MLX, llama.cpp
 - **Cloud:** OpenAI, Anthropic, Gemini, Hugging Face, Ollama
@@ -115,7 +122,7 @@ Same `@Generable`, `Tool` protocol, and session API. Write code once, swap backe
 
 ### Primary: Fork [Dimillian/FoundationChat](https://github.com/Dimillian/FoundationChat)
 
-- **313 stars**, MIT, by Thomas Ricouard (creator of IceCubesApp)
+- MIT, by Thomas Ricouard (creator of IceCubesApp)
 - Clean SwiftUI chat with streaming, multi-conversation, SwiftData persistence
 - **Already has tool calling** via `Tool` protocol with working example
 - Small enough to understand in an evening, clean enough to fork confidently
@@ -123,25 +130,25 @@ Same `@Generable`, `Tool` protocol, and session API. Write code once, swap backe
 
 ### Reference: [rudrankriyam/Foundation-Models-Framework-Example](https://github.com/rudrankriyam/Foundation-Models-Framework-Example)
 
-- **928 stars**, MIT, last pushed 2026-02-17
+- MIT
 - 9 tool implementations, RAG, voice, multi-language
 - Best reference for Foundation Models patterns (not for forking — too large/demo-oriented)
 
 ### Alternative: [CherryHQ/hanlin-ai](https://github.com/CherryHQ/hanlin-ai)
 
-- **204 stars**, MIT, last pushed 2026-01-24
+- MIT
 - 20+ LLM providers, tool calling, streaming, RAG, voice, vision
 - Production-grade but large codebase — strip down rather than build up
 
-### Other notable repos:
+### Other notable repos (reference only):
 
-| Repo | Stars | Notes |
-|------|-------|-------|
-| [mattt/chat-ui-swift](https://github.com/mattt/chat-ui-swift) | 68 | Designed for AnyLanguageModel; currently macOS only |
-| [mi12labs/SwiftAI](https://github.com/mi12labs/SwiftAI) | 317 | Library (not app); best AI orchestration layer |
-| [exyte/Chat](https://github.com/exyte/Chat) | 1,682 | Best pure chat UI framework; no AI integration |
-| [indragiek/Context](https://github.com/indragiek/Context) | 777 | MCP debugging tool; extractable MCP client code |
-| [jamesrochabrun/MCPSwiftWrapper](https://github.com/jamesrochabrun/MCPSwiftWrapper) | 35 | Only repo combining MCP + chat UI; basic/demo quality |
+| Repo | Notes |
+|------|-------|
+| [mattt/chat-ui-swift](https://github.com/mattt/chat-ui-swift) | Designed for AnyLanguageModel; currently macOS only |
+| [mi12labs/SwiftAI](https://github.com/mi12labs/SwiftAI) | Library (not app); AI orchestration layer |
+| [exyte/Chat](https://github.com/exyte/Chat) | Pure chat UI framework; no AI integration |
+| [indragiek/Context](https://github.com/indragiek/Context) | MCP debugging tool; extractable MCP client code |
+| [jamesrochabrun/MCPSwiftWrapper](https://github.com/jamesrochabrun/MCPSwiftWrapper) | MCP + chat UI demo-style wrapper |
 
 ---
 
@@ -149,8 +156,9 @@ Same `@Generable`, `Tool` protocol, and session API. Write code once, swap backe
 
 | Phase | When | What |
 |-------|------|------|
-| Spike | Mar-Apr 2026 | Fork FoundationChat, get it talking to Flaim MCP gateway. Test 4096-token limit viability. |
-| MVP | May-Jun 2026 | Auth integration, 7 tool wrappers, local caching, polish |
+| Spike | Mar 2026 (4 weeks) | Fork FoundationChat, connect Flaim MCP gateway, validate single-turn UX and token budget constraints on real prompts. |
+| Go/No-Go Gate | End of Mar 2026 | Proceed only if quality bar is met and scope does not disrupt directory + marketing priorities. |
+| MVP | Apr-May 2026 (only if Go) | Auth integration, 7 tool wrappers, local caching, polish |
 | TestFlight | Jun-Jul 2026 | Family-and-friends beta |
 | App Store | Late Jul 2026 | Ship before fantasy football draft season (Aug-Sep) |
 
@@ -167,6 +175,7 @@ Same `@Generable`, `Tool` protocol, and session API. Write code once, swap backe
 | Maintenance burden for solo dev | Medium | Keep scope minimal; use standard Apple stack (SwiftUI + SwiftData) |
 | iOS dev learning curve (new stack) | Medium | Fork a working repo; learn by modifying, not from scratch |
 | Crowds out draft-season marketing | High | Treat as secondary; spike first, commit only if fun |
+| Existing AI fantasy app competition | Medium | Position Flaim on verifiable league-context accuracy + MCP ecosystem interoperability |
 | App Store review rejection | Low | Read-only, no user-generated content, standard auth patterns |
 
 ---
@@ -176,10 +185,11 @@ Same `@Generable`, `Tool` protocol, and session API. Write code once, swap backe
 Answer these after the spike:
 1. Is the 4096-token limit workable for simple fantasy queries?
 2. Is SwiftUI/iOS development fun or a chore?
-3. Can you realistically ship by late July without sacrificing marketing work?
-4. Does the on-device experience feel good enough to be worth the App Store listing?
+3. Can you hit useful output quality in a single-turn workflow (start/sit, waivers, matchup summary)?
+4. Can you realistically ship by late July without sacrificing marketing work?
+5. Does the experience differentiate enough from existing AI fantasy apps to win installs?
 
-If 3/4 are "yes," proceed to MVP. Otherwise, shelve and focus on directory submissions + Reddit/Threads ramp.
+If 4/5 are "yes," proceed to MVP. Otherwise, shelve and focus on directory submissions + Reddit/Threads ramp.
 
 ---
 
@@ -190,7 +200,10 @@ If 3/4 are "yes," proceed to MVP. Otherwise, shelve and focus on directory submi
 - [WWDC25: Meet the Foundation Models framework](https://developer.apple.com/videos/play/wwdc2025/286/)
 - [WWDC25: Deep dive into Foundation Models](https://developer.apple.com/videos/play/wwdc2025/301/)
 - [Apple ML Research: 2025 Foundation Models updates](https://machinelearning.apple.com/research/apple-foundation-models-2025-updates)
+- [How to get Apple Intelligence (requirements, languages, regions)](https://support.apple.com/en-us/121115)
 - [MCP Swift SDK](https://github.com/modelcontextprotocol/swift-sdk)
 - [AnyLanguageModel](https://github.com/mattt/AnyLanguageModel)
 - [MCP Specification (Streamable HTTP)](https://modelcontextprotocol.io)
+- [WalterPicks – AI Insights (App Store)](https://apps.apple.com/us/app/walterpicks-ai-insights/id1521523140)
+- [RotoBot - AI Fantasy Advice (App Store)](https://apps.apple.com/us/app/annual-subscription/id6502530085)
 - Deep research report: `/Users/ggugger/Code/deep-research-report.md`

--- a/docs/dev/CURRENT-EXECUTION-STATE.md
+++ b/docs/dev/CURRENT-EXECUTION-STATE.md
@@ -56,6 +56,13 @@ This is the canonical execution-status page for current work. It replaces overla
 - Presubmit passed: `npm run presubmit -- 2026-02-10T19-27-44Z` (`RESULT: PASS`).
 - OpenAI organization verification initiated (status: in review).
 
+8. Sleeper Phase 2 (2026-02-24)
+- `get_free_agents` added for Sleeper NFL and NBA; routed through unified gateway.
+- KV-backed player index cache (`SLEEPER_PLAYERS_CACHE`) with 24h TTL; falls back to in-memory when KV unavailable.
+- Sleeper transactions now enriched with player name/position/team from cached index.
+- KV namespaces created and wired into all sleeper-client wrangler configs (prod + preview).
+- All sleeper-client and targeted fantasy-mcp tests pass (43 + 47 tests); type-check clean.
+
 7. Transactions tool rollout (2026-02-23)
 - `get_transactions` shipped in unified gateway (`fantasy-mcp`) and ESPN/Yahoo/Sleeper clients.
 - Tool contract and docs updated for v1 behavior:

--- a/docs/dev/CURRENT-EXECUTION-STATE.md
+++ b/docs/dev/CURRENT-EXECUTION-STATE.md
@@ -1,6 +1,6 @@
 # Current Execution State
 
-Last updated: 2026-02-20
+Last updated: 2026-02-24
 Owner: Flaim (solo)
 
 This is the canonical execution-status page for current work. It replaces overlapping sprint/incident plans that were moved to the external archive bundle (see `../flaim-docs-archive/2026-02-08-repo-doc-cleanup/README.md`).
@@ -9,12 +9,13 @@ This is the canonical execution-status page for current work. It replaces overla
 
 - Unified MCP service is live on `https://api.flaim.app/mcp`.
 - Auth hardening and error taxonomy work from Sprint A are shipped.
-- End-to-end eval execution is healthy (`9/9` scenarios completed on four consecutive fresh runs: `2026-02-08T22-39-03Z`, `2026-02-08T22-48-28Z`, `2026-02-09T11-53-41Z`, `2026-02-19T13-39-48Z`).
+- End-to-end eval execution is healthy (latest fresh run `2026-02-24T00-56-48Z`: `17/17`, `0` errors; `accept` and `presubmit` PASS).
 - The previous OpenAI MCP `424` discovery failure is resolved.
 - Automated submission preflight is passing (`eval` + `accept` + `presubmit`) on consecutive fresh runs.
 - Manual OAuth token-lifecycle checks are complete for ChatGPT, Gemini CLI, Claude Code, and claude.ai.
 - Vendor-doc revalidation is complete (see `../submissions/*`).
-- Ready for directory submission (OpenAI submission is the next concrete action).
+- `get_transactions` is shipped in the unified gateway and all platform clients with explicit v1 caveats.
+- Submission remains close to ready, but eval + submission evidence should be refreshed to include `get_transactions`.
 
 ## Completed Recently
 
@@ -49,17 +50,29 @@ This is the canonical execution-status page for current work. It replaces overla
 - Presubmit passed: `npm run presubmit -- 2026-02-09T11-53-41Z` (`RESULT: PASS`).
 
 6. Tool annotations fixed and verified (2026-02-10)
-- Added missing `openWorldHint: false` and `destructiveHint: false` to all MCP tools (identified as common OpenAI rejection reason).
+- Added missing `openWorldHint: true` and `destructiveHint: false` to all MCP tools (identified as common OpenAI rejection reason).
 - Fresh full eval run passed: `2026-02-10T19-27-44Z` (`9/9`, `0` errors).
 - Acceptance passed: `npm run accept -- 2026-02-10T19-27-44Z`.
 - Presubmit passed: `npm run presubmit -- 2026-02-10T19-27-44Z` (`RESULT: PASS`).
 - OpenAI organization verification initiated (status: in review).
 
+7. Transactions tool rollout (2026-02-23)
+- `get_transactions` shipped in unified gateway (`fantasy-mcp`) and ESPN/Yahoo/Sleeper clients.
+- Tool contract and docs updated for v1 behavior:
+  - ESPN/Sleeper honor explicit `week`; default to current + previous week when omitted.
+  - Yahoo ignores explicit `week` and uses a recent 14-day timestamp window.
+  - Yahoo `type=waiver` filtering is intentionally unsupported in v1.
+- Phase 2 enrichments are explicitly deferred:
+  - ESPN `mTransactions2` enrichment
+  - Yahoo pending-waiver/pending-trade team fan-out
+  - Sleeper player-name enrichment aligned with Sleeper free-agents work
+
 ## Next Actions
 
-1. **[READY NOW]** Submit to OpenAI Apps Directory. Internal blockers are resolved (demo account ready, verification route deployed, packet updated); remaining external step is setting `OPENAI_APPS_VERIFICATION_TOKEN` when OpenAI issues it during submission. See `../submissions/openai-app-submission.md`.
-2. Decide Anthropic submission strategy (submit now vs delay).
-3. Keep preflight evidence current if any auth/tool changes land.
+1. Capture and attach `get_transactions` screenshots/evidence in the submission packets.
+2. **[READY NEXT]** Submit to OpenAI Apps Directory. Remaining external step is setting `OPENAI_APPS_VERIFICATION_TOKEN` when OpenAI issues it during submission. See `../submissions/openai-app-submission.md`.
+3. Decide Anthropic submission strategy (submit now vs delay).
+4. Keep preflight evidence current if any auth/tool changes land.
 4. ~~Submit to MCP Registry~~ — **Done** (published as `app.flaim/mcp` on 2026-02-10).
 5. ~~Gemini CLI extension packaging~~ — **Done** (`gemini-extension.json` committed 2026-02-10; auto-indexes within ~1 week).
 6. ~~Submit to community directories~~ — **Done** (2026-02-10): Glama (pending review), MCP.so (pending review), awesome-mcp-servers (PR #1918 open), PulseMCP (auto-indexing from official registry).

--- a/docs/dev/CURRENT-EXECUTION-STATE.md
+++ b/docs/dev/CURRENT-EXECUTION-STATE.md
@@ -80,8 +80,8 @@ This is the canonical execution-status page for current work. It replaces overla
 2. **[READY NEXT]** Submit to OpenAI Apps Directory. Remaining external step is setting `OPENAI_APPS_VERIFICATION_TOKEN` when OpenAI issues it during submission. See `../submissions/openai-app-submission.md`.
 3. Decide Anthropic submission strategy (submit now vs delay).
 4. Keep preflight evidence current if any auth/tool changes land.
-4. ~~Submit to MCP Registry~~ — **Done** (published as `app.flaim/mcp` on 2026-02-10).
-5. ~~Gemini CLI extension packaging~~ — **Done** (`gemini-extension.json` committed 2026-02-10; auto-indexes within ~1 week).
+5. ~~Submit to MCP Registry~~ — **Done** (published as `app.flaim/mcp` on 2026-02-10).
+6. ~~Gemini CLI extension packaging~~ — **Done** (`gemini-extension.json` committed 2026-02-10; auto-indexes within ~1 week).
 6. ~~Submit to community directories~~ — **Done** (2026-02-10): Glama (pending review), MCP.so (pending review), awesome-mcp-servers (PR #1918 open), PulseMCP (auto-indexing from official registry).
 
 7. Basketball & Hockey buildout (2026-02-10, shipped 2026-02-13)

--- a/docs/dev/TODO.md
+++ b/docs/dev/TODO.md
@@ -16,7 +16,7 @@ Use this as the active backlog only. For overall phase status, see `docs/dev/CUR
 - ESPN `mTransactions2` enrichment for richer bid/transaction detail.
 - Yahoo pending waiver/pending trade team fan-out.
 - Sleeper player-name enrichment (aligned with Sleeper free-agents work).
-3. Add free agent support for Sleeper (phase 2 in /plans)
+3. ~~Add free agent support for Sleeper~~ — **Done** (Phase 2 shipped 2026-02-24)
 4. Add stat enrichment for Sleeper (phase 3 in /plans)
 
 ## Maintenance / Reliability

--- a/docs/dev/TODO.md
+++ b/docs/dev/TODO.md
@@ -1,18 +1,23 @@
 # TODO
-Last updated: 2026-02-22
+Last updated: 2026-02-24
 
 Use this as the active backlog only. For overall phase status, see `docs/dev/CURRENT-EXECUTION-STATE.md`.
 
 ## Short-Term
-1. Submit to OpenAI Apps Directory.
-2. Decide Anthropic submission strategy.
+1. Capture `get_transactions` screenshots/evidence and check off the transactions delta checklist.
+2. Submit to OpenAI Apps Directory.
+3. Decide Anthropic submission strategy.
 - Submit now vs delay based on directory fit.
-3. Keep submission preflight evidence current.
+4. Keep submission preflight evidence current.
 
 ## Medium-Term 
 1. Improve clerk magic link emails
-2. Add free agent support for Sleeper (phase 2 in /plans)
-3. Add stat enrichment for Sleeper (phase 3 in /plans)
+2. Transactions Phase 2 enrichments:
+- ESPN `mTransactions2` enrichment for richer bid/transaction detail.
+- Yahoo pending waiver/pending trade team fan-out.
+- Sleeper player-name enrichment (aligned with Sleeper free-agents work).
+3. Add free agent support for Sleeper (phase 2 in /plans)
+4. Add stat enrichment for Sleeper (phase 3 in /plans)
 
 ## Maintenance / Reliability
 1. Add external uptime checks for `/health` endpoints.
@@ -24,6 +29,7 @@ Use this as the active backlog only. For overall phase status, see `docs/dev/CUR
 2. iOS app with Foundation Models + MCP (see `docs/dev/2026-02-22-ios-app-research.md` for full research, recommendations, and timeline).
 
 ## Recent Verification Notes
+- `flaim-eval` fresh run `2026-02-24T00-56-48Z` passed end-to-end with transaction scenarios added: `eval` (`17/17`, `0` errors), `enrich`, `accept`, and `presubmit` (`RESULT: PASS`).
 - `flaim-eval` fresh run `2026-02-09T11-53-41Z` passed end-to-end: `eval`, `accept`, and `presubmit`.
 - `flaim-eval` fresh run `2026-02-08T22-39-03Z` passed end-to-end: `eval`, `accept`, and `presubmit`.
 - `flaim-eval` fresh run `2026-02-08T22-48-28Z` also passed end-to-end: `eval`, `accept`, and `presubmit`.

--- a/workers/README.md
+++ b/workers/README.md
@@ -151,6 +151,7 @@ cd workers/auth-worker && wrangler deploy --env preview   # or --env prod
 cd workers/fantasy-mcp && npm run deploy:preview          # or npm run deploy:prod
 cd workers/espn-client && npm run deploy:preview          # or npm run deploy:prod
 cd workers/yahoo-client && npm run deploy:preview         # or npm run deploy:prod
+cd workers/sleeper-client && npm run deploy:preview       # or npm run deploy:prod
 ```
 
 Workers use custom routes via `api.flaim.app`:

--- a/workers/fantasy-mcp/src/__tests__/router.test.ts
+++ b/workers/fantasy-mcp/src/__tests__/router.test.ts
@@ -93,5 +93,45 @@ describe('fantasy-mcp router', () => {
         code: 'PLATFORM_NOT_SUPPORTED',
       });
     });
+
+    it('routes sleeper get_free_agents through SLEEPER binding', async () => {
+      const params: ToolParams = {
+        platform: 'sleeper',
+        sport: 'football',
+        league_id: 'league-77',
+        season_year: 2025,
+        count: 10,
+      };
+      const responseBody: RouteResult = {
+        success: true,
+        data: {
+          platform: 'sleeper',
+          league_id: 'league-77',
+          count: 1,
+          players: [{ id: 'p2' }],
+        },
+      };
+
+      const env = {
+        SLEEPER: {
+          fetch: async (request: Request) => {
+            expect(request.url).toBe('https://internal/execute');
+            expect(await request.json()).toEqual({
+              tool: 'get_free_agents',
+              params,
+              authHeader: undefined,
+            });
+            return new Response(JSON.stringify(responseBody), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          },
+        },
+      } as unknown as Env;
+
+      const result = await routeToClient(env, 'get_free_agents', params);
+
+      expect(result).toEqual(responseBody);
+    });
   });
 });

--- a/workers/fantasy-mcp/src/mcp/tools.ts
+++ b/workers/fantasy-mcp/src/mcp/tools.ts
@@ -911,8 +911,8 @@ export function getUnifiedTools(): UnifiedTool[] {
       description: `Get available free agents, optionally filtered by position. Sorted by ownership percentage. Requires authentication. Use values from get_user_session. Read-only and safe to retry. Current date is ${currentDate}.`,
       inputSchema: {
         platform: z
-          .enum(['espn', 'yahoo'])
-          .describe('Fantasy platform — "espn" or "yahoo" (Sleeper does not support free agents)'),
+          .enum(['espn', 'yahoo', 'sleeper'])
+          .describe('Fantasy platform — "espn", "yahoo", or "sleeper"'),
         sport: z
           .enum(['football', 'baseball', 'basketball', 'hockey'])
           .describe('Sport type (e.g., "football", "baseball")'),

--- a/workers/sleeper-client/README.md
+++ b/workers/sleeper-client/README.md
@@ -52,14 +52,25 @@ interface ExecuteRequest {
 - `get_standings` — League standings (computed from roster settings: wins, losses, ties, points)
 - `get_roster` — Team roster with player details
 - `get_matchups` — Weekly matchups (paired by `matchup_id`)
-- `get_transactions` — Recent transactions (adds, drops, waivers, trades)
+- `get_free_agents` — Available free agents (uses KV-backed player index cache)
+- `get_transactions` — Recent transactions with player name/position enrichment
 
 ### Basketball (NBA)
 - `get_league_info` — League settings and members
 - `get_standings` — League standings (computed from roster settings: wins, losses, ties, points)
 - `get_roster` — Team roster with player details
 - `get_matchups` — Weekly matchups (paired by `matchup_id`)
-- `get_transactions` — Recent transactions (adds, drops, waivers, trades)
+- `get_free_agents` — Available free agents (uses KV-backed player index cache)
+- `get_transactions` — Recent transactions with player name/position enrichment
+
+## Player Cache (KV)
+
+`get_free_agents` and `get_transactions` enrichment both use a shared KV-backed player index (`SLEEPER_PLAYERS_CACHE`):
+- Fetches `GET /v1/players/{sport}` (NFL or NBA) on cache miss.
+- Caches active players only, with a 24-hour TTL.
+- Cache key format: `players:{sport}:v1`.
+- Falls back to in-memory cache if the KV binding is unavailable.
+- Gracefully degrades: if the player index fails, transactions still return player IDs and `get_free_agents` returns an empty list with a `warning` field.
 
 ## Sleeper API Notes
 

--- a/workers/sleeper-client/src/__tests__/routing.test.ts
+++ b/workers/sleeper-client/src/__tests__/routing.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi, type MockedFunction } from 'vitest';
 import app from '../index';
 import type { Env } from '../types';
+import { footballHandlers } from '../sports/football/handlers';
+
+const mockFetch = vi.fn() as MockedFunction<typeof fetch>;
+global.fetch = mockFetch;
 
 function mockExecutionContext(): ExecutionContext {
   return {
@@ -9,17 +13,29 @@ function mockExecutionContext(): ExecutionContext {
   } as unknown as ExecutionContext;
 }
 
-async function executeRequest(sport: string, tool = 'get_league_info'): Promise<{ success: boolean; code?: string }> {
+async function executeRequest(
+  sport: string,
+  tool = 'get_league_info',
+  env: Env = {} as Env
+): Promise<{ success: boolean; code?: string }> {
   const req = new Request('https://internal/execute', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ tool, params: { sport, league_id: 'lg1', season_year: 2025 } }),
   });
-  const res = await app.fetch(req, {} as Env, mockExecutionContext());
+  const res = await app.fetch(req, env, mockExecutionContext());
   return res.json() as Promise<{ success: boolean; code?: string }>;
 }
 
 describe('sleeper-client sport routing', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('returns SPORT_NOT_SUPPORTED for baseball', async () => {
     const body = await executeRequest('baseball');
     expect(body.success).toBe(false);
@@ -30,5 +46,99 @@ describe('sleeper-client sport routing', () => {
     const body = await executeRequest('hockey');
     expect(body.success).toBe(false);
     expect(body.code).toBe('SPORT_NOT_SUPPORTED');
+  });
+
+  it('passes env bindings through execute route', async () => {
+    const env = {
+      SLEEPER_PLAYERS_CACHE: {} as KVNamespace,
+    } as Env;
+    const handlerSpy = vi.spyOn(footballHandlers, 'get_league_info').mockImplementation(async (receivedEnv: Env) => ({
+      success: receivedEnv === env,
+    }));
+
+    const body = await executeRequest('football', 'get_league_info', env);
+    expect(handlerSpy).toHaveBeenCalledTimes(1);
+    expect(body.success).toBe(true);
+  });
+
+  it('returns UNKNOWN_TOOL for unknown football tool when env is provided', async () => {
+    const env = {
+      SLEEPER_PLAYERS_CACHE: {} as KVNamespace,
+    } as Env;
+    const body = await executeRequest('football', 'unknown_tool_name', env);
+    expect(body.success).toBe(false);
+    expect(body.code).toBe('UNKNOWN_TOOL');
+  });
+
+  it('routes get_free_agents for supported sport with structured success payload', async () => {
+    const env = {
+      SLEEPER_PLAYERS_CACHE: {
+        get: vi.fn().mockResolvedValueOnce(JSON.stringify([
+          { player_id: 'p1', full_name: 'Rostered', position: 'QB', team: 'BUF', active: true },
+          { player_id: 'p2', full_name: 'Available', position: 'QB', team: 'KC', active: true },
+        ])),
+        put: vi.fn(),
+      } as unknown as KVNamespace,
+    } as Env;
+
+    mockFetch.mockResolvedValueOnce(new Response(JSON.stringify([
+      { players: ['p1'] },
+    ]), { status: 200 }));
+
+    const req = new Request('https://internal/execute', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tool: 'get_free_agents',
+        params: { sport: 'football', league_id: 'lg1', season_year: 2025, count: 10, position: 'QB' },
+      }),
+    });
+
+    const res = await app.fetch(req, env, mockExecutionContext());
+    const body = await res.json() as {
+      success: boolean;
+      data?: { players?: Array<{ id: string }>; count?: number; league_id?: string };
+    };
+
+    expect(body.success).toBe(true);
+    expect(body.data?.league_id).toBe('lg1');
+    expect(body.data?.count).toBe(1);
+    expect(body.data?.players?.[0]?.id).toBe('p2');
+  });
+
+  it('routes get_free_agents for basketball with structured success payload', async () => {
+    const env = {
+      SLEEPER_PLAYERS_CACHE: {
+        get: vi.fn().mockResolvedValueOnce(JSON.stringify([
+          { player_id: 'b1', full_name: 'Rostered Guard', position: 'PG', team: 'BOS', active: true },
+          { player_id: 'b2', full_name: 'Available Guard', position: 'PG', team: 'NYK', active: true },
+        ])),
+        put: vi.fn(),
+      } as unknown as KVNamespace,
+    } as Env;
+
+    mockFetch.mockResolvedValueOnce(new Response(JSON.stringify([
+      { players: ['b1'] },
+    ]), { status: 200 }));
+
+    const req = new Request('https://internal/execute', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tool: 'get_free_agents',
+        params: { sport: 'basketball', league_id: 'lg2', season_year: 2025, count: 10, position: 'PG' },
+      }),
+    });
+
+    const res = await app.fetch(req, env, mockExecutionContext());
+    const body = await res.json() as {
+      success: boolean;
+      data?: { players?: Array<{ id: string }>; count?: number; league_id?: string };
+    };
+
+    expect(body.success).toBe(true);
+    expect(body.data?.league_id).toBe('lg2');
+    expect(body.data?.count).toBe(1);
+    expect(body.data?.players?.[0]?.id).toBe('b2');
   });
 });

--- a/workers/sleeper-client/src/index.ts
+++ b/workers/sleeper-client/src/index.ts
@@ -48,7 +48,7 @@ app.post('/execute', async (c) => {
       message: `${tool} ${sport} league=${league_id} season=${season_year}`,
     });
 
-    const result = await routeToSport(sport, tool, params);
+    const result = await routeToSport(c.env, sport, tool, params);
 
     const duration = Date.now() - startTime;
     console.log(`[sleeper-client] ${correlationId} ${tool} ${sport} completed in ${duration}ms success=${result.success}`);
@@ -100,6 +100,7 @@ app.post('/execute', async (c) => {
 });
 
 async function routeToSport(
+  env: Env,
   sport: Sport,
   tool: string,
   params: ExecuteRequest['params'],
@@ -108,13 +109,12 @@ async function routeToSport(
     case 'football': {
       const handler = footballHandlers[tool];
       if (!handler) return { success: false, error: `Unknown football tool: ${tool}`, code: 'UNKNOWN_TOOL' };
-      // Sleeper API is public — no env/authHeader needed by handlers
-      return handler({} as Env, params);
+      return handler(env, params);
     }
     case 'basketball': {
       const handler = basketballHandlers[tool];
       if (!handler) return { success: false, error: `Unknown basketball tool: ${tool}`, code: 'UNKNOWN_TOOL' };
-      return handler({} as Env, params);
+      return handler(env, params);
     }
     default:
       return { success: false, error: `Sport "${sport}" is not supported for Sleeper`, code: 'SPORT_NOT_SUPPORTED' };

--- a/workers/sleeper-client/src/shared/__tests__/sleeper-free-agents.test.ts
+++ b/workers/sleeper-client/src/shared/__tests__/sleeper-free-agents.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { buildSleeperFreeAgents } from '../sleeper-free-agents';
+import type { SleeperPlayerRecord } from '../sleeper-players-cache';
+
+describe('sleeper-free-agents', () => {
+  it('excludes rostered players and applies position filter', () => {
+    const players = new Map<string, SleeperPlayerRecord>([
+      ['p1', { player_id: 'p1', full_name: 'A QB', position: 'QB', team: 'BUF', active: true }],
+      ['p2', { player_id: 'p2', full_name: 'B RB', position: 'RB', team: 'KC', active: true }],
+      ['p3', { player_id: 'p3', full_name: 'C QB', position: 'QB', team: 'PHI', active: true }],
+    ]);
+    const rostered = new Set(['p1']);
+
+    const result = buildSleeperFreeAgents(players, rostered, 'QB', 25);
+
+    expect(result).toEqual([
+      { id: 'p3', name: 'C QB', position: 'QB', team: 'PHI' },
+    ]);
+  });
+
+  it('sorts deterministically by active then name then id', () => {
+    const players = new Map<string, SleeperPlayerRecord>([
+      ['z2', { player_id: 'z2', full_name: 'Zeta', active: true }],
+      ['a2', { player_id: 'a2', full_name: 'Alpha', active: true }],
+      ['a1', { player_id: 'a1', full_name: 'Alpha', active: true }],
+    ]);
+
+    const result = buildSleeperFreeAgents(players, new Set(), undefined, 25);
+
+    expect(result.map((player) => player.id)).toEqual(['a1', 'a2', 'z2']);
+  });
+
+  it('clamps count to the 1..100 range', () => {
+    const players = new Map<string, SleeperPlayerRecord>();
+    for (let i = 0; i < 150; i += 1) {
+      const id = `p${String(i).padStart(3, '0')}`;
+      players.set(id, { player_id: id, full_name: `Player ${i}`, active: true });
+    }
+
+    const maxResult = buildSleeperFreeAgents(players, new Set(), undefined, 200);
+    expect(maxResult).toHaveLength(100);
+
+    const minResult = buildSleeperFreeAgents(players, new Set(), undefined, 0);
+    expect(minResult).toHaveLength(1);
+  });
+});

--- a/workers/sleeper-client/src/shared/__tests__/sleeper-players-cache.test.ts
+++ b/workers/sleeper-client/src/shared/__tests__/sleeper-players-cache.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi, type MockedFunction } from 'vitest';
+import {
+  cacheKeyForSport,
+  clearSleeperPlayersInMemoryCacheForTesting,
+  getSleeperPlayersIndex,
+} from '../sleeper-players-cache';
+import type { Env } from '../../types';
+
+const mockFetch = vi.fn() as MockedFunction<typeof fetch>;
+global.fetch = mockFetch;
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('sleeper-players-cache', () => {
+  const kvGet = vi.fn();
+  const kvPut = vi.fn();
+  const env = {
+    SLEEPER_PLAYERS_CACHE: {
+      get: kvGet,
+      put: kvPut,
+    },
+  } as unknown as Env;
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    kvGet.mockReset();
+    kvPut.mockReset();
+    clearSleeperPlayersInMemoryCacheForTesting();
+  });
+
+  it('returns cache hit without upstream fetch', async () => {
+    kvGet.mockResolvedValueOnce(JSON.stringify([
+      { player_id: '1', full_name: 'Cached Player', position: 'QB', team: 'BUF', active: true },
+    ]));
+
+    const index = await getSleeperPlayersIndex(env, 'football');
+
+    expect(index.get('1')?.full_name).toBe('Cached Player');
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(kvPut).not.toHaveBeenCalled();
+  });
+
+  it('fetches and caches nfl players on cache miss', async () => {
+    kvGet.mockResolvedValueOnce(null);
+    mockFetch.mockResolvedValueOnce(jsonResponse({
+      '11': { player_id: '11', full_name: 'Alpha A', position: 'RB', team: 'NYJ', active: true },
+      '12': { player_id: '12', full_name: 'Inactive B', position: 'WR', team: 'SF', active: false },
+    }));
+
+    const index = await getSleeperPlayersIndex(env, 'football');
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch.mock.calls[0]?.[0]).toBe('https://api.sleeper.app/v1/players/nfl');
+    expect(index.has('11')).toBe(true);
+    expect(index.has('12')).toBe(false);
+    expect(kvPut).toHaveBeenCalledTimes(1);
+    const [key, value, options] = kvPut.mock.calls[0] as [string, string, { expirationTtl: number }];
+    expect(key).toBe(cacheKeyForSport('football'));
+    expect(options).toEqual({ expirationTtl: 86400 });
+    expect(JSON.parse(value)).toEqual([
+      { player_id: '11', full_name: 'Alpha A', position: 'RB', team: 'NYJ', active: true },
+    ]);
+  });
+
+  it('falls back to refetch when cache JSON is invalid', async () => {
+    kvGet.mockResolvedValueOnce('{bad-json');
+    mockFetch.mockResolvedValueOnce(jsonResponse({
+      '21': { player_id: '21', full_name: 'Refetch C', position: 'PG', team: 'BOS', active: true },
+    }));
+
+    const index = await getSleeperPlayersIndex(env, 'basketball');
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch.mock.calls[0]?.[0]).toBe('https://api.sleeper.app/v1/players/nba');
+    expect(index.get('21')?.full_name).toBe('Refetch C');
+    expect(kvPut).toHaveBeenCalledTimes(1);
+  });
+
+  it('retains only active players from cached array payloads', async () => {
+    kvGet.mockResolvedValueOnce(JSON.stringify([
+      { player_id: '31', full_name: 'Active D', active: true },
+      { player_id: '32', full_name: 'Inactive E', active: false },
+      { player_id: '33', full_name: 'Missing Active Flag' },
+    ]));
+
+    const index = await getSleeperPlayersIndex(env, 'football');
+
+    expect(index.has('31')).toBe(true);
+    expect(index.has('32')).toBe(false);
+    expect(index.has('33')).toBe(false);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('warms in-memory cache from KV hit to avoid repeat KV reads', async () => {
+    kvGet.mockResolvedValueOnce(JSON.stringify([
+      { player_id: '41', full_name: 'KV Warmed Player', position: 'TE', team: 'DET', active: true },
+    ]));
+
+    const first = await getSleeperPlayersIndex(env, 'football');
+    const second = await getSleeperPlayersIndex(env, 'football');
+
+    expect(first.get('41')?.full_name).toBe('KV Warmed Player');
+    expect(second.get('41')?.full_name).toBe('KV Warmed Player');
+    expect(kvGet).toHaveBeenCalledTimes(1);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/workers/sleeper-client/src/shared/__tests__/sleeper-transactions.test.ts
+++ b/workers/sleeper-client/src/shared/__tests__/sleeper-transactions.test.ts
@@ -56,5 +56,28 @@ describe('sleeper-transactions', () => {
     expect(rows[0].transaction_id).toBe('b1');
     expect(rows[0].type).toBe('waiver');
     expect(rows[0].faab_bid).toBe(17);
+    expect(rows[0].players_added).toEqual([{ id: '123', name: undefined, position: undefined, team: undefined }]);
+  });
+
+  it('enriches player adds/drops when resolver provides metadata', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse([
+      {
+        transaction_id: 'x1',
+        type: 'waiver',
+        status: 'complete',
+        status_updated: 200,
+        leg: 9,
+        adds: { '123': 3 },
+        drops: { '456': 3 },
+      },
+    ]));
+
+    const rows = await fetchSleeperTransactionsByWeeks('league', [9], (playerId) => {
+      if (playerId === '123') return { name: 'Josh Allen', position: 'QB', team: 'BUF' };
+      return undefined;
+    });
+
+    expect(rows[0].players_added).toEqual([{ id: '123', name: 'Josh Allen', position: 'QB', team: 'BUF' }]);
+    expect(rows[0].players_dropped).toEqual([{ id: '456', name: undefined, position: undefined, team: undefined }]);
   });
 });

--- a/workers/sleeper-client/src/shared/sleeper-free-agents-handler.ts
+++ b/workers/sleeper-client/src/shared/sleeper-free-agents-handler.ts
@@ -1,0 +1,62 @@
+import { extractErrorCode, type ExecuteResponse } from '@flaim/worker-shared';
+import type { Env, SleeperRoster, Sport, ToolParams } from '../types';
+import { handleSleeperError, sleeperFetch } from './sleeper-api';
+import { buildSleeperFreeAgents } from './sleeper-free-agents';
+import { getSleeperPlayersIndex } from './sleeper-players-cache';
+
+function clampCount(value: unknown): number {
+  const rawCount = Number.isFinite(Number(value)) ? Number(value) : 25;
+  return Math.max(1, Math.min(100, Math.trunc(rawCount)));
+}
+
+export function createSleeperGetFreeAgentsHandler(cacheSport: Sport) {
+  return async function handleGetFreeAgents(
+    env: Env,
+    params: ToolParams,
+  ): Promise<ExecuteResponse> {
+    const { league_id } = params;
+
+    try {
+      const rostersRes = await sleeperFetch(`/league/${league_id}/rosters`);
+      if (!rostersRes.ok) handleSleeperError(rostersRes);
+
+      const rosters: SleeperRoster[] = await rostersRes.json();
+      const rostered = new Set<string>();
+      for (const roster of rosters) {
+        for (const playerId of roster.players ?? []) {
+          rostered.add(String(playerId));
+        }
+      }
+
+      const requestedCount = clampCount(params.count);
+      let freeAgents: ReturnType<typeof buildSleeperFreeAgents> = [];
+      let warning: string | undefined;
+
+      try {
+        const playersIndex = await getSleeperPlayersIndex(env, cacheSport);
+        freeAgents = buildSleeperFreeAgents(playersIndex, rostered, params.position, requestedCount);
+      } catch {
+        warning = 'PLAYER_ENRICHMENT_UNAVAILABLE: free-agent player index unavailable; returning empty list';
+      }
+
+      return {
+        success: true,
+        data: {
+          platform: 'sleeper',
+          sport: params.sport,
+          league_id,
+          season_year: params.season_year,
+          count: freeAgents.length,
+          players: freeAgents,
+          ...(warning ? { warning } : {}),
+        },
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+        code: extractErrorCode(error),
+      };
+    }
+  };
+}

--- a/workers/sleeper-client/src/shared/sleeper-free-agents-handler.ts
+++ b/workers/sleeper-client/src/shared/sleeper-free-agents-handler.ts
@@ -35,7 +35,8 @@ export function createSleeperGetFreeAgentsHandler(cacheSport: Sport) {
       try {
         const playersIndex = await getSleeperPlayersIndex(env, cacheSport);
         freeAgents = buildSleeperFreeAgents(playersIndex, rostered, params.position, requestedCount);
-      } catch {
+      } catch (error) {
+        console.error('[handleGetFreeAgents] Failed to get player index:', error);
         warning = 'PLAYER_ENRICHMENT_UNAVAILABLE: free-agent player index unavailable; returning empty list';
       }
 

--- a/workers/sleeper-client/src/shared/sleeper-free-agents.ts
+++ b/workers/sleeper-client/src/shared/sleeper-free-agents.ts
@@ -1,0 +1,40 @@
+import type { SleeperPlayerRecord } from './sleeper-players-cache';
+
+export interface SleeperFreeAgent {
+  id: string;
+  name: string;
+  position?: string;
+  team?: string;
+}
+
+function clampCount(count: number): number {
+  return Math.max(1, Math.min(100, Math.trunc(count)));
+}
+
+export function buildSleeperFreeAgents(
+  players: Map<string, SleeperPlayerRecord>,
+  rosteredPlayerIds: Set<string>,
+  position?: string,
+  count = 25,
+): SleeperFreeAgent[] {
+  const normalizedPosition = position?.trim().toUpperCase();
+  const maxCount = clampCount(count);
+
+  const freeAgents = Array.from(players.values())
+    .filter((player) => player.active)
+    .filter((player) => !rosteredPlayerIds.has(player.player_id))
+    .filter((player) => !normalizedPosition || player.position?.toUpperCase() === normalizedPosition)
+    .sort((a, b) => {
+      const nameCmp = a.full_name.localeCompare(b.full_name);
+      if (nameCmp !== 0) return nameCmp;
+      return a.player_id.localeCompare(b.player_id);
+    })
+    .slice(0, maxCount);
+
+  return freeAgents.map((player) => ({
+    id: player.player_id,
+    name: player.full_name,
+    position: player.position,
+    team: player.team,
+  }));
+}

--- a/workers/sleeper-client/src/shared/sleeper-players-cache.ts
+++ b/workers/sleeper-client/src/shared/sleeper-players-cache.ts
@@ -1,0 +1,141 @@
+import type { Env } from '../types';
+import { handleSleeperError, sleeperFetch } from './sleeper-api';
+
+const PLAYERS_CACHE_TTL_SECONDS = 24 * 60 * 60;
+const inMemoryPlayersCache = new Map<string, { value: string; expiresAt: number }>();
+
+export function clearSleeperPlayersInMemoryCacheForTesting(): void {
+  inMemoryPlayersCache.clear();
+}
+
+export interface SleeperPlayerRecord {
+  player_id: string;
+  full_name: string;
+  first_name?: string;
+  last_name?: string;
+  position?: string;
+  team?: string;
+  active: boolean;
+}
+
+type SleeperPlayerCacheSport = 'football' | 'basketball';
+
+type SleeperPlayersApiRecord = {
+  player_id?: unknown;
+  full_name?: unknown;
+  first_name?: unknown;
+  last_name?: unknown;
+  position?: unknown;
+  team?: unknown;
+  active?: unknown;
+};
+
+function toCacheSportPath(sport: SleeperPlayerCacheSport): '/players/nfl' | '/players/nba' {
+  return sport === 'football' ? '/players/nfl' : '/players/nba';
+}
+
+function asNonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function parsePlayerRecord(raw: SleeperPlayersApiRecord, fallbackId?: string): SleeperPlayerRecord | null {
+  const id = asNonEmptyString(raw.player_id) ?? asNonEmptyString(fallbackId);
+  if (!id) return null;
+
+  const firstName = asNonEmptyString(raw.first_name);
+  const lastName = asNonEmptyString(raw.last_name);
+  const derivedName = [firstName, lastName].filter(Boolean).join(' ').trim();
+  const fullName = asNonEmptyString(raw.full_name) ?? (derivedName || id);
+
+  return {
+    player_id: id,
+    full_name: fullName,
+    first_name: firstName,
+    last_name: lastName,
+    position: asNonEmptyString(raw.position),
+    team: asNonEmptyString(raw.team),
+    active: raw.active === true,
+  };
+}
+
+function normalizePlayers(input: unknown): SleeperPlayerRecord[] | null {
+  if (Array.isArray(input)) {
+    const fromArray: SleeperPlayerRecord[] = [];
+    for (const item of input) {
+      if (!item || typeof item !== 'object') continue;
+      const parsed = parsePlayerRecord(item as SleeperPlayersApiRecord);
+      if (!parsed || !parsed.active) continue;
+      fromArray.push(parsed);
+    }
+    return fromArray;
+  }
+
+  if (!input || typeof input !== 'object') {
+    return null;
+  }
+
+  const fromObject: SleeperPlayerRecord[] = [];
+  for (const [playerId, value] of Object.entries(input as Record<string, unknown>)) {
+    if (!value || typeof value !== 'object') continue;
+    const parsed = parsePlayerRecord(value as SleeperPlayersApiRecord, playerId);
+    if (!parsed || !parsed.active) continue;
+    fromObject.push(parsed);
+  }
+
+  return fromObject;
+}
+
+function toPlayerIndex(players: SleeperPlayerRecord[]): Map<string, SleeperPlayerRecord> {
+  const map = new Map<string, SleeperPlayerRecord>();
+  for (const player of players) {
+    map.set(player.player_id, player);
+  }
+  return map;
+}
+
+export function cacheKeyForSport(sport: SleeperPlayerCacheSport): string {
+  return `players:${sport}:v1`;
+}
+
+export async function getSleeperPlayersIndex(
+  env: Env,
+  sport: SleeperPlayerCacheSport,
+): Promise<Map<string, SleeperPlayerRecord>> {
+  const cacheKey = cacheKeyForSport(sport);
+  const now = Date.now();
+  const cachedInMemory = inMemoryPlayersCache.get(cacheKey);
+  let cached = cachedInMemory && cachedInMemory.expiresAt > now ? cachedInMemory.value : null;
+
+  if (!cached) cached = await env.SLEEPER_PLAYERS_CACHE.get(cacheKey);
+
+  if (cached) {
+    try {
+      const parsedCached = normalizePlayers(JSON.parse(cached));
+      if (parsedCached) {
+        inMemoryPlayersCache.set(cacheKey, {
+          value: cached,
+          expiresAt: now + PLAYERS_CACHE_TTL_SECONDS * 1000,
+        });
+        return toPlayerIndex(parsedCached);
+      }
+    } catch {
+      // Defensive fallback: refetch from Sleeper when cache data is malformed.
+    }
+  }
+
+  const response = await sleeperFetch(toCacheSportPath(sport));
+  if (!response.ok) handleSleeperError(response);
+
+  const payload = await response.json();
+  const parsedPlayers = normalizePlayers(payload) ?? [];
+  const serialized = JSON.stringify(parsedPlayers);
+  await env.SLEEPER_PLAYERS_CACHE.put(cacheKey, serialized, {
+    expirationTtl: PLAYERS_CACHE_TTL_SECONDS,
+  });
+  inMemoryPlayersCache.set(cacheKey, {
+    value: serialized,
+    expiresAt: now + PLAYERS_CACHE_TTL_SECONDS * 1000,
+  });
+
+  return toPlayerIndex(parsedPlayers);
+}

--- a/workers/sleeper-client/src/sports/basketball/__tests__/free-agents.test.ts
+++ b/workers/sleeper-client/src/sports/basketball/__tests__/free-agents.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi, type MockedFunction } from 'vitest';
+import { basketballHandlers } from '../handlers';
+import type { Env, ToolParams } from '../../../types';
+import { sleeperFetch } from '../../../shared/sleeper-api';
+import { getSleeperPlayersIndex } from '../../../shared/sleeper-players-cache';
+import { buildSleeperFreeAgents } from '../../../shared/sleeper-free-agents';
+
+vi.mock('../../../shared/sleeper-api', () => ({
+  sleeperFetch: vi.fn(),
+  handleSleeperError: vi.fn((response: Response) => {
+    throw new Error(`SLEEPER_API_ERROR: Sleeper returned ${response.status}`);
+  }),
+}));
+
+vi.mock('../../../shared/sleeper-players-cache', () => ({
+  getSleeperPlayersIndex: vi.fn(),
+}));
+
+vi.mock('../../../shared/sleeper-free-agents', () => ({
+  buildSleeperFreeAgents: vi.fn(),
+}));
+
+describe('sleeper basketball get_free_agents handler', () => {
+  const sleeperFetchMock = sleeperFetch as MockedFunction<typeof sleeperFetch>;
+  const getPlayersIndexMock = getSleeperPlayersIndex as MockedFunction<typeof getSleeperPlayersIndex>;
+  const buildFreeAgentsMock = buildSleeperFreeAgents as MockedFunction<typeof buildSleeperFreeAgents>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches rosters and uses basketball players cache', async () => {
+    sleeperFetchMock.mockResolvedValueOnce(new Response(JSON.stringify([
+      { players: ['501', '502'] },
+    ]), { status: 200 }));
+
+    const playersIndex = new Map();
+    getPlayersIndexMock.mockResolvedValue(playersIndex as never);
+    buildFreeAgentsMock.mockReturnValue([
+      { id: '700', name: 'NBA FA', position: 'PG', team: 'BOS' },
+    ]);
+
+    const params: ToolParams = {
+      sport: 'basketball',
+      league_id: 'league_nba',
+      season_year: 2025,
+      position: 'PG',
+      count: 8,
+    };
+
+    const env = { SLEEPER_PLAYERS_CACHE: {} as KVNamespace } as Env;
+    const result = await basketballHandlers.get_free_agents(env, params);
+
+    expect(sleeperFetchMock).toHaveBeenCalledWith('/league/league_nba/rosters');
+    expect(getPlayersIndexMock).toHaveBeenCalledWith(env, 'basketball');
+    expect(buildFreeAgentsMock).toHaveBeenCalledWith(
+      playersIndex,
+      new Set(['501', '502']),
+      'PG',
+      8,
+    );
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data).toEqual({
+      platform: 'sleeper',
+      sport: 'basketball',
+      league_id: 'league_nba',
+      season_year: 2025,
+      count: 1,
+      players: [{ id: '700', name: 'NBA FA', position: 'PG', team: 'BOS' }],
+    });
+  });
+
+  it('clamps requested count to min 1', async () => {
+    sleeperFetchMock.mockResolvedValueOnce(new Response(JSON.stringify([{ players: [] }]), { status: 200 }));
+    getPlayersIndexMock.mockResolvedValue(new Map() as never);
+    buildFreeAgentsMock.mockReturnValue([]);
+
+    const params: ToolParams = {
+      sport: 'basketball',
+      league_id: 'league_nba',
+      season_year: 2025,
+      count: 0,
+    };
+
+    await basketballHandlers.get_free_agents({ SLEEPER_PLAYERS_CACHE: {} as KVNamespace } as Env, params);
+
+    expect(buildFreeAgentsMock).toHaveBeenCalledWith(expect.any(Map), new Set(), undefined, 1);
+  });
+
+  it('returns success with warning and empty players when index load fails', async () => {
+    sleeperFetchMock.mockResolvedValueOnce(new Response(JSON.stringify([{ players: ['501'] }]), { status: 200 }));
+    getPlayersIndexMock.mockRejectedValueOnce(new Error('cache unavailable'));
+
+    const params: ToolParams = {
+      sport: 'basketball',
+      league_id: 'league_nba',
+      season_year: 2025,
+      count: 5,
+    };
+
+    const result = await basketballHandlers.get_free_agents({} as Env, params);
+
+    expect(result.success).toBe(true);
+    expect(buildFreeAgentsMock).not.toHaveBeenCalled();
+    if (!result.success) return;
+    expect(result.data).toMatchObject({
+      platform: 'sleeper',
+      league_id: 'league_nba',
+      count: 0,
+      players: [],
+    });
+    expect((result.data as { warning?: string }).warning).toContain('PLAYER_ENRICHMENT_UNAVAILABLE');
+  });
+});

--- a/workers/sleeper-client/src/sports/basketball/__tests__/transactions.test.ts
+++ b/workers/sleeper-client/src/sports/basketball/__tests__/transactions.test.ts
@@ -2,15 +2,21 @@ import { beforeEach, describe, expect, it, vi, type MockedFunction } from 'vites
 import { basketballHandlers } from '../handlers';
 import type { ToolParams } from '../../../types';
 import { fetchSleeperTransactionsByWeeks, getSleeperCurrentWeek } from '../../../shared/sleeper-transactions';
+import { getSleeperPlayersIndex } from '../../../shared/sleeper-players-cache';
 
 vi.mock('../../../shared/sleeper-transactions', () => ({
   getSleeperCurrentWeek: vi.fn(),
   fetchSleeperTransactionsByWeeks: vi.fn(),
 }));
 
+vi.mock('../../../shared/sleeper-players-cache', () => ({
+  getSleeperPlayersIndex: vi.fn(),
+}));
+
 describe('sleeper basketball get_transactions handler', () => {
   const getCurrentWeekMock = getSleeperCurrentWeek as MockedFunction<typeof getSleeperCurrentWeek>;
   const fetchTransactionsMock = fetchSleeperTransactionsByWeeks as MockedFunction<typeof fetchSleeperTransactionsByWeeks>;
+  const getPlayersIndexMock = getSleeperPlayersIndex as MockedFunction<typeof getSleeperPlayersIndex>;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -18,6 +24,9 @@ describe('sleeper basketball get_transactions handler', () => {
 
   it('uses NBA state week when week is omitted', async () => {
     getCurrentWeekMock.mockResolvedValue(18);
+    getPlayersIndexMock.mockResolvedValue(new Map([
+      ['p1', { player_id: 'p1', full_name: 'Player One', active: true }],
+    ]) as never);
     fetchTransactionsMock.mockResolvedValue([
       { transaction_id: 't2', type: 'trade', status: 'complete', timestamp: 2000, week: 18 },
       { transaction_id: 't1', type: 'add', status: 'complete', timestamp: 1000, week: 17 },
@@ -30,15 +39,63 @@ describe('sleeper basketball get_transactions handler', () => {
       count: 100,
     };
 
-    const result = await basketballHandlers.get_transactions({} as never, params);
+    const result = await basketballHandlers.get_transactions({ SLEEPER_PLAYERS_CACHE: {} as KVNamespace } as never, params);
 
     expect(result.success).toBe(true);
     expect(getCurrentWeekMock).toHaveBeenCalledWith('/state/nba');
-    expect(fetchTransactionsMock).toHaveBeenCalledWith('league_nba_1', [18, 17]);
+    expect(fetchTransactionsMock).toHaveBeenCalledWith('league_nba_1', [18, 17], expect.any(Function));
 
     if (!result.success) return;
     const data = result.data as { count: number; window: { mode: string; weeks: number[] } };
     expect(data.count).toBe(2);
     expect(data.window).toEqual({ mode: 'recent_two_weeks', weeks: [18, 17] });
+  });
+
+  it('degrades gracefully when player lookup cache fails', async () => {
+    getPlayersIndexMock.mockRejectedValue(new Error('cache failure'));
+    fetchTransactionsMock.mockResolvedValue([
+      { transaction_id: 't1', type: 'add', status: 'complete', timestamp: 1000, week: 9 },
+    ] as never);
+
+    const params: ToolParams = {
+      sport: 'basketball',
+      league_id: 'league_nba_1',
+      season_year: 2025,
+      week: 9,
+    };
+
+    const result = await basketballHandlers.get_transactions({ SLEEPER_PLAYERS_CACHE: {} as KVNamespace } as never, params);
+
+    expect(result.success).toBe(true);
+    expect(fetchTransactionsMock).toHaveBeenCalledWith('league_nba_1', [9], undefined);
+  });
+
+  it.each([
+    { requested: 0, expected: 1 },
+    { requested: -2, expected: 1 },
+    { requested: 200, expected: 3 },
+  ])('clamps count=$requested to expected result size=$expected', async ({ requested, expected }) => {
+    getPlayersIndexMock.mockResolvedValue(new Map() as never);
+    fetchTransactionsMock.mockResolvedValue([
+      { transaction_id: 't1', type: 'trade', status: 'complete', timestamp: 3000, week: 9 },
+      { transaction_id: 't2', type: 'waiver', status: 'complete', timestamp: 2000, week: 9 },
+      { transaction_id: 't3', type: 'add', status: 'complete', timestamp: 1000, week: 9 },
+    ] as never);
+
+    const params: ToolParams = {
+      sport: 'basketball',
+      league_id: 'league_nba_1',
+      season_year: 2025,
+      week: 9,
+      count: requested,
+    };
+
+    const result = await basketballHandlers.get_transactions({} as never, params);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const data = result.data as { count: number; transactions: unknown[] };
+    expect(data.count).toBe(expected);
+    expect(data.transactions).toHaveLength(expected);
   });
 });

--- a/workers/sleeper-client/src/sports/basketball/handlers.ts
+++ b/workers/sleeper-client/src/sports/basketball/handlers.ts
@@ -291,8 +291,8 @@ async function handleGetTransactions(
           team: player.team,
         };
       };
-    } catch {
-      // Graceful degradation: transactions still return IDs when metadata lookup fails.
+    } catch (error) {
+      console.error('[handleGetTransactions] Failed to get player index for enrichment:', error);
       resolvePlayer = undefined;
     }
 

--- a/workers/sleeper-client/src/sports/basketball/handlers.ts
+++ b/workers/sleeper-client/src/sports/basketball/handlers.ts
@@ -1,6 +1,8 @@
 import type { Env, ToolParams, ExecuteResponse, SleeperLeague, SleeperRoster, SleeperMatchup, SleeperLeagueUser } from '../../types';
 import { sleeperFetch, handleSleeperError } from '../../shared/sleeper-api';
 import { fetchSleeperTransactionsByWeeks, getSleeperCurrentWeek } from '../../shared/sleeper-transactions';
+import { getSleeperPlayersIndex } from '../../shared/sleeper-players-cache';
+import { createSleeperGetFreeAgentsHandler } from '../../shared/sleeper-free-agents-handler';
 import { extractErrorCode } from '@flaim/worker-shared';
 
 type HandlerFn = (
@@ -10,11 +12,14 @@ type HandlerFn = (
   correlationId?: string
 ) => Promise<ExecuteResponse>;
 
+const handleGetFreeAgents = createSleeperGetFreeAgentsHandler('basketball');
+
 export const basketballHandlers: Record<string, HandlerFn> = {
   get_league_info: handleGetLeagueInfo,
   get_standings: handleGetStandings,
   get_roster: handleGetRoster,
   get_matchups: handleGetMatchups,
+  get_free_agents: handleGetFreeAgents,
   get_transactions: handleGetTransactions,
 };
 
@@ -260,7 +265,7 @@ async function handleGetMatchups(
 }
 
 async function handleGetTransactions(
-  _env: Env,
+  env: Env,
   params: ToolParams,
 ): Promise<ExecuteResponse> {
   const { league_id, week, count, type } = params;
@@ -268,9 +273,30 @@ async function handleGetTransactions(
   try {
     const currentWeek = week || await getSleeperCurrentWeek('/state/nba');
     const weeks = week ? [Math.max(1, week)] : Array.from(new Set([currentWeek, Math.max(1, currentWeek - 1)]));
-    const maxCount = count ?? 25;
+    const rawCount = Number.isFinite(Number(count)) ? Number(count) : 25;
+    const maxCount = Math.max(1, Math.min(100, Math.trunc(rawCount)));
 
-    const rows = await fetchSleeperTransactionsByWeeks(league_id, weeks);
+    let resolvePlayer:
+      | ((playerId: string) => { name?: string; position?: string; team?: string } | undefined)
+      | undefined;
+
+    try {
+      const playersIndex = await getSleeperPlayersIndex(env, 'basketball');
+      resolvePlayer = (playerId) => {
+        const player = playersIndex.get(playerId);
+        if (!player) return undefined;
+        return {
+          name: player.full_name,
+          position: player.position,
+          team: player.team,
+        };
+      };
+    } catch {
+      // Graceful degradation: transactions still return IDs when metadata lookup fails.
+      resolvePlayer = undefined;
+    }
+
+    const rows = await fetchSleeperTransactionsByWeeks(league_id, weeks, resolvePlayer);
     const filtered = rows
       .filter((txn) => !type || txn.type === type)
       .slice(0, maxCount);

--- a/workers/sleeper-client/src/sports/football/__tests__/free-agents.test.ts
+++ b/workers/sleeper-client/src/sports/football/__tests__/free-agents.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi, type MockedFunction } from 'vitest';
+import { footballHandlers } from '../handlers';
+import type { Env, ToolParams } from '../../../types';
+import { sleeperFetch } from '../../../shared/sleeper-api';
+import { getSleeperPlayersIndex } from '../../../shared/sleeper-players-cache';
+import { buildSleeperFreeAgents } from '../../../shared/sleeper-free-agents';
+
+vi.mock('../../../shared/sleeper-api', () => ({
+  sleeperFetch: vi.fn(),
+  handleSleeperError: vi.fn((response: Response) => {
+    throw new Error(`SLEEPER_API_ERROR: Sleeper returned ${response.status}`);
+  }),
+}));
+
+vi.mock('../../../shared/sleeper-players-cache', () => ({
+  getSleeperPlayersIndex: vi.fn(),
+}));
+
+vi.mock('../../../shared/sleeper-free-agents', () => ({
+  buildSleeperFreeAgents: vi.fn(),
+}));
+
+describe('sleeper football get_free_agents handler', () => {
+  const sleeperFetchMock = sleeperFetch as MockedFunction<typeof sleeperFetch>;
+  const getPlayersIndexMock = getSleeperPlayersIndex as MockedFunction<typeof getSleeperPlayersIndex>;
+  const buildFreeAgentsMock = buildSleeperFreeAgents as MockedFunction<typeof buildSleeperFreeAgents>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches rosters, uses player cache helper, and returns shaped response', async () => {
+    sleeperFetchMock.mockResolvedValueOnce(new Response(JSON.stringify([
+      { players: ['101', '102'] },
+      { players: ['103'] },
+    ]), { status: 200 }));
+
+    const playersIndex = new Map();
+    getPlayersIndexMock.mockResolvedValue(playersIndex as never);
+    buildFreeAgentsMock.mockReturnValue([
+      { id: '999', name: 'A Player', position: 'QB', team: 'BUF' },
+    ]);
+
+    const params: ToolParams = {
+      sport: 'football',
+      league_id: 'league_1',
+      season_year: 2025,
+      position: 'QB',
+      count: 10,
+    };
+
+    const env = { SLEEPER_PLAYERS_CACHE: {} as KVNamespace } as Env;
+    const result = await footballHandlers.get_free_agents(env, params);
+
+    expect(sleeperFetchMock).toHaveBeenCalledWith('/league/league_1/rosters');
+    expect(getPlayersIndexMock).toHaveBeenCalledWith(env, 'football');
+    expect(buildFreeAgentsMock).toHaveBeenCalledWith(
+      playersIndex,
+      new Set(['101', '102', '103']),
+      'QB',
+      10,
+    );
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data).toEqual({
+      platform: 'sleeper',
+      sport: 'football',
+      league_id: 'league_1',
+      season_year: 2025,
+      count: 1,
+      players: [{ id: '999', name: 'A Player', position: 'QB', team: 'BUF' }],
+    });
+  });
+
+  it('clamps requested count to max 100', async () => {
+    sleeperFetchMock.mockResolvedValueOnce(new Response(JSON.stringify([{ players: [] }]), { status: 200 }));
+    getPlayersIndexMock.mockResolvedValue(new Map() as never);
+    buildFreeAgentsMock.mockReturnValue([]);
+
+    const params: ToolParams = {
+      sport: 'football',
+      league_id: 'league_1',
+      season_year: 2025,
+      count: 999,
+    };
+
+    await footballHandlers.get_free_agents({ SLEEPER_PLAYERS_CACHE: {} as KVNamespace } as Env, params);
+
+    expect(buildFreeAgentsMock).toHaveBeenCalledWith(expect.any(Map), new Set(), undefined, 100);
+  });
+
+  it('returns success with warning and empty players when index load fails', async () => {
+    sleeperFetchMock.mockResolvedValueOnce(new Response(JSON.stringify([{ players: ['101'] }]), { status: 200 }));
+    getPlayersIndexMock.mockRejectedValueOnce(new Error('cache unavailable'));
+
+    const params: ToolParams = {
+      sport: 'football',
+      league_id: 'league_1',
+      season_year: 2025,
+      count: 5,
+    };
+
+    const result = await footballHandlers.get_free_agents({} as Env, params);
+
+    expect(result.success).toBe(true);
+    expect(buildFreeAgentsMock).not.toHaveBeenCalled();
+    if (!result.success) return;
+    expect(result.data).toMatchObject({
+      platform: 'sleeper',
+      league_id: 'league_1',
+      count: 0,
+      players: [],
+    });
+    expect((result.data as { warning?: string }).warning).toContain('PLAYER_ENRICHMENT_UNAVAILABLE');
+  });
+});

--- a/workers/sleeper-client/src/sports/football/__tests__/transactions.test.ts
+++ b/workers/sleeper-client/src/sports/football/__tests__/transactions.test.ts
@@ -2,15 +2,21 @@ import { beforeEach, describe, expect, it, vi, type MockedFunction } from 'vites
 import { footballHandlers } from '../handlers';
 import type { ToolParams } from '../../../types';
 import { fetchSleeperTransactionsByWeeks, getSleeperCurrentWeek } from '../../../shared/sleeper-transactions';
+import { getSleeperPlayersIndex } from '../../../shared/sleeper-players-cache';
 
 vi.mock('../../../shared/sleeper-transactions', () => ({
   getSleeperCurrentWeek: vi.fn(),
   fetchSleeperTransactionsByWeeks: vi.fn(),
 }));
 
+vi.mock('../../../shared/sleeper-players-cache', () => ({
+  getSleeperPlayersIndex: vi.fn(),
+}));
+
 describe('sleeper football get_transactions handler', () => {
   const getCurrentWeekMock = getSleeperCurrentWeek as MockedFunction<typeof getSleeperCurrentWeek>;
   const fetchTransactionsMock = fetchSleeperTransactionsByWeeks as MockedFunction<typeof fetchSleeperTransactionsByWeeks>;
+  const getPlayersIndexMock = getSleeperPlayersIndex as MockedFunction<typeof getSleeperPlayersIndex>;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -18,6 +24,9 @@ describe('sleeper football get_transactions handler', () => {
 
   it('uses NFL state week when week is omitted', async () => {
     getCurrentWeekMock.mockResolvedValue(12);
+    getPlayersIndexMock.mockResolvedValue(new Map([
+      ['p1', { player_id: 'p1', full_name: 'Player One', active: true }],
+    ]) as never);
     fetchTransactionsMock.mockResolvedValue([
       { transaction_id: 't2', type: 'trade', status: 'complete', timestamp: 2000, week: 12 },
       { transaction_id: 't1', type: 'add', status: 'complete', timestamp: 1000, week: 11 },
@@ -30,11 +39,11 @@ describe('sleeper football get_transactions handler', () => {
       count: 100,
     };
 
-    const result = await footballHandlers.get_transactions({} as never, params);
+    const result = await footballHandlers.get_transactions({ SLEEPER_PLAYERS_CACHE: {} as KVNamespace } as never, params);
 
     expect(result.success).toBe(true);
     expect(getCurrentWeekMock).toHaveBeenCalledWith('/state/nfl');
-    expect(fetchTransactionsMock).toHaveBeenCalledWith('league_1', [12, 11]);
+    expect(fetchTransactionsMock).toHaveBeenCalledWith('league_1', [12, 11], expect.any(Function));
 
     if (!result.success) return;
     const data = result.data as { count: number; window: { mode: string; weeks: number[] } };
@@ -44,6 +53,9 @@ describe('sleeper football get_transactions handler', () => {
 
   it('uses explicit week and applies type/count filters', async () => {
     getCurrentWeekMock.mockResolvedValue(12);
+    getPlayersIndexMock.mockResolvedValue(new Map([
+      ['p2', { player_id: 'p2', full_name: 'Player Two', active: true }],
+    ]) as never);
     fetchTransactionsMock.mockResolvedValue([
       { transaction_id: 'a1', type: 'add', status: 'complete', timestamp: 3000, week: 9 },
       { transaction_id: 'w1', type: 'waiver', status: 'complete', timestamp: 2000, week: 9 },
@@ -59,14 +71,62 @@ describe('sleeper football get_transactions handler', () => {
       count: 1,
     };
 
-    const result = await footballHandlers.get_transactions({} as never, params);
+    const result = await footballHandlers.get_transactions({ SLEEPER_PLAYERS_CACHE: {} as KVNamespace } as never, params);
 
     expect(result.success).toBe(true);
-    expect(fetchTransactionsMock).toHaveBeenCalledWith('league_1', [9]);
+    expect(fetchTransactionsMock).toHaveBeenCalledWith('league_1', [9], expect.any(Function));
 
     if (!result.success) return;
     const data = result.data as { count: number; transactions: Array<{ transaction_id: string }> };
     expect(data.count).toBe(1);
     expect(data.transactions[0]?.transaction_id).toBe('w1');
+  });
+
+  it('degrades gracefully when player lookup cache fails', async () => {
+    getPlayersIndexMock.mockRejectedValue(new Error('cache failure'));
+    fetchTransactionsMock.mockResolvedValue([
+      { transaction_id: 't1', type: 'add', status: 'complete', timestamp: 1000, week: 9 },
+    ] as never);
+
+    const params: ToolParams = {
+      sport: 'football',
+      league_id: 'league_1',
+      season_year: 2025,
+      week: 9,
+    };
+
+    const result = await footballHandlers.get_transactions({ SLEEPER_PLAYERS_CACHE: {} as KVNamespace } as never, params);
+
+    expect(result.success).toBe(true);
+    expect(fetchTransactionsMock).toHaveBeenCalledWith('league_1', [9], undefined);
+  });
+
+  it.each([
+    { requested: 0, expected: 1 },
+    { requested: -5, expected: 1 },
+    { requested: 999, expected: 3 },
+  ])('clamps count=$requested to expected result size=$expected', async ({ requested, expected }) => {
+    getPlayersIndexMock.mockResolvedValue(new Map() as never);
+    fetchTransactionsMock.mockResolvedValue([
+      { transaction_id: 't1', type: 'trade', status: 'complete', timestamp: 3000, week: 9 },
+      { transaction_id: 't2', type: 'waiver', status: 'complete', timestamp: 2000, week: 9 },
+      { transaction_id: 't3', type: 'add', status: 'complete', timestamp: 1000, week: 9 },
+    ] as never);
+
+    const params: ToolParams = {
+      sport: 'football',
+      league_id: 'league_1',
+      season_year: 2025,
+      week: 9,
+      count: requested,
+    };
+
+    const result = await footballHandlers.get_transactions({} as never, params);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const data = result.data as { count: number; transactions: unknown[] };
+    expect(data.count).toBe(expected);
+    expect(data.transactions).toHaveLength(expected);
   });
 });

--- a/workers/sleeper-client/src/sports/football/handlers.ts
+++ b/workers/sleeper-client/src/sports/football/handlers.ts
@@ -336,8 +336,8 @@ async function handleGetTransactions(
           team: player.team,
         };
       };
-    } catch {
-      // Graceful degradation: transactions still return IDs when metadata lookup fails.
+    } catch (error) {
+      console.error('[handleGetTransactions] Failed to get player index for enrichment:', error);
       resolvePlayer = undefined;
     }
 

--- a/workers/sleeper-client/src/types.ts
+++ b/workers/sleeper-client/src/types.ts
@@ -1,7 +1,7 @@
 import type { BaseEnvWithAuth } from '@flaim/worker-shared';
 
 export interface Env extends BaseEnvWithAuth {
-  // Sleeper API is public — no extra bindings needed beyond auth-worker (for league storage)
+  SLEEPER_PLAYERS_CACHE: KVNamespace;
 }
 
 export type Sport = 'football' | 'basketball';

--- a/workers/sleeper-client/wrangler.jsonc
+++ b/workers/sleeper-client/wrangler.jsonc
@@ -16,6 +16,9 @@
     "prod": {
       "name": "sleeper-client",
       "workers_dev": true,
+      "kv_namespaces": [
+        { "binding": "SLEEPER_PLAYERS_CACHE", "id": "b34c0c797b7b4e1285458361694b8d5e", "preview_id": "b34c0c797b7b4e1285458361694b8d5e" }
+      ],
       "services": [
         { "binding": "AUTH_WORKER", "service": "auth-worker" }
       ],
@@ -28,6 +31,9 @@
     "preview": {
       "name": "sleeper-client-preview",
       "workers_dev": true,
+      "kv_namespaces": [
+        { "binding": "SLEEPER_PLAYERS_CACHE", "id": "81df4492a52c456c9f6362a5cc5a5816", "preview_id": "81df4492a52c456c9f6362a5cc5a5816" }
+      ],
       "services": [
         { "binding": "AUTH_WORKER", "service": "auth-worker-preview" }
       ],
@@ -40,6 +46,9 @@
     "dev": {
       "name": "sleeper-client-dev",
       "workers_dev": true,
+      "kv_namespaces": [
+        { "binding": "SLEEPER_PLAYERS_CACHE", "id": "81df4492a52c456c9f6362a5cc5a5816", "preview_id": "81df4492a52c456c9f6362a5cc5a5816" }
+      ],
       "services": [
         { "binding": "AUTH_WORKER", "service": "auth-worker-dev" }
       ],

--- a/workers/sleeper-client/wrangler.jsonc
+++ b/workers/sleeper-client/wrangler.jsonc
@@ -17,7 +17,7 @@
       "name": "sleeper-client",
       "workers_dev": true,
       "kv_namespaces": [
-        { "binding": "SLEEPER_PLAYERS_CACHE", "id": "b34c0c797b7b4e1285458361694b8d5e", "preview_id": "b34c0c797b7b4e1285458361694b8d5e" }
+        { "binding": "SLEEPER_PLAYERS_CACHE", "id": "b34c0c797b7b4e1285458361694b8d5e", "preview_id": "81df4492a52c456c9f6362a5cc5a5816" }
       ],
       "services": [
         { "binding": "AUTH_WORKER", "service": "auth-worker" }

--- a/workers/sleeper-client/wrangler.test.jsonc
+++ b/workers/sleeper-client/wrangler.test.jsonc
@@ -1,5 +1,8 @@
 {
   "name": "sleeper-client-test",
   "main": "./src/index.ts",
-  "compatibility_date": "2024-12-01"
+  "compatibility_date": "2024-12-01",
+  "kv_namespaces": [
+    { "binding": "SLEEPER_PLAYERS_CACHE", "id": "81df4492a52c456c9f6362a5cc5a5816", "preview_id": "81df4492a52c456c9f6362a5cc5a5816" }
+  ]
 }


### PR DESCRIPTION
## Summary

- Adds `get_free_agents` for Sleeper NFL and NBA through the unified gateway (`platform: "sleeper"` now accepted in gateway schema)
- Implements a KV-backed player index cache (`SLEEPER_PLAYERS_CACHE`, 24h TTL) shared by free-agents and transactions enrichment
- Enriches Sleeper transaction player adds/drops with name, position, and team from the cached index
- Wires real Cloudflare KV namespace IDs (prod + preview) — removes all placeholder IDs
- Deletes two legacy orphaned KV namespaces (`CRED_KV`, `SESSION_KV`) that were empty and unreferenced

## What's included

**Implementation (committed by Codex):**
- `e77c636` — cleanup/refactor (deduplication, cache/test fixes from review)
- `3e4dd7c` — main Phase 2 implementation (free agents, KV cache, transaction enrichment, routing/integration tests)

**This PR adds:**
- KV namespace IDs wired into `wrangler.jsonc` / `wrangler.test.jsonc`
- Completed Task 11 docs: `sleeper-client/README.md`, `workers/README.md`, `docs/TESTING.md`, `docs/CHANGELOG.md`, `CURRENT-EXECUTION-STATE.md`, `TODO.md`

## Test plan

- [ ] All sleeper-client tests pass: `cd workers/sleeper-client && npm test` (43/43)
- [ ] sleeper-client type-check clean: `npm run type-check`
- [ ] fantasy-mcp targeted tests pass: `cd workers/fantasy-mcp && npm test` (47/47)
- [ ] fantasy-mcp type-check clean: `npm run type-check`
- [ ] Smoke: `get_free_agents` returns named players for football and basketball
- [ ] Smoke: `get_transactions` returns enriched player metadata (name/position/team)
- [ ] Smoke: second free-agents call shows no `/players/nfl` fetch in logs (cache hit confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)