### PR TITLE
Fix gateway reliability: error propagation + route timeout

### DIFF
--- a/workers/fantasy-mcp/src/__tests__/router.test.ts
+++ b/workers/fantasy-mcp/src/__tests__/router.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { routeToClient, type RouteResult } from '../router';
 import type { Env, ToolParams } from '../types';
 import { INTERNAL_SERVICE_TOKEN_HEADER } from '@flaim/worker-shared';
@@ -135,6 +135,46 @@ describe('fantasy-mcp router', () => {
       const result = await routeToClient(env, 'get_free_agents', params);
 
       expect(result).toEqual(responseBody);
+    });
+
+    it('returns a timeout error when the platform worker takes too long', async () => {
+      vi.useFakeTimers();
+
+      const params: ToolParams = {
+        platform: 'espn',
+        sport: 'football',
+        league_id: '12345',
+        season_year: 2024,
+      };
+
+      const env = {
+        INTERNAL_SERVICE_TOKEN: 'internal-secret',
+        ESPN: {
+          fetch: async (request: Request) => {
+            // Simulate a fetch that hangs until aborted
+            return new Promise<Response>((_resolve, reject) => {
+              request.signal.addEventListener('abort', () => {
+                reject(new DOMException('The operation was aborted.', 'AbortError'));
+              });
+            });
+          },
+        },
+      } as unknown as Env;
+
+      const resultPromise = routeToClient(env, 'get_standings', params);
+
+      // Advance timers past the 15s timeout
+      await vi.advanceTimersByTimeAsync(16000);
+
+      const result = await resultPromise;
+
+      expect(result).toEqual({
+        success: false,
+        error: 'Platform worker "espn" timed out after 15s',
+        code: 'ROUTING_ERROR',
+      });
+
+      vi.useRealTimers();
     });
   });
 });

--- a/workers/fantasy-mcp/src/__tests__/router.test.ts
+++ b/workers/fantasy-mcp/src/__tests__/router.test.ts
@@ -163,14 +163,14 @@ describe('fantasy-mcp router', () => {
 
       const resultPromise = routeToClient(env, 'get_standings', params);
 
-      // Advance timers past the 15s timeout
-      await vi.advanceTimersByTimeAsync(16000);
+      // Advance timers past the 25s timeout
+      await vi.advanceTimersByTimeAsync(26000);
 
       const result = await resultPromise;
 
       expect(result).toEqual({
         success: false,
-        error: 'Platform worker "espn" timed out after 15s',
+        error: 'Platform worker "espn" timed out after 25s',
         code: 'ROUTING_ERROR',
       });
 

--- a/workers/fantasy-mcp/src/mcp/tools.ts
+++ b/workers/fantasy-mcp/src/mcp/tools.ts
@@ -211,7 +211,7 @@ async function fetchYahooLeagues(
     clearTimeout(timeoutId);
     const isTimeout = (error as Error).name === 'AbortError';
     const errorMsg = isTimeout ? 'Yahoo leagues fetch timed out' : `Yahoo leagues fetch failed: ${(error as Error).message}`;
-    console.error(`[fantasy-mcp] ${cid} failed to fetch Yahoo leagues: ${isTimeout ? 'timeout' : (error as Error).message}`);
+    console.error(`[fantasy-mcp] ${cid} failed to fetch Yahoo leagues: ${errorMsg}`);
     return { leagues: [], error: errorMsg };
   }
 }
@@ -277,7 +277,7 @@ async function fetchSleeperLeagues(
     clearTimeout(timeoutId);
     const isTimeout = (error as Error).name === 'AbortError';
     const errorMsg = isTimeout ? 'Sleeper leagues fetch timed out' : `Sleeper leagues fetch failed: ${(error as Error).message}`;
-    console.error(`[fantasy-mcp] ${cid} failed to fetch Sleeper leagues: ${isTimeout ? 'timeout' : (error as Error).message}`);
+    console.error(`[fantasy-mcp] ${cid} failed to fetch Sleeper leagues: ${errorMsg}`);
     return { leagues: [], error: errorMsg };
   }
 }
@@ -465,8 +465,8 @@ export function getUnifiedTools(): UnifiedTool[] {
             fetchSleeperLeagues(env, authHeader, correlationId, evalRunId, evalTraceId),
           ]);
 
-          const yahooData = yahooResult.status === 'fulfilled' ? yahooResult.value : { leagues: [] as UserLeague[], error: 'Yahoo fetch rejected' };
-          const sleeperData = sleeperResult.status === 'fulfilled' ? sleeperResult.value : { leagues: [] as UserLeague[], error: 'Sleeper fetch rejected' };
+          const yahooData = yahooResult.status === 'fulfilled' ? yahooResult.value : { leagues: [] as UserLeague[], error: `Yahoo fetch rejected: ${yahooResult.reason}` };
+          const sleeperData = sleeperResult.status === 'fulfilled' ? sleeperResult.value : { leagues: [] as UserLeague[], error: `Sleeper fetch rejected: ${sleeperResult.reason}` };
 
           // Collect warnings from failed fetches
           const warnings: string[] = [];

--- a/workers/fantasy-mcp/src/mcp/tools.ts
+++ b/workers/fantasy-mcp/src/mcp/tools.ts
@@ -181,7 +181,7 @@ async function fetchYahooLeagues(
 
     if (!response.ok) {
       console.error(`[fantasy-mcp] ${cid} Yahoo leagues fetch failed: ${response.status}`);
-      return { leagues: [] };
+      return { leagues: [], error: `Yahoo leagues fetch failed: ${response.status}` };
     }
 
     const data = (await response.json()) as {
@@ -210,8 +210,9 @@ async function fetchYahooLeagues(
   } catch (error) {
     clearTimeout(timeoutId);
     const isTimeout = (error as Error).name === 'AbortError';
+    const errorMsg = isTimeout ? 'Yahoo leagues fetch timed out' : `Yahoo leagues fetch failed: ${(error as Error).message}`;
     console.error(`[fantasy-mcp] ${cid} failed to fetch Yahoo leagues: ${isTimeout ? 'timeout' : (error as Error).message}`);
-    return { leagues: [] };
+    return { leagues: [], error: errorMsg };
   }
 }
 
@@ -248,7 +249,7 @@ async function fetchSleeperLeagues(
 
     if (!response.ok) {
       console.error(`[fantasy-mcp] ${cid} Sleeper leagues fetch failed: ${response.status}`);
-      return { leagues: [] };
+      return { leagues: [], error: `Sleeper leagues fetch failed: ${response.status}` };
     }
 
     const data = (await response.json()) as {
@@ -275,8 +276,9 @@ async function fetchSleeperLeagues(
   } catch (error) {
     clearTimeout(timeoutId);
     const isTimeout = (error as Error).name === 'AbortError';
+    const errorMsg = isTimeout ? 'Sleeper leagues fetch timed out' : `Sleeper leagues fetch failed: ${(error as Error).message}`;
     console.error(`[fantasy-mcp] ${cid} failed to fetch Sleeper leagues: ${isTimeout ? 'timeout' : (error as Error).message}`);
-    return { leagues: [] };
+    return { leagues: [], error: errorMsg };
   }
 }
 
@@ -463,8 +465,14 @@ export function getUnifiedTools(): UnifiedTool[] {
             fetchSleeperLeagues(env, authHeader, correlationId, evalRunId, evalTraceId),
           ]);
 
-          const yahooData = yahooResult.status === 'fulfilled' ? yahooResult.value : { leagues: [] as UserLeague[] };
-          const sleeperData = sleeperResult.status === 'fulfilled' ? sleeperResult.value : { leagues: [] as UserLeague[] };
+          const yahooData = yahooResult.status === 'fulfilled' ? yahooResult.value : { leagues: [] as UserLeague[], error: 'Yahoo fetch rejected' };
+          const sleeperData = sleeperResult.status === 'fulfilled' ? sleeperResult.value : { leagues: [] as UserLeague[], error: 'Sleeper fetch rejected' };
+
+          // Collect warnings from failed fetches
+          const warnings: string[] = [];
+          if (espnData.error) warnings.push(`ESPN: ${espnData.error}`);
+          if (yahooData.error) warnings.push(`Yahoo: ${yahooData.error}`);
+          if (sleeperData.error) warnings.push(`Sleeper: ${sleeperData.error}`);
 
           // Combine all leagues
           const allLeagues = [...espnData.leagues, ...yahooData.leagues, ...sleeperData.leagues];
@@ -633,6 +641,7 @@ export function getUnifiedTools(): UnifiedTool[] {
               ])
             ),
             allLeagues: leagues,
+            warnings: warnings.length > 0 ? warnings : undefined,
             instructions: sessionMessage,
           };
           return {
@@ -682,9 +691,13 @@ export function getUnifiedTools(): UnifiedTool[] {
 
           const results = await Promise.allSettled(promises);
           const allLeagues: UserLeague[] = [];
+          const warnings: string[] = [];
           for (const result of results) {
             if (result.status === 'fulfilled') {
               allLeagues.push(...result.value.leagues);
+              if (result.value.error) warnings.push(result.value.error);
+            } else {
+              warnings.push(`Fetch rejected: ${result.reason}`);
             }
           }
 
@@ -731,6 +744,7 @@ export function getUnifiedTools(): UnifiedTool[] {
             oldSeasonsFromActiveLeagues: oldSeasons,
             totalOldLeagues: oldLeagues.length,
             totalOldSeasons: Object.values(oldSeasons).flat().length,
+            warnings: warnings.length > 0 ? warnings : undefined,
           });
         } catch (error) {
           const message = error instanceof Error ? error.message : 'Unknown error';

--- a/workers/fantasy-mcp/src/router.ts
+++ b/workers/fantasy-mcp/src/router.ts
@@ -38,6 +38,9 @@ export async function routeToClient(
   }
 
   // Forward request to platform worker
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 15000);
+
   try {
     const baseHeaders: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -56,9 +59,12 @@ export async function routeToClient(
         body: JSON.stringify({
           tool,
           params,
-        })
+        }),
+        signal: controller.signal,
       })
     );
+
+    clearTimeout(timeoutId);
 
     if (!response.ok) {
       const errorData = await response.json().catch(() => ({})) as { error?: string; code?: string };
@@ -71,6 +77,14 @@ export async function routeToClient(
 
     return await response.json() as RouteResult;
   } catch (error) {
+    clearTimeout(timeoutId);
+    if (error instanceof Error && error.name === 'AbortError') {
+      return {
+        success: false,
+        error: `Platform worker "${platform}" timed out after 15s`,
+        code: 'ROUTING_ERROR',
+      };
+    }
     return {
       success: false,
       error: error instanceof Error ? error.message : 'Failed to reach platform worker',

--- a/workers/fantasy-mcp/src/router.ts
+++ b/workers/fantasy-mcp/src/router.ts
@@ -39,7 +39,7 @@ export async function routeToClient(
 
   // Forward request to platform worker
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), 15000);
+  const timeoutId = setTimeout(() => controller.abort(), 25000);
 
   try {
     const baseHeaders: Record<string, string> = {
@@ -81,7 +81,7 @@ export async function routeToClient(
     if (error instanceof Error && error.name === 'AbortError') {
       return {
         success: false,
-        error: `Platform worker "${platform}" timed out after 15s`,
+        error: `Platform worker "${platform}" timed out after 25s`,
         code: 'ROUTING_ERROR',
       };
     }


### PR DESCRIPTION
## Summary
- **Yahoo/Sleeper error propagation** — `fetchYahooLeagues`/`fetchSleeperLeagues` now return `{ leagues: [], error }` on failure instead of silently returning empty arrays. `get_user_session` and `get_ancient_history` collect these errors as `warnings` in the response, matching ESPN's existing pattern.
- **`routeToClient` timeout** — Added 15s `AbortController` to the gateway→platform worker fetch, preventing hung workers from blocking up to CF's 30s limit.
- **Router timeout test** — New test using fake timers to verify timeout behavior.

## Test plan
- [x] `npm test` in `workers/fantasy-mcp` — 53 tests passing (45 unit + 8 integration)
- [x] `npm run type-check` — clean
- [ ] Verify warnings surface correctly in Claude/ChatGPT MCP session responses
- [ ] Confirm timeout behavior with a slow platform worker in preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)