### PR TITLE
Add search_players MCP tool (FLA-33)

### DIFF
--- a/workers/espn-client/src/shared/espn-players-cache.ts
+++ b/workers/espn-client/src/shared/espn-players-cache.ts
@@ -60,8 +60,8 @@ export async function getEspnPlayersIndex(
   let cached: string | null = null;
   try {
     cached = await env.ESPN_PLAYERS_CACHE.get(key);
-  } catch {
-    // KV read failed — fall through to fetch
+  } catch (error) {
+    console.error('[espn-players-cache] KV read failed; falling through to fetch:', error);
   }
 
   if (cached) {
@@ -75,8 +75,8 @@ export async function getEspnPlayersIndex(
         }
         return index;
       }
-    } catch {
-      // Corrupt cache — fall through to fetch
+    } catch (error) {
+      console.error('[espn-players-cache] Corrupt KV cache; falling through to fetch:', error);
     }
   }
 

--- a/workers/espn-client/src/shared/espn-players-cache.ts
+++ b/workers/espn-client/src/shared/espn-players-cache.ts
@@ -1,0 +1,122 @@
+import type { Env } from '../types';
+import { espnFetch } from './espn-api';
+
+const PLAYERS_CACHE_TTL_SECONDS = 24 * 60 * 60;
+
+export interface EspnPlayerRecord {
+  id: number;
+  fullName: string;
+  defaultPositionId: number;
+  proTeamId: number;
+  percentOwned: number;
+}
+
+type EspnPlayerCacheSport = 'football' | 'baseball' | 'basketball' | 'hockey';
+
+const GAME_ID_MAP: Record<EspnPlayerCacheSport, string> = {
+  football: 'ffl',
+  baseball: 'flb',
+  basketball: 'fba',
+  hockey: 'fhl',
+};
+
+const PLAYER_LIMITS: Record<EspnPlayerCacheSport, number> = {
+  football: 3000,
+  baseball: 5000,
+  basketball: 2000,
+  hockey: 2000,
+};
+
+function cacheKey(sport: EspnPlayerCacheSport, year: number): string {
+  return `espn-players:${sport}:${year}:v1`;
+}
+
+function parsePlayerRecord(raw: unknown): EspnPlayerRecord | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const r = raw as Record<string, unknown>;
+  const id = typeof r.id === 'number' ? r.id : null;
+  const fullName = typeof r.fullName === 'string' && r.fullName.trim() ? r.fullName.trim() : null;
+  if (!id || !fullName) return null;
+
+  const ownership = r.ownership as Record<string, unknown> | undefined;
+  const percentOwned = typeof ownership?.percentOwned === 'number' ? ownership.percentOwned : 0;
+
+  return {
+    id,
+    fullName,
+    defaultPositionId: typeof r.defaultPositionId === 'number' ? r.defaultPositionId : 0,
+    proTeamId: typeof r.proTeamId === 'number' ? r.proTeamId : 0,
+    percentOwned,
+  };
+}
+
+export async function getEspnPlayersIndex(
+  env: Env,
+  sport: EspnPlayerCacheSport,
+  year: number,
+): Promise<Map<number, EspnPlayerRecord>> {
+  const key = cacheKey(sport, year);
+
+  let cached: string | null = null;
+  try {
+    cached = await env.ESPN_PLAYERS_CACHE.get(key);
+  } catch {
+    // KV read failed — fall through to fetch
+  }
+
+  if (cached) {
+    try {
+      const parsed = JSON.parse(cached) as unknown[];
+      if (Array.isArray(parsed)) {
+        const index = new Map<number, EspnPlayerRecord>();
+        for (const item of parsed) {
+          const record = parsePlayerRecord(item);
+          if (record) index.set(record.id, record);
+        }
+        return index;
+      }
+    } catch {
+      // Corrupt cache — fall through to fetch
+    }
+  }
+
+  const gameId = GAME_ID_MAP[sport];
+  const limit = PLAYER_LIMITS[sport];
+  const path = `/seasons/${year}/players?view=players_wl`;
+  const filterHeader = JSON.stringify({
+    limit,
+    sortPercOwned: { sortPriority: 1, sortAsc: false },
+  });
+
+  const response = await espnFetch(path, gameId, {
+    timeout: 15000,
+    headers: { 'X-Fantasy-Filter': filterHeader },
+  });
+
+  if (!response.ok) {
+    throw new Error(`ESPN_API_ERROR: players_wl returned ${response.status} for ${sport}`);
+  }
+
+  const payload = await response.json() as unknown[];
+  const players = Array.isArray(payload) ? payload : [];
+
+  const records: EspnPlayerRecord[] = [];
+  for (const item of players) {
+    const record = parsePlayerRecord(item);
+    if (record) records.push(record);
+  }
+
+  try {
+    await env.ESPN_PLAYERS_CACHE.put(key, JSON.stringify(records), {
+      expirationTtl: PLAYERS_CACHE_TTL_SECONDS,
+    });
+  } catch (error) {
+    console.error('[espn-players-cache] KV write failed; serving from fetch:', error);
+  }
+
+  const index = new Map<number, EspnPlayerRecord>();
+  for (const record of records) {
+    index.set(record.id, record);
+  }
+  return index;
+}

