### PR TITLE
fix: address 4 backend code quality issues

### DIFF
--- a/workers/auth-worker/src/__tests__/eval-api-key.test.ts
+++ b/workers/auth-worker/src/__tests__/eval-api-key.test.ts
@@ -430,6 +430,7 @@ describe('eval API key auth', () => {
       rateLimitedEnv as any
     );
     expect(res.status).toBe(429);
+    expect(res.headers.get('Retry-After')).toBe('60');
     const body = await res.json() as { error?: string };
     expect(body.error).toBe('rate_limit_exceeded');
   });

--- a/workers/auth-worker/src/__tests__/eval-api-key.test.ts
+++ b/workers/auth-worker/src/__tests__/eval-api-key.test.ts
@@ -418,4 +418,19 @@ describe('eval API key auth', () => {
     );
     expect(res.status).toBe(401);
   });
+
+  it('GET /authorize returns 429 when rate limited', async () => {
+    const rateLimitedEnv = {
+      ...baseEnv,
+      TOKEN_RATE_LIMITER: { limit: async () => ({ success: false }) },
+    };
+
+    const res = await appFetch(
+      makeRequest('/authorize?response_type=code&client_id=test&redirect_uri=https://claude.ai/callback&code_challenge=abc&code_challenge_method=S256'),
+      rateLimitedEnv as any
+    );
+    expect(res.status).toBe(429);
+    const body = await res.json() as { error?: string };
+    expect(body.error).toBe('rate_limit_exceeded');
+  });
 });

--- a/workers/auth-worker/src/index-hono.ts
+++ b/workers/auth-worker/src/index-hono.ts
@@ -639,7 +639,7 @@ api.get('/authorize', async (c) => {
     return c.json({
       error: 'rate_limit_exceeded',
       error_description: 'Too many authorization requests. Please try again later.',
-    }, 429);
+    }, 429, { 'Retry-After': '60' });
   }
   return handleAuthorize(c.req.raw, c.env as OAuthEnv);
 });
@@ -652,7 +652,7 @@ api.post('/token', async (c) => {
     return c.json({
       error: 'rate_limit_exceeded',
       error_description: 'Too many token requests. Please try again later.',
-    }, 429);
+    }, 429, { 'Retry-After': '60' });
   }
   return handleToken(c.req.raw, c.env as OAuthEnv, getCorsHeaders(c.req.raw));
 });

--- a/workers/auth-worker/src/index-hono.ts
+++ b/workers/auth-worker/src/index-hono.ts
@@ -631,8 +631,16 @@ api.all('/register', (c) => {
   return handleClientRegistration(c.req.raw, c.env as OAuthEnv, getCorsHeaders(c.req.raw));
 });
 
-// Authorization endpoint - redirects to frontend consent page
-api.get('/authorize', (c) => {
+// Authorization endpoint - redirects to frontend consent page (rate-limited per IP)
+api.get('/authorize', async (c) => {
+  const clientIp = c.req.header('CF-Connecting-IP') || 'unknown';
+  const { success } = await c.env.TOKEN_RATE_LIMITER.limit({ key: `authorize:${clientIp}` });
+  if (!success) {
+    return c.json({
+      error: 'rate_limit_exceeded',
+      error_description: 'Too many authorization requests. Please try again later.',
+    }, 429);
+  }
   return handleAuthorize(c.req.raw, c.env as OAuthEnv);
 });
 

--- a/workers/espn-client/src/sports/baseball/handlers.ts
+++ b/workers/espn-client/src/sports/baseball/handlers.ts
@@ -259,8 +259,9 @@ async function handleGetMatchups(
     const schedule = data.schedule || [];
 
     // Transform matchups
+    const matchupPeriod = week || data.scoringPeriodId;
     const matchups = schedule
-      .filter((matchup) => matchup.matchupPeriodId === (week || data.scoringPeriodId))
+      .filter((matchup) => matchupPeriod == null || matchup.matchupPeriodId === matchupPeriod)
       .map((matchup) => ({
         matchupPeriodId: matchup.matchupPeriodId,
         home: matchup.home ? {
@@ -285,7 +286,7 @@ async function handleGetMatchups(
         leagueId: league_id,
         seasonYear: season_year,
         currentScoringPeriod: data.scoringPeriodId,
-        matchupPeriod: week || data.scoringPeriodId,
+        matchupPeriod: matchupPeriod ?? null,
         matchups
       }
     };

--- a/workers/espn-client/src/sports/baseball/handlers.ts
+++ b/workers/espn-client/src/sports/baseball/handlers.ts
@@ -259,7 +259,7 @@ async function handleGetMatchups(
     const schedule = data.schedule || [];
 
     // Transform matchups
-    const matchupPeriod = week ?? data.scoringPeriodId;
+    const matchupPeriod = week ?? data.scoringPeriodId ?? data.currentMatchupPeriod;
     const matchups = schedule
       .filter((matchup) => matchupPeriod == null || matchup.matchupPeriodId === matchupPeriod)
       .map((matchup) => ({

--- a/workers/espn-client/src/sports/baseball/handlers.ts
+++ b/workers/espn-client/src/sports/baseball/handlers.ts
@@ -259,7 +259,7 @@ async function handleGetMatchups(
     const schedule = data.schedule || [];
 
     // Transform matchups
-    const matchupPeriod = week || data.scoringPeriodId;
+    const matchupPeriod = week ?? data.scoringPeriodId;
     const matchups = schedule
       .filter((matchup) => matchupPeriod == null || matchup.matchupPeriodId === matchupPeriod)
       .map((matchup) => ({

--- a/workers/espn-client/src/sports/basketball/handlers.ts
+++ b/workers/espn-client/src/sports/basketball/handlers.ts
@@ -259,8 +259,9 @@ async function handleGetMatchups(
     const schedule = data.schedule || [];
 
     // Transform matchups
+    const matchupPeriod = week || data.scoringPeriodId;
     const matchups = schedule
-      .filter((matchup) => matchup.matchupPeriodId === (week || data.scoringPeriodId))
+      .filter((matchup) => matchupPeriod == null || matchup.matchupPeriodId === matchupPeriod)
       .map((matchup) => ({
         matchupPeriodId: matchup.matchupPeriodId,
         home: matchup.home ? {
@@ -285,7 +286,7 @@ async function handleGetMatchups(
         leagueId: league_id,
         seasonYear: season_year,
         currentScoringPeriod: data.scoringPeriodId,
-        matchupPeriod: week || data.scoringPeriodId,
+        matchupPeriod: matchupPeriod ?? null,
         matchups
       }
     };

--- a/workers/espn-client/src/sports/basketball/handlers.ts
+++ b/workers/espn-client/src/sports/basketball/handlers.ts
@@ -259,7 +259,7 @@ async function handleGetMatchups(
     const schedule = data.schedule || [];
 
     // Transform matchups
-    const matchupPeriod = week ?? data.scoringPeriodId;
+    const matchupPeriod = week ?? data.scoringPeriodId ?? data.currentMatchupPeriod;
     const matchups = schedule
       .filter((matchup) => matchupPeriod == null || matchup.matchupPeriodId === matchupPeriod)
       .map((matchup) => ({

--- a/workers/espn-client/src/sports/basketball/handlers.ts
+++ b/workers/espn-client/src/sports/basketball/handlers.ts
@@ -259,7 +259,7 @@ async function handleGetMatchups(
     const schedule = data.schedule || [];
 
     // Transform matchups
-    const matchupPeriod = week || data.scoringPeriodId;
+    const matchupPeriod = week ?? data.scoringPeriodId;
     const matchups = schedule
       .filter((matchup) => matchupPeriod == null || matchup.matchupPeriodId === matchupPeriod)
       .map((matchup) => ({

--- a/workers/espn-client/src/sports/football/__tests__/matchups.test.ts
+++ b/workers/espn-client/src/sports/football/__tests__/matchups.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi, type MockedFunction } from 'vitest';
+import { footballHandlers } from '../handlers';
+import type { ToolParams } from '../../../types';
+import { getCredentials } from '../../../shared/auth';
+import { espnFetch } from '../../../shared/espn-api';
+
+vi.mock('../../../shared/auth', () => ({
+  getCredentials: vi.fn(),
+}));
+
+vi.mock('../../../shared/espn-api', async () => {
+  const actual = await vi.importActual('../../../shared/espn-api') as Record<string, unknown>;
+  return {
+    ...actual,
+    espnFetch: vi.fn(),
+  };
+});
+
+describe('football get_matchups handler', () => {
+  const getCredentialsMock = getCredentials as MockedFunction<typeof getCredentials>;
+  const espnFetchMock = espnFetch as MockedFunction<typeof espnFetch>;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns all matchups when scoringPeriodId is missing and no week specified', async () => {
+    getCredentialsMock.mockResolvedValue({ s2: 'token', swid: '{swid}' });
+    espnFetchMock.mockResolvedValue(
+      new Response(JSON.stringify({
+        // scoringPeriodId intentionally omitted
+        schedule: [
+          {
+            matchupPeriodId: 1,
+            home: { teamId: 1, totalPoints: 100 },
+            away: { teamId: 2, totalPoints: 90 },
+            winner: 'HOME',
+          },
+          {
+            matchupPeriodId: 2,
+            home: { teamId: 3, totalPoints: 80 },
+            away: { teamId: 4, totalPoints: 70 },
+            winner: 'HOME',
+          },
+        ],
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    );
+
+    const params: ToolParams = { sport: 'football', league_id: '123', season_year: 2025 };
+    const result = await footballHandlers.get_matchups({} as never, params, 'Bearer x', 'cid');
+
+    expect(result.success).toBe(true);
+    const data = result.data as { matchups: unknown[]; matchupPeriod: number | null };
+    // Should return all matchups instead of filtering to empty
+    expect(data.matchups).toHaveLength(2);
+    expect(data.matchupPeriod).toBeNull();
+  });
+
+  it('filters to specified week when provided', async () => {
+    getCredentialsMock.mockResolvedValue({ s2: 'token', swid: '{swid}' });
+    espnFetchMock.mockResolvedValue(
+      new Response(JSON.stringify({
+        scoringPeriodId: 5,
+        schedule: [
+          { matchupPeriodId: 3, home: { teamId: 1, totalPoints: 100 }, away: { teamId: 2, totalPoints: 90 }, winner: 'HOME' },
+          { matchupPeriodId: 4, home: { teamId: 3, totalPoints: 80 }, away: { teamId: 4, totalPoints: 70 }, winner: 'HOME' },
+        ],
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    );
+
+    const params: ToolParams = { sport: 'football', league_id: '123', season_year: 2025, week: 3 };
+    const result = await footballHandlers.get_matchups({} as never, params, 'Bearer x', 'cid');
+
+    expect(result.success).toBe(true);
+    const data = result.data as { matchups: unknown[]; matchupPeriod: number };
+    expect(data.matchups).toHaveLength(1);
+    expect(data.matchupPeriod).toBe(3);
+  });
+});

--- a/workers/espn-client/src/sports/football/handlers.ts
+++ b/workers/espn-client/src/sports/football/handlers.ts
@@ -208,7 +208,7 @@ async function handleGetMatchups(
     const schedule = data.schedule || [];
 
     // Transform matchups
-    const matchupPeriod = week || data.scoringPeriodId;
+    const matchupPeriod = week ?? data.scoringPeriodId;
     const matchups = schedule
       .filter((matchup) => matchupPeriod == null || matchup.matchupPeriodId === matchupPeriod)
       .map((matchup) => ({

--- a/workers/espn-client/src/sports/football/handlers.ts
+++ b/workers/espn-client/src/sports/football/handlers.ts
@@ -208,7 +208,7 @@ async function handleGetMatchups(
     const schedule = data.schedule || [];
 
     // Transform matchups
-    const matchupPeriod = week ?? data.scoringPeriodId;
+    const matchupPeriod = week ?? data.scoringPeriodId ?? data.currentMatchupPeriod;
     const matchups = schedule
       .filter((matchup) => matchupPeriod == null || matchup.matchupPeriodId === matchupPeriod)
       .map((matchup) => ({

--- a/workers/espn-client/src/sports/football/handlers.ts
+++ b/workers/espn-client/src/sports/football/handlers.ts
@@ -208,8 +208,9 @@ async function handleGetMatchups(
     const schedule = data.schedule || [];
 
     // Transform matchups
+    const matchupPeriod = week || data.scoringPeriodId;
     const matchups = schedule
-      .filter((matchup) => matchup.matchupPeriodId === (week || data.scoringPeriodId))
+      .filter((matchup) => matchupPeriod == null || matchup.matchupPeriodId === matchupPeriod)
       .map((matchup) => ({
         matchupPeriodId: matchup.matchupPeriodId,
         home: matchup.home ? {
@@ -234,7 +235,7 @@ async function handleGetMatchups(
         leagueId: league_id,
         seasonYear: season_year,
         currentScoringPeriod: data.scoringPeriodId,
-        matchupPeriod: week || data.scoringPeriodId,
+        matchupPeriod: matchupPeriod ?? null,
         matchups
       }
     };

--- a/workers/espn-client/src/sports/hockey/handlers.ts
+++ b/workers/espn-client/src/sports/hockey/handlers.ts
@@ -259,8 +259,9 @@ async function handleGetMatchups(
     const schedule = data.schedule || [];
 
     // Transform matchups
+    const matchupPeriod = week || data.scoringPeriodId;
     const matchups = schedule
-      .filter((matchup) => matchup.matchupPeriodId === (week || data.scoringPeriodId))
+      .filter((matchup) => matchupPeriod == null || matchup.matchupPeriodId === matchupPeriod)
       .map((matchup) => ({
         matchupPeriodId: matchup.matchupPeriodId,
         home: matchup.home ? {
@@ -285,7 +286,7 @@ async function handleGetMatchups(
         leagueId: league_id,
         seasonYear: season_year,
         currentScoringPeriod: data.scoringPeriodId,
-        matchupPeriod: week || data.scoringPeriodId,
+        matchupPeriod: matchupPeriod ?? null,
         matchups
       }
     };

--- a/workers/espn-client/src/sports/hockey/handlers.ts
+++ b/workers/espn-client/src/sports/hockey/handlers.ts
@@ -259,7 +259,7 @@ async function handleGetMatchups(
     const schedule = data.schedule || [];
 
     // Transform matchups
-    const matchupPeriod = week ?? data.scoringPeriodId;
+    const matchupPeriod = week ?? data.scoringPeriodId ?? data.currentMatchupPeriod;
     const matchups = schedule
       .filter((matchup) => matchupPeriod == null || matchup.matchupPeriodId === matchupPeriod)
       .map((matchup) => ({

--- a/workers/espn-client/src/sports/hockey/handlers.ts
+++ b/workers/espn-client/src/sports/hockey/handlers.ts
@@ -259,7 +259,7 @@ async function handleGetMatchups(
     const schedule = data.schedule || [];
 
     // Transform matchups
-    const matchupPeriod = week || data.scoringPeriodId;
+    const matchupPeriod = week ?? data.scoringPeriodId;
     const matchups = schedule
       .filter((matchup) => matchupPeriod == null || matchup.matchupPeriodId === matchupPeriod)
       .map((matchup) => ({

--- a/workers/fantasy-mcp/src/__tests__/tools.test.ts
+++ b/workers/fantasy-mcp/src/__tests__/tools.test.ts
@@ -427,6 +427,32 @@ describe('fantasy-mcp tools', () => {
     expect(payload.data?.count).toBe(1);
   });
 
+  it('get_matchups week schema rejects zero and negative values', () => {
+    const tool = getUnifiedTools().find((t) => t.name === 'get_matchups');
+    expect(tool).toBeTruthy();
+
+    const weekSchema = asZod(tool!.inputSchema.week);
+    // Valid: undefined (optional), positive integer
+    expect(weekSchema.safeParse(undefined).success).toBe(true);
+    expect(weekSchema.safeParse(1).success).toBe(true);
+    expect(weekSchema.safeParse(17).success).toBe(true);
+    // Invalid: zero, negative, float
+    expect(weekSchema.safeParse(0).success).toBe(false);
+    expect(weekSchema.safeParse(-1).success).toBe(false);
+    expect(weekSchema.safeParse(1.5).success).toBe(false);
+  });
+
+  it('get_roster week schema rejects zero and negative values', () => {
+    const tool = getUnifiedTools().find((t) => t.name === 'get_roster');
+    expect(tool).toBeTruthy();
+
+    const weekSchema = asZod(tool!.inputSchema.week);
+    expect(weekSchema.safeParse(undefined).success).toBe(true);
+    expect(weekSchema.safeParse(1).success).toBe(true);
+    expect(weekSchema.safeParse(0).success).toBe(false);
+    expect(weekSchema.safeParse(-1).success).toBe(false);
+  });
+
   it('each tool declares a required scope', () => {
     const tools = getUnifiedTools();
     for (const tool of tools) {

--- a/workers/fantasy-mcp/src/mcp/tools.ts
+++ b/workers/fantasy-mcp/src/mcp/tools.ts
@@ -829,7 +829,7 @@ export function getUnifiedTools(): UnifiedTool[] {
           .describe('Sport type (e.g., "football", "baseball")'),
         league_id: z.string().describe('League ID (get from get_user_session)'),
         season_year: z.number().describe('Season start year (e.g., 2025 for MLB 2025, 2024 for NBA 2024-25)'),
-        week: z.number().optional().describe('Week number (optional, defaults to current week)'),
+        week: z.number().int().min(1).optional().describe('Week number (optional, must be ≥ 1, defaults to current week)'),
       },
       handler: async (args, env, authHeader, correlationId, evalRunId, evalTraceId) => {
         const params: ToolParams = {
@@ -867,7 +867,7 @@ export function getUnifiedTools(): UnifiedTool[] {
         league_id: z.string().describe('League ID (get from get_user_session)'),
         season_year: z.number().describe('Season start year (e.g., 2025 for MLB 2025, 2024 for NBA 2024-25)'),
         team_id: z.string().optional().describe('Team ID (optional, defaults to user\'s team)'),
-        week: z.number().optional().describe('Week number (optional, defaults to current week)'),
+        week: z.number().int().min(1).optional().describe('Week number (optional, must be ≥ 1, defaults to current week)'),
       },
       handler: async (args, env, authHeader, correlationId, evalRunId, evalTraceId) => {
         const params: ToolParams = {

--- a/workers/yahoo-client/src/shared/handlers/get-free-agents.ts
+++ b/workers/yahoo-client/src/shared/handlers/get-free-agents.ts
@@ -1,7 +1,7 @@
 import type { HandlerFn, YahooHandlerContext } from './types';
 import { getYahooCredentials } from '../auth';
 import { yahooFetch, handleYahooError, requireCredentials } from '../yahoo-api';
-import { asArray, getPath, logStructure, unwrapLeague } from '../normalizers';
+import { asArray, getPath, logStructure, unwrapLeague, parseYahooPercentOwned } from '../normalizers';
 import { ErrorCode } from '@flaim/worker-shared';
 import { extractPlayerMeta, toExecuteErrorResponse, withLogLabel } from './utils';
 
@@ -55,7 +55,7 @@ export function createGetFreeAgentsHandler(config: YahooHandlerContext): Handler
           name: (playerMeta.name as Record<string, unknown>)?.full as string,
           team: playerMeta.editorial_team_abbr as string,
           position: playerMeta.display_position as string,
-          percentOwned: ownership?.percent_owned ? parseFloat(String(ownership.percent_owned)) : undefined,
+          percentOwned: parseYahooPercentOwned(ownership?.percent_owned),
           status: playerMeta.status as string | undefined,
         };
       });

--- a/workers/yahoo-client/src/sports/__tests__/handlers-cross-sport.test.ts
+++ b/workers/yahoo-client/src/sports/__tests__/handlers-cross-sport.test.ts
@@ -338,5 +338,35 @@ describe('yahoo cross-sport handler characterization tests', () => {
       expect(result.code).toBe('MISSING_PARAM');
       expect(fetchMock).not.toHaveBeenCalled();
     });
+
+    it.each(scenarios)('$label preserves percent_owned: 0 instead of dropping it', async ({ sport, handlers }) => {
+      const response = {
+        fantasy_content: {
+          league: [
+            { league_key: '449.l.123', name: 'Test League' },
+            {
+              players: {
+                '0': {
+                  player: [
+                    [{ player_key: 'fa101', player_id: '201', name: { full: 'Zero Owned' }, editorial_team_abbr: 'BOS', display_position: 'OF' }],
+                    { ownership: { percent_owned: '0' } },
+                  ],
+                },
+                count: 1,
+              },
+            },
+          ],
+        },
+      };
+      fetchMock.mockResolvedValue(jsonResponse(response));
+
+      const params: ToolParams = { sport, league_id: '449.l.123', season_year: 2025 };
+      const result = await handlers.get_free_agents({} as never, params, 'Bearer x', `cid-${sport}`);
+
+      expect(result.success).toBe(true);
+      const data = result.data as { freeAgents: Array<{ percentOwned: number | null | undefined }> };
+      // percent_owned: "0" must not be dropped as undefined
+      expect(data.freeAgents[0].percentOwned).toBe(0);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- **Yahoo `get_free_agents`**: Use `parseYahooPercentOwned()` instead of truthy check, fixing `percent_owned: 0` being dropped as `undefined`
- **ESPN matchups (all 4 sports)**: Handle missing `scoringPeriodId` gracefully — return all matchups instead of silently filtering to empty
- **fantasy-mcp week validation**: Enforce `.int().min(1)` on `week` param for `get_matchups` and `get_roster`, matching existing `get_transactions` validation
- **auth-worker `/authorize`**: Add rate limiting (10 req/60s per IP) to the previously unprotected public OAuth endpoint

## Context
Identified during a cross-agent (Claude + Codex) backend infrastructure review. All 4 fixes were independently validated by both agents before implementation.

## Test plan
- [x] All 4 workers pass type-check (`tsc --noEmit`)
- [x] All 361 tests pass (yahoo: 94, espn: 65, fantasy-mcp: 52, auth: 158)
- [ ] Verify Yahoo free agents return `percentOwned: 0` for unowned players in preview
- [ ] Verify ESPN matchups still return data when no explicit week is passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)