### PR TITLE
fix: address 6 frontend code quality issues

### DIFF
--- a/web/app/(site)/leagues/page.tsx
+++ b/web/app/(site)/leagues/page.tsx
@@ -44,8 +44,7 @@ import {
 } from '@/components/ui/dialog';
 import { useEspnCredentials } from '@/lib/use-espn-credentials';
 import { getDefaultSeasonYear } from '@/lib/season-utils';
-
-const CHROME_EXTENSION_URL = "https://chromewebstore.google.com/detail/flaim-espn-fantasy-connec/mbnokejgglkfgkeeenolgdpcnfakpbkn";
+import { CHROME_EXTENSION_URL } from '@/config/constants';
 
 interface League {
   leagueId: string;
@@ -137,6 +136,8 @@ interface UnifiedLeagueGroup {
 const SPORT_OPTIONS: { value: Sport; label: string; emoji: string }[] = [
   { value: 'football', label: 'Football', emoji: '\u{1F3C8}' },
   { value: 'baseball', label: 'Baseball', emoji: '\u26BE' },
+  { value: 'basketball', label: 'Basketball', emoji: '\u{1F3C0}' },
+  { value: 'hockey', label: 'Hockey', emoji: '\u{1F3D2}' },
 ];
 
 // Generate season options (current year down to 2000)
@@ -533,6 +534,7 @@ function LeaguesPageContent() {
       }
     } catch (err) {
       console.error('Failed to disconnect Sleeper:', err);
+      setLeagueError('Failed to disconnect Sleeper. Please try again.');
     } finally {
       setIsSleeperDisconnecting(false);
     }
@@ -562,6 +564,7 @@ function LeaguesPageContent() {
       }
     } catch (err) {
       console.error('Failed to disconnect Yahoo:', err);
+      setLeagueError('Failed to disconnect Yahoo. Please try again.');
     } finally {
       setIsYahooDisconnecting(false);
     }

--- a/web/app/api/espn/leagues/route.ts
+++ b/web/app/api/espn/leagues/route.ts
@@ -7,6 +7,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@clerk/nextjs/server';
+import type { WorkerErrorResponse, WorkerLeaguesResponse } from '@/types/api-responses';
 
 export async function GET() {
   try {
@@ -43,13 +44,13 @@ export async function GET() {
         return NextResponse.json({ leagues: [] }, { status: 200 });
       }
       
-      const workerData = await workerResponse.json() as any;
+      const workerData = await workerResponse.json() as WorkerErrorResponse;
       return NextResponse.json({
         error: workerData?.error || 'Failed to fetch leagues'
       }, { status: workerResponse.status });
     }
 
-    const workerData = await workerResponse.json() as any;
+    const workerData = await workerResponse.json() as WorkerLeaguesResponse;
     return NextResponse.json(workerData, { status: 200 });
 
   } catch (error) {
@@ -139,7 +140,7 @@ export async function POST(request: NextRequest) {
       body: JSON.stringify({ leagues: body.leagues })
     });
 
-    const workerData = await workerResponse.json() as any;
+    const workerData = await workerResponse.json() as WorkerLeaguesResponse;
 
     if (!workerResponse.ok) {
       return NextResponse.json({
@@ -198,7 +199,7 @@ export async function DELETE(request: NextRequest) {
       }
     });
 
-    const workerData = await workerResponse.json() as any;
+    const workerData = await workerResponse.json() as WorkerLeaguesResponse;
 
     if (!workerResponse.ok) {
       return NextResponse.json({

--- a/web/app/api/espn/leagues/route.ts
+++ b/web/app/api/espn/leagues/route.ts
@@ -140,14 +140,14 @@ export async function POST(request: NextRequest) {
       body: JSON.stringify({ leagues: body.leagues })
     });
 
-    const workerData = await workerResponse.json() as WorkerLeaguesResponse;
-
     if (!workerResponse.ok) {
+      const workerData = await workerResponse.json() as WorkerErrorResponse;
       return NextResponse.json({
         error: workerData?.error || 'Failed to save leagues'
       }, { status: workerResponse.status });
     }
 
+    const workerData = await workerResponse.json() as WorkerLeaguesResponse;
     return NextResponse.json(workerData, { status: 200 });
 
   } catch (error) {
@@ -199,14 +199,14 @@ export async function DELETE(request: NextRequest) {
       }
     });
 
-    const workerData = await workerResponse.json() as WorkerLeaguesResponse;
-
     if (!workerResponse.ok) {
+      const workerData = await workerResponse.json() as WorkerErrorResponse;
       return NextResponse.json({
         error: workerData?.error || 'Failed to remove league'
       }, { status: workerResponse.status });
     }
 
+    const workerData = await workerResponse.json() as WorkerLeaguesResponse;
     return NextResponse.json(workerData, { status: 200 });
 
   } catch (error) {

--- a/web/app/opengraph-image.tsx
+++ b/web/app/opengraph-image.tsx
@@ -28,6 +28,7 @@ export default function Image() {
           src={`${baseUrl}/flaim-mark-hero-dark.png`}
           width={100}
           height={100}
+          alt=""
           style={{ marginBottom: '32px' }}
         />
         <div

--- a/web/components/site/StepConnectPlatforms.tsx
+++ b/web/components/site/StepConnectPlatforms.tsx
@@ -50,6 +50,7 @@ export function StepConnectPlatforms({ className }: StepConnectPlatformsProps) {
 
   // Yahoo state
   const [yahooStatus, setYahooStatus] = useState<YahooStatus>('loading');
+
   // Sleeper state
   const [sleeperUsername, setSleeperUsername] = useState('');
   const [sleeperStatus, setSleeperStatus] = useState<{ connected: boolean; sleeperUsername?: string | null; leagueCount?: number } | null>(null);

--- a/web/components/site/StepConnectPlatforms.tsx
+++ b/web/components/site/StepConnectPlatforms.tsx
@@ -17,8 +17,7 @@ import { Card } from '@/components/ui/card';
 import { Chrome, Check, Loader2, Shield, Eye, EyeOff, Wrench } from 'lucide-react';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { pingExtension, isChromeBrowser, type ExtensionPingResult } from '@/lib/extension-ping';
-
-const CHROME_EXTENSION_URL = "https://chromewebstore.google.com/detail/flaim-espn-fantasy-connec/mbnokejgglkfgkeeenolgdpcnfakpbkn";
+import { CHROME_EXTENSION_URL } from '@/config/constants';
 
 type EspnStatus =
   | 'loading'
@@ -51,8 +50,6 @@ export function StepConnectPlatforms({ className }: StepConnectPlatformsProps) {
 
   // Yahoo state
   const [yahooStatus, setYahooStatus] = useState<YahooStatus>('loading');
-  const [yahooLeagueCount, setYahooLeagueCount] = useState(0);
-
   // Sleeper state
   const [sleeperUsername, setSleeperUsername] = useState('');
   const [sleeperStatus, setSleeperStatus] = useState<{ connected: boolean; sleeperUsername?: string | null; leagueCount?: number } | null>(null);
@@ -88,15 +85,10 @@ export function StepConnectPlatforms({ className }: StepConnectPlatformsProps) {
       } catch { /* ignore */ }
 
       try {
-        const credsRes = await fetch('/api/auth/espn/credentials?forEdit=true');
+        const credsRes = await fetch('/api/auth/espn/credentials');
         if (credsRes.ok) {
-          const data = (await credsRes.json()) as { hasCredentials?: boolean; swid?: string; s2?: string };
+          const data = (await credsRes.json()) as { hasCredentials?: boolean };
           setHasCredentials(!!data.hasCredentials);
-          if (data.swid || data.s2) {
-            if (data.swid) setSwid(data.swid);
-            if (data.s2) setEspnS2(data.s2);
-            setHasLoadedCreds(true);
-          }
         }
       } catch { /* ignore */ }
 
@@ -117,12 +109,6 @@ export function StepConnectPlatforms({ className }: StepConnectPlatformsProps) {
           const data = (await res.json()) as { connected?: boolean };
           if (data.connected) {
             setYahooStatus('connected');
-            // Get league count
-            const leaguesRes = await fetch('/api/connect/yahoo/leagues');
-            if (leaguesRes.ok) {
-              const leaguesData = (await leaguesRes.json()) as { leagues?: unknown[] };
-              setYahooLeagueCount(leaguesData.leagues?.length || 0);
-            }
           } else {
             setYahooStatus('not_connected');
           }

--- a/web/config/constants.ts
+++ b/web/config/constants.ts
@@ -1,5 +1,7 @@
 export const MODEL = "gpt-5-mini-2025-08-07";
 
+export const CHROME_EXTENSION_URL = "https://chromewebstore.google.com/detail/flaim-espn-fantasy-connec/mbnokejgglkfgkeeenolgdpcnfakpbkn";
+
 // NOTE: System prompt has been moved to lib/prompts/system-prompt.ts
 // for easier editing and maintenance.
 

--- a/web/types/api-responses.ts
+++ b/web/types/api-responses.ts
@@ -45,3 +45,18 @@ export interface TurnResponseRequest {
   tools?: any[];
   previous_response_id?: string;
 }
+
+export interface WorkerErrorResponse {
+  error?: string;
+}
+
+export interface WorkerLeaguesResponse extends WorkerErrorResponse {
+  leagues?: Array<{
+    leagueId: string;
+    sport: string;
+    leagueName?: string;
+    teamId?: string;
+    seasonYear?: number;
+  }>;
+  deleted?: boolean;
+}


### PR DESCRIPTION
## Summary
- **Complete `SPORT_OPTIONS`** — add basketball/hockey so `getSportLabel()`/`getSportEmoji()` stop returning fallbacks
- **OG image `alt` prop** — add decorative `alt=""` to `<img>` in opengraph-image.tsx
- **Remove dead state** — drop unused `yahooLeagueCount` state and the league-count fetch it powered
- **Stop eager credential fetch** — landing page no longer fetches editable ESPN credentials; `handleOpenDialog` still fetches on demand
- **Shared constant** — extract `CHROME_EXTENSION_URL` to `web/config/constants.ts`, replace both local copies
- **Type worker responses** — replace 4× `as any` in ESPN leagues route with `WorkerErrorResponse`/`WorkerLeaguesResponse`
- **Surface disconnect errors** — Yahoo/Sleeper disconnect catch blocks now call `setLeagueError()` so failures show in the existing alert

## Test plan
- [ ] `npx tsc --noEmit` — zero errors (verified)
- [ ] `npm run lint` — zero warnings (verified)
- [ ] `npm run ui:check` — no violations (verified)
- [ ] Verify basketball/hockey leagues render correct labels and emoji on /leagues
- [ ] Verify ESPN credential dialog still loads credentials on open
- [ ] Simulate Yahoo/Sleeper disconnect failure and confirm error alert appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)