--- a/workers/espn-client/src/sports/baseball/handlers.ts
+++ b/workers/espn-client/src/sports/baseball/handlers.ts
@@ -3,6 +3,7 @@ import type { Env, ToolParams, ExecuteResponse, EspnLeagueResponse, EspnPlayerPo
 import { getCredentials } from '../../shared/auth';
 import { espnFetch, handleEspnError, requireCredentials } from '../../shared/espn-api';
 import { fetchEspnTransactionsByWeeks, getEspnLeagueContext, fetchEspnPlayersByIds, enrichTransactions } from '../../shared/espn-transactions';
+import { getEspnPlayersIndex } from '../../shared/espn-players-cache';
 import { extractErrorCode } from '@flaim/worker-shared';
 import {
   getPositionName,
@@ -30,7 +31,58 @@ export const baseballHandlers: Record<string, HandlerFn> = {
   get_roster: handleGetRoster,
   get_free_agents: handleGetFreeAgents,
   get_transactions: handleGetTransactions,
+  search_players: handleSearchPlayers,
 };
+
+async function handleSearchPlayers(
+  env: Env,
+  params: ToolParams,
+): Promise<ExecuteResponse> {
+  const { query, position, count, season_year } = params;
+
+  if (!query) {
+    return { success: false, error: 'query is required for search_players', code: 'MISSING_PARAM' };
+  }
+
+  try {
+    const limit = Math.max(1, Math.min(25, Math.trunc(Number.isFinite(Number(count)) ? Number(count) : 10)));
+    const playersIndex = await getEspnPlayersIndex(env, 'baseball', season_year);
+    const normalizedQuery = query.toLowerCase();
+    const normalizedPosition = position?.trim().toUpperCase();
+
+    const players = Array.from(playersIndex.values())
+      .filter((p) => p.fullName.toLowerCase().includes(normalizedQuery))
+      .filter((p) => {
+        if (!normalizedPosition) return true;
+        return getPositionName(p.defaultPositionId).toUpperCase() === normalizedPosition;
+      })
+      .slice(0, limit)
+      .map((p) => ({
+        id: String(p.id),
+        name: p.fullName,
+        position: getPositionName(p.defaultPositionId),
+        team: getProTeamAbbrev(p.proTeamId),
+        percentOwned: p.percentOwned,
+      }));
+
+    return {
+      success: true,
+      data: {
+        platform: 'espn',
+        sport: params.sport,
+        query,
+        count: players.length,
+        players,
+      },
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+      code: extractErrorCode(error),
+    };
+  }
+}
 
 /**
  * Get league information and settings

--- a/workers/espn-client/src/sports/basketball/handlers.ts
+++ b/workers/espn-client/src/sports/basketball/handlers.ts
@@ -3,6 +3,7 @@ import type { Env, ToolParams, ExecuteResponse, EspnLeagueResponse, EspnPlayerPo
 import { getCredentials } from '../../shared/auth';
 import { espnFetch, handleEspnError, requireCredentials } from '../../shared/espn-api';
 import { fetchEspnTransactionsByWeeks, getEspnLeagueContext, fetchEspnPlayersByIds, enrichTransactions } from '../../shared/espn-transactions';
+import { getEspnPlayersIndex } from '../../shared/espn-players-cache';
 import { extractErrorCode } from '@flaim/worker-shared';
 import {
   getPositionName,
@@ -30,7 +31,58 @@ export const basketballHandlers: Record<string, HandlerFn> = {
   get_roster: handleGetRoster,
   get_free_agents: handleGetFreeAgents,
   get_transactions: handleGetTransactions,
+  search_players: handleSearchPlayers,
 };
+
+async function handleSearchPlayers(
+  env: Env,
+  params: ToolParams,
+): Promise<ExecuteResponse> {
+  const { query, position, count, season_year } = params;
+
+  if (!query) {
+    return { success: false, error: 'query is required for search_players', code: 'MISSING_PARAM' };
+  }
+
+  try {
+    const limit = Math.max(1, Math.min(25, Math.trunc(Number.isFinite(Number(count)) ? Number(count) : 10)));
+    const playersIndex = await getEspnPlayersIndex(env, 'basketball', season_year);
+    const normalizedQuery = query.toLowerCase();
+    const normalizedPosition = position?.trim().toUpperCase();
+
+    const players = Array.from(playersIndex.values())
+      .filter((p) => p.fullName.toLowerCase().includes(normalizedQuery))
+      .filter((p) => {
+        if (!normalizedPosition) return true;
+        return getPositionName(p.defaultPositionId).toUpperCase() === normalizedPosition;
+      })
+      .slice(0, limit)
+      .map((p) => ({
+        id: String(p.id),
+        name: p.fullName,
+        position: getPositionName(p.defaultPositionId),
+        team: getProTeamAbbrev(p.proTeamId),
+        percentOwned: p.percentOwned,
+      }));
+
+    return {
+      success: true,
+      data: {
+        platform: 'espn',
+        sport: params.sport,
+        query,
+        count: players.length,
+        players,
+      },
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+      code: extractErrorCode(error),
+    };
+  }
+}
 
 /**
  * Get league information and settings

--- a/workers/espn-client/src/sports/football/handlers.ts
+++ b/workers/espn-client/src/sports/football/handlers.ts
@@ -441,7 +441,9 @@ async function handleSearchPlayers(
     const limit = Math.max(1, Math.min(25, Math.trunc(Number.isFinite(Number(count)) ? Number(count) : 10)));
     const playersIndex = await getEspnPlayersIndex(env, 'football', season_year);
     const normalizedQuery = query.toLowerCase();
-    const normalizedPosition = position?.trim().toUpperCase();
+    // Normalize common D/ST alias so "DST" matches ESPN's "D/ST" label
+    const rawPosition = position?.trim().toUpperCase();
+    const normalizedPosition = rawPosition === 'DST' ? 'D/ST' : rawPosition;
 
     const players = Array.from(playersIndex.values())
       .filter((p) => p.fullName.toLowerCase().includes(normalizedQuery))

--- a/workers/espn-client/src/sports/football/handlers.ts
+++ b/workers/espn-client/src/sports/football/handlers.ts
@@ -3,6 +3,7 @@ import type { Env, ToolParams, ExecuteResponse, EspnLeagueResponse, EspnPlayerPo
 import { getCredentials } from '../../shared/auth';
 import { espnFetch, handleEspnError, requireCredentials } from '../../shared/espn-api';
 import { fetchEspnTransactionsByWeeks, getEspnLeagueContext, fetchEspnPlayersByIds, enrichTransactions } from '../../shared/espn-transactions';
+import { getEspnPlayersIndex } from '../../shared/espn-players-cache';
 import { extractErrorCode } from '@flaim/worker-shared';
 import {
   getPositionName,
@@ -30,6 +31,7 @@ export const footballHandlers: Record<string, HandlerFn> = {
   get_roster: handleGetRoster,
   get_free_agents: handleGetFreeAgents,
   get_transactions: handleGetTransactions,
+  search_players: handleSearchPlayers,
 };
 
 /**
@@ -421,6 +423,56 @@ async function handleGetFreeAgents(
       success: false,
       error: error instanceof Error ? error.message : 'Unknown error occurred',
       code: extractErrorCode(error)
+    };
+  }
+}
+
+async function handleSearchPlayers(
+  env: Env,
+  params: ToolParams,
+): Promise<ExecuteResponse> {
+  const { query, position, count, season_year } = params;
+
+  if (!query) {
+    return { success: false, error: 'query is required for search_players', code: 'MISSING_PARAM' };
+  }
+
+  try {
+    const limit = Math.max(1, Math.min(25, Math.trunc(Number.isFinite(Number(count)) ? Number(count) : 10)));
+    const playersIndex = await getEspnPlayersIndex(env, 'football', season_year);
+    const normalizedQuery = query.toLowerCase();
+    const normalizedPosition = position?.trim().toUpperCase();
+
+    const players = Array.from(playersIndex.values())
+      .filter((p) => p.fullName.toLowerCase().includes(normalizedQuery))
+      .filter((p) => {
+        if (!normalizedPosition) return true;
+        return getPositionName(p.defaultPositionId).toUpperCase() === normalizedPosition;
+      })
+      .slice(0, limit)
+      .map((p) => ({
+        id: String(p.id),
+        name: p.fullName,
+        position: getPositionName(p.defaultPositionId),
+        team: getProTeamAbbrev(p.proTeamId),
+        percentOwned: p.percentOwned,
+      }));
+
+    return {
+      success: true,
+      data: {
+        platform: 'espn',
+        sport: params.sport,
+        query,
+        count: players.length,
+        players,
+      },
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+      code: extractErrorCode(error),
     };
   }
 }

--- a/workers/espn-client/src/sports/football/mappings.ts
+++ b/workers/espn-client/src/sports/football/mappings.ts
@@ -12,6 +12,12 @@ export const POSITION_MAP: Record<number, string> = {
   3: 'WR',     // Wide Receiver
   4: 'TE',     // Tight End
   5: 'K',      // Kicker
+  6: 'D/ST',   // Defense/Special Teams (IDP)
+  8: 'DT',     // Defensive Tackle (IDP)
+  9: 'DE',     // Defensive End (IDP)
+  10: 'LB',    // Linebacker (IDP)
+  11: 'CB',    // Cornerback (IDP)
+  12: 'S',     // Safety (IDP)
   16: 'D/ST',  // Defense/Special Teams
 };
 

--- a/workers/espn-client/src/sports/hockey/handlers.ts
+++ b/workers/espn-client/src/sports/hockey/handlers.ts
@@ -3,6 +3,7 @@ import type { Env, ToolParams, ExecuteResponse, EspnLeagueResponse, EspnPlayerPo
 import { getCredentials } from '../../shared/auth';
 import { espnFetch, handleEspnError, requireCredentials } from '../../shared/espn-api';
 import { fetchEspnTransactionsByWeeks, getEspnLeagueContext, fetchEspnPlayersByIds, enrichTransactions } from '../../shared/espn-transactions';
+import { getEspnPlayersIndex } from '../../shared/espn-players-cache';
 import { extractErrorCode } from '@flaim/worker-shared';
 import {
   getPositionName,
@@ -30,7 +31,58 @@ export const hockeyHandlers: Record<string, HandlerFn> = {
   get_roster: handleGetRoster,
   get_free_agents: handleGetFreeAgents,
   get_transactions: handleGetTransactions,
+  search_players: handleSearchPlayers,
 };
+
+async function handleSearchPlayers(
+  env: Env,
+  params: ToolParams,
+): Promise<ExecuteResponse> {
+  const { query, position, count, season_year } = params;
+
+  if (!query) {
+    return { success: false, error: 'query is required for search_players', code: 'MISSING_PARAM' };
+  }
+
+  try {
+    const limit = Math.max(1, Math.min(25, Math.trunc(Number.isFinite(Number(count)) ? Number(count) : 10)));
+    const playersIndex = await getEspnPlayersIndex(env, 'hockey', season_year);
+    const normalizedQuery = query.toLowerCase();
+    const normalizedPosition = position?.trim().toUpperCase();
+
+    const players = Array.from(playersIndex.values())
+      .filter((p) => p.fullName.toLowerCase().includes(normalizedQuery))
+      .filter((p) => {
+        if (!normalizedPosition) return true;
+        return getPositionName(p.defaultPositionId).toUpperCase() === normalizedPosition;
+      })
+      .slice(0, limit)
+      .map((p) => ({
+        id: String(p.id),
+        name: p.fullName,
+        position: getPositionName(p.defaultPositionId),
+        team: getProTeamAbbrev(p.proTeamId),
+        percentOwned: p.percentOwned,
+      }));
+
+    return {
+      success: true,
+      data: {
+        platform: 'espn',
+        sport: params.sport,
+        query,
+        count: players.length,
+        players,
+      },
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+      code: extractErrorCode(error),
+    };
+  }
+}
 
 /**
  * Get league information and settings

--- a/workers/espn-client/src/types.ts
+++ b/workers/espn-client/src/types.ts
@@ -126,7 +126,7 @@ export interface EspnPlayerPoolEntry {
 }
 
 export interface Env extends BaseEnvWithAuth {
-  // ESPN-client specific vars if needed
+  ESPN_PLAYERS_CACHE: KVNamespace;
 }
 
 export type Sport = 'football' | 'baseball' | 'basketball' | 'hockey';
@@ -146,6 +146,7 @@ export interface ToolParams {
   type?: 'add' | 'drop' | 'trade' | 'waiver';
   position?: string;
   count?: number;
+  query?: string;
 }
 
 export type { ExecuteResponse } from '@flaim/worker-shared';

--- a/workers/espn-client/wrangler.jsonc
+++ b/workers/espn-client/wrangler.jsonc
@@ -24,6 +24,9 @@
     "prod": {
       "name": "espn-client",
       "workers_dev": true,
+      "kv_namespaces": [
+        { "binding": "ESPN_PLAYERS_CACHE", "id": "8aed89c806d34c53aa5edf53c26f9d32", "preview_id": "ed5d96feef944254af880eafe9c131b3" }
+      ],
       // Service binding for auth-worker (avoids same-zone fetch error 1042)
       "services": [
         { "binding": "AUTH_WORKER", "service": "auth-worker" }
@@ -39,6 +42,9 @@
     "preview": {
       "name": "espn-client-preview",
       "workers_dev": true,
+      "kv_namespaces": [
+        { "binding": "ESPN_PLAYERS_CACHE", "id": "ed5d96feef944254af880eafe9c131b3", "preview_id": "ed5d96feef944254af880eafe9c131b3" }
+      ],
       // Service binding for auth-worker
       "services": [
         { "binding": "AUTH_WORKER", "service": "auth-worker-preview" }
@@ -54,6 +60,9 @@
     "dev": {
       "name": "espn-client-dev",
       "workers_dev": true,
+      "kv_namespaces": [
+        { "binding": "ESPN_PLAYERS_CACHE", "id": "ed5d96feef944254af880eafe9c131b3", "preview_id": "ed5d96feef944254af880eafe9c131b3" }
+      ],
       // Service binding for auth-worker
       "services": [
         { "binding": "AUTH_WORKER", "service": "auth-worker-dev" }

--- a/workers/fantasy-mcp/src/__tests__/tools.test.ts
+++ b/workers/fantasy-mcp/src/__tests__/tools.test.ts
@@ -22,6 +22,7 @@ describe('fantasy-mcp tools', () => {
       'get_standings',
       'get_transactions',
       'get_user_session',
+      'search_players',
     ]);
   });
 

--- a/workers/fantasy-mcp/src/types.ts
+++ b/workers/fantasy-mcp/src/types.ts
@@ -22,4 +22,5 @@ export interface ToolParams {
   type?: 'add' | 'drop' | 'trade' | 'waiver';
   position?: string;
   count?: number;
+  query?: string;
 }

--- a/workers/sleeper-client/src/shared/sleeper-free-agents.ts
+++ b/workers/sleeper-client/src/shared/sleeper-free-agents.ts
@@ -7,8 +7,37 @@ export interface SleeperFreeAgent {
   team?: string;
 }
 
+export interface SleeperPlayerSearchResult {
+  id: string;
+  name: string;
+  position?: string;
+  team?: string;
+}
+
 function clampCount(count: number): number {
   return Math.max(1, Math.min(100, Math.trunc(count)));
+}
+
+export function buildSleeperPlayerSearch(
+  players: Map<string, SleeperPlayerRecord>,
+  query: string,
+  position?: string,
+  count = 10,
+): SleeperPlayerSearchResult[] {
+  const normalizedQuery = query.toLowerCase();
+  const normalizedPosition = position?.trim().toUpperCase();
+  const maxCount = Math.max(1, Math.min(25, Math.trunc(count)));
+
+  return Array.from(players.values())
+    .filter((player) => player.full_name.toLowerCase().includes(normalizedQuery))
+    .filter((player) => !normalizedPosition || player.position?.toUpperCase() === normalizedPosition)
+    .slice(0, maxCount)
+    .map((player) => ({
+      id: player.player_id,
+      name: player.full_name,
+      position: player.position,
+      team: player.team,
+    }));
 }
 
 export function buildSleeperFreeAgents(

--- a/workers/sleeper-client/src/sports/football/handlers.ts
+++ b/workers/sleeper-client/src/sports/football/handlers.ts
@@ -3,6 +3,7 @@ import { sleeperFetch, handleSleeperError } from '../../shared/sleeper-api';
 import { fetchSleeperTransactionsByWeeks, getSleeperCurrentWeek } from '../../shared/sleeper-transactions';
 import { getSleeperPlayersIndex } from '../../shared/sleeper-players-cache';
 import { createSleeperGetFreeAgentsHandler } from '../../shared/sleeper-free-agents-handler';
+import { buildSleeperPlayerSearch } from '../../shared/sleeper-free-agents';
 import { extractErrorCode } from '@flaim/worker-shared';
 
 type HandlerFn = (
@@ -21,7 +22,42 @@ export const footballHandlers: Record<string, HandlerFn> = {
   get_matchups: handleGetMatchups,
   get_free_agents: handleGetFreeAgents,
   get_transactions: handleGetTransactions,
+  search_players: handleSearchPlayers,
 };
+
+async function handleSearchPlayers(
+  env: Env,
+  params: ToolParams,
+): Promise<ExecuteResponse> {
+  const { query, position, count } = params;
+
+  if (!query) {
+    return { success: false, error: 'query is required for search_players', code: 'MISSING_PARAM' };
+  }
+
+  try {
+    const requestedCount = Math.max(1, Math.min(25, Math.trunc(Number.isFinite(Number(count)) ? Number(count) : 10)));
+    const playersIndex = await getSleeperPlayersIndex(env, 'football');
+    const players = buildSleeperPlayerSearch(playersIndex, query, position, requestedCount);
+
+    return {
+      success: true,
+      data: {
+        platform: 'sleeper',
+        sport: params.sport,
+        query,
+        count: players.length,
+        players,
+      },
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+      code: extractErrorCode(error),
+    };
+  }
+}
 
 async function handleGetLeagueInfo(
   _env: Env,

--- a/workers/sleeper-client/src/types.ts
+++ b/workers/sleeper-client/src/types.ts
@@ -21,6 +21,7 @@ export interface ToolParams {
   type?: 'add' | 'drop' | 'trade' | 'waiver';
   position?: string;
   count?: number;
+  query?: string;
 }
 
 export type { ExecuteResponse } from '@flaim/worker-shared';

--- a/workers/yahoo-client/src/sports/baseball/handlers.ts
+++ b/workers/yahoo-client/src/sports/baseball/handlers.ts
@@ -20,7 +20,92 @@ export const baseballHandlers: Record<string, HandlerFn> = {
   get_matchups: handleGetMatchups,
   get_free_agents: handleGetFreeAgents,
   get_transactions: handleGetTransactions,
+  search_players: handleSearchPlayers,
 };
+
+async function handleSearchPlayers(
+  env: Env,
+  params: ToolParams,
+  authHeader?: string,
+  correlationId?: string
+): Promise<ExecuteResponse> {
+  const { league_id, query, position, count } = params;
+
+  if (!query) {
+    return { success: false, error: 'query is required for search_players', code: 'MISSING_PARAM' };
+  }
+
+  try {
+    const credentials = await getYahooCredentials(env, authHeader, correlationId);
+    requireCredentials(credentials, 'search_players');
+
+    const limit = Math.min(Math.max(1, count || 10), 25);
+    let queryParams = `;search=${encodeURIComponent(query)};count=${limit}`;
+
+    const posFilter = getPositionFilter(position);
+    if (posFilter) {
+      queryParams += `;position=${posFilter}`;
+    }
+
+    const response = await yahooFetch(`/league/${league_id}/players${queryParams}`, { credentials });
+
+    if (!response.ok) {
+      handleYahooError(response);
+    }
+
+    const raw = await response.json();
+
+    const leagueArray = getPath(raw, ['fantasy_content', 'league']);
+    const league = unwrapLeague(leagueArray);
+
+    const playersObj = league.players as Record<string, unknown> | undefined;
+    const playersArray = asArray(playersObj);
+
+    const players = playersArray.map((playerWrapper: unknown) => {
+      const playerData = getPath(playerWrapper, ['player']) as unknown[];
+
+      const metaArray = playerData?.[0] as unknown[];
+      let playerMeta: Record<string, unknown> = {};
+      if (Array.isArray(metaArray)) {
+        for (const item of metaArray) {
+          if (typeof item === 'object' && item !== null) {
+            playerMeta = { ...playerMeta, ...item };
+          }
+        }
+      }
+
+      const ownershipData = playerData?.[1] as Record<string, unknown> | undefined;
+      const ownership = ownershipData?.ownership as Record<string, unknown> | undefined;
+
+      return {
+        playerKey: playerMeta.player_key as string,
+        playerId: playerMeta.player_id as string,
+        name: (playerMeta.name as Record<string, unknown>)?.full as string,
+        team: playerMeta.editorial_team_abbr as string,
+        position: playerMeta.display_position as string,
+        percentOwned: ownership?.percent_owned ? parseFloat(String(ownership.percent_owned)) : undefined,
+        status: playerMeta.status as string | undefined,
+      };
+    });
+
+    return {
+      success: true,
+      data: {
+        leagueKey: league.league_key,
+        leagueName: league.name,
+        query,
+        count: players.length,
+        players,
+      },
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+      code: extractErrorCode(error),
+    };
+  }
+}
 
 async function handleGetLeagueInfo(
   env: Env,

--- a/workers/yahoo-client/src/sports/basketball/handlers.ts
+++ b/workers/yahoo-client/src/sports/basketball/handlers.ts
@@ -20,7 +20,92 @@ export const basketballHandlers: Record<string, HandlerFn> = {
   get_matchups: handleGetMatchups,
   get_free_agents: handleGetFreeAgents,
   get_transactions: handleGetTransactions,
+  search_players: handleSearchPlayers,
 };
+
+async function handleSearchPlayers(
+  env: Env,
+  params: ToolParams,
+  authHeader?: string,
+  correlationId?: string
+): Promise<ExecuteResponse> {
+  const { league_id, query, position, count } = params;
+
+  if (!query) {
+    return { success: false, error: 'query is required for search_players', code: 'MISSING_PARAM' };
+  }
+
+  try {
+    const credentials = await getYahooCredentials(env, authHeader, correlationId);
+    requireCredentials(credentials, 'search_players');
+
+    const limit = Math.min(Math.max(1, count || 10), 25);
+    let queryParams = `;search=${encodeURIComponent(query)};count=${limit}`;
+
+    const posFilter = getPositionFilter(position);
+    if (posFilter) {
+      queryParams += `;position=${posFilter}`;
+    }
+
+    const response = await yahooFetch(`/league/${league_id}/players${queryParams}`, { credentials });
+
+    if (!response.ok) {
+      handleYahooError(response);
+    }
+
+    const raw = await response.json();
+
+    const leagueArray = getPath(raw, ['fantasy_content', 'league']);
+    const league = unwrapLeague(leagueArray);
+
+    const playersObj = league.players as Record<string, unknown> | undefined;
+    const playersArray = asArray(playersObj);
+
+    const players = playersArray.map((playerWrapper: unknown) => {
+      const playerData = getPath(playerWrapper, ['player']) as unknown[];
+
+      const metaArray = playerData?.[0] as unknown[];
+      let playerMeta: Record<string, unknown> = {};
+      if (Array.isArray(metaArray)) {
+        for (const item of metaArray) {
+          if (typeof item === 'object' && item !== null) {
+            playerMeta = { ...playerMeta, ...item };
+          }
+        }
+      }
+
+      const ownershipData = playerData?.[1] as Record<string, unknown> | undefined;
+      const ownership = ownershipData?.ownership as Record<string, unknown> | undefined;
+
+      return {
+        playerKey: playerMeta.player_key as string,
+        playerId: playerMeta.player_id as string,
+        name: (playerMeta.name as Record<string, unknown>)?.full as string,
+        team: playerMeta.editorial_team_abbr as string,
+        position: playerMeta.display_position as string,
+        percentOwned: ownership?.percent_owned ? parseFloat(String(ownership.percent_owned)) : undefined,
+        status: playerMeta.status as string | undefined,
+      };
+    });
+
+    return {
+      success: true,
+      data: {
+        leagueKey: league.league_key,
+        leagueName: league.name,
+        query,
+        count: players.length,
+        players,
+      },
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+      code: extractErrorCode(error),
+    };
+  }
+}
 
 async function handleGetLeagueInfo(
   env: Env,

--- a/workers/yahoo-client/src/sports/football/handlers.ts
+++ b/workers/yahoo-client/src/sports/football/handlers.ts
@@ -20,7 +20,92 @@ export const footballHandlers: Record<string, HandlerFn> = {
   get_matchups: handleGetMatchups,
   get_free_agents: handleGetFreeAgents,
   get_transactions: handleGetTransactions,
+  search_players: handleSearchPlayers,
 };
+
+async function handleSearchPlayers(
+  env: Env,
+  params: ToolParams,
+  authHeader?: string,
+  correlationId?: string
+): Promise<ExecuteResponse> {
+  const { league_id, query, position, count } = params;
+
+  if (!query) {
+    return { success: false, error: 'query is required for search_players', code: 'MISSING_PARAM' };
+  }
+
+  try {
+    const credentials = await getYahooCredentials(env, authHeader, correlationId);
+    requireCredentials(credentials, 'search_players');
+
+    const limit = Math.min(Math.max(1, count || 10), 25);
+    let queryParams = `;search=${encodeURIComponent(query)};count=${limit}`;
+
+    const posFilter = getPositionFilter(position);
+    if (posFilter) {
+      queryParams += `;position=${posFilter}`;
+    }
+
+    const response = await yahooFetch(`/league/${league_id}/players${queryParams}`, { credentials });
+
+    if (!response.ok) {
+      handleYahooError(response);
+    }
+
+    const raw = await response.json();
+
+    const leagueArray = getPath(raw, ['fantasy_content', 'league']);
+    const league = unwrapLeague(leagueArray);
+
+    const playersObj = league.players as Record<string, unknown> | undefined;
+    const playersArray = asArray(playersObj);
+
+    const players = playersArray.map((playerWrapper: unknown) => {
+      const playerData = getPath(playerWrapper, ['player']) as unknown[];
+
+      const metaArray = playerData?.[0] as unknown[];
+      let playerMeta: Record<string, unknown> = {};
+      if (Array.isArray(metaArray)) {
+        for (const item of metaArray) {
+          if (typeof item === 'object' && item !== null) {
+            playerMeta = { ...playerMeta, ...item };
+          }
+        }
+      }
+
+      const ownershipData = playerData?.[1] as Record<string, unknown> | undefined;
+      const ownership = ownershipData?.ownership as Record<string, unknown> | undefined;
+
+      return {
+        playerKey: playerMeta.player_key as string,
+        playerId: playerMeta.player_id as string,
+        name: (playerMeta.name as Record<string, unknown>)?.full as string,
+        team: playerMeta.editorial_team_abbr as string,
+        position: playerMeta.display_position as string,
+        percentOwned: ownership?.percent_owned ? parseFloat(String(ownership.percent_owned)) : undefined,
+        status: playerMeta.status as string | undefined,
+      };
+    });
+
+    return {
+      success: true,
+      data: {
+        leagueKey: league.league_key,
+        leagueName: league.name,
+        query,
+        count: players.length,
+        players,
+      },
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+      code: extractErrorCode(error),
+    };
+  }
+}
 
 async function handleGetLeagueInfo(
   env: Env,

--- a/workers/yahoo-client/src/sports/hockey/handlers.ts
+++ b/workers/yahoo-client/src/sports/hockey/handlers.ts
@@ -20,7 +20,92 @@ export const hockeyHandlers: Record<string, HandlerFn> = {
   get_matchups: handleGetMatchups,
   get_free_agents: handleGetFreeAgents,
   get_transactions: handleGetTransactions,
+  search_players: handleSearchPlayers,
 };
+
+async function handleSearchPlayers(
+  env: Env,
+  params: ToolParams,
+  authHeader?: string,
+  correlationId?: string
+): Promise<ExecuteResponse> {
+  const { league_id, query, position, count } = params;
+
+  if (!query) {
+    return { success: false, error: 'query is required for search_players', code: 'MISSING_PARAM' };
+  }
+
+  try {
+    const credentials = await getYahooCredentials(env, authHeader, correlationId);
+    requireCredentials(credentials, 'search_players');
+
+    const limit = Math.min(Math.max(1, count || 10), 25);
+    let queryParams = `;search=${encodeURIComponent(query)};count=${limit}`;
+
+    const posFilter = getPositionFilter(position);
+    if (posFilter) {
+      queryParams += `;position=${posFilter}`;
+    }
+
+    const response = await yahooFetch(`/league/${league_id}/players${queryParams}`, { credentials });
+
+    if (!response.ok) {
+      handleYahooError(response);
+    }
+
+    const raw = await response.json();
+
+    const leagueArray = getPath(raw, ['fantasy_content', 'league']);
+    const league = unwrapLeague(leagueArray);
+
+    const playersObj = league.players as Record<string, unknown> | undefined;
+    const playersArray = asArray(playersObj);
+
+    const players = playersArray.map((playerWrapper: unknown) => {
+      const playerData = getPath(playerWrapper, ['player']) as unknown[];
+
+      const metaArray = playerData?.[0] as unknown[];
+      let playerMeta: Record<string, unknown> = {};
+      if (Array.isArray(metaArray)) {
+        for (const item of metaArray) {
+          if (typeof item === 'object' && item !== null) {
+            playerMeta = { ...playerMeta, ...item };
+          }
+        }
+      }
+
+      const ownershipData = playerData?.[1] as Record<string, unknown> | undefined;
+      const ownership = ownershipData?.ownership as Record<string, unknown> | undefined;
+
+      return {
+        playerKey: playerMeta.player_key as string,
+        playerId: playerMeta.player_id as string,
+        name: (playerMeta.name as Record<string, unknown>)?.full as string,
+        team: playerMeta.editorial_team_abbr as string,
+        position: playerMeta.display_position as string,
+        percentOwned: ownership?.percent_owned ? parseFloat(String(ownership.percent_owned)) : undefined,
+        status: playerMeta.status as string | undefined,
+      };
+    });
+
+    return {
+      success: true,
+      data: {
+        leagueKey: league.league_key,
+        leagueName: league.name,
+        query,
+        count: players.length,
+        players,
+      },
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+      code: extractErrorCode(error),
+    };
+  }
+}
 
 async function handleGetLeagueInfo(
   env: Env,

--- a/workers/yahoo-client/src/types.ts
+++ b/workers/yahoo-client/src/types.ts
@@ -21,6 +21,7 @@ export interface ToolParams {
   type?: 'add' | 'drop' | 'trade' | 'waiver';
   position?: string;
   count?: number;
+  query?: string;
 }
 
 export type { ExecuteResponse } from '@flaim/worker-shared';


### PR DESCRIPTION
## Summary
- New `search_players` tool registered in the fantasy-mcp gateway (Tool 7) — searches players by name across all roster statuses (rostered, FA, waived), returning identity-only results (name, position, pro team)
- ESPN: KV-cached `players_wl` endpoint (`espn-players-cache.ts`) with per-sport limits and 24hr TTL; handlers added for all 4 sports; IDP positions added to football POSITION_MAP
- Yahoo: Native `;search=` matrix param — handlers added for all 4 sports, reusing existing player normalization
- Sleeper: New `buildSleeperPlayerSearch` helper (TDD, 6 new tests) added to football + basketball handlers; includes inactive players, no roster exclusion

## Test Plan
- [ ] `npm run type-check` in all 4 workers — no errors (verified)
- [ ] `npm test` in `sleeper-client` — 49 tests passing (verified)
- [ ] Deploy to preview: `npm run deploy:workers:preview`
- [ ] Sleeper football: `search_players(query="mahomes")` → Patrick Mahomes, KC, QB
- [ ] ESPN football: first call ~3s (KV populate), second call fast
- [ ] ESPN baseball: `search_players(query="bellinger")` → multi-sport confirmed
- [ ] Yahoo football: `search_players(query="allen")` → Josh Allen + others
- [ ] Position filter: `search_players(query="patrick", position="LB")` → Patrick Queen only
- [ ] Update FLA-33 to Done in Linear

🤖 Generated with [Claude Code](https://claude.com/claude-code)