### PR TITLE
fix: expose team ownership across ESPN, Yahoo, and Sleeper

### DIFF
--- a/workers/espn-client/src/sports/__tests__/league-info-teams.test.ts
+++ b/workers/espn-client/src/sports/__tests__/league-info-teams.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi, type MockedFunction } from 'vitest';
+import { baseballHandlers } from '../baseball/handlers';
+import { basketballHandlers } from '../basketball/handlers';
+import { footballHandlers } from '../football/handlers';
+import { hockeyHandlers } from '../hockey/handlers';
+import type { ToolParams } from '../../types';
+import { getCredentials } from '../../shared/auth';
+import { espnFetch } from '../../shared/espn-api';
+
+vi.mock('../../shared/auth', () => ({
+  getCredentials: vi.fn(),
+}));
+
+vi.mock('../../shared/espn-api', async () => {
+  const actual = await vi.importActual('../../shared/espn-api') as Record<string, unknown>;
+  return {
+    ...actual,
+    espnFetch: vi.fn(),
+  };
+});
+
+const scenarios = [
+  { label: 'football', sport: 'football', handlers: footballHandlers },
+  { label: 'baseball', sport: 'baseball', handlers: baseballHandlers },
+  { label: 'basketball', sport: 'basketball', handlers: basketballHandlers },
+  { label: 'hockey', sport: 'hockey', handlers: hockeyHandlers },
+] as const;
+
+const mockLeagueResponse = {
+  id: 123,
+  seasonId: 2025,
+  segmentId: 0,
+  scoringPeriodId: 5,
+  currentMatchupPeriod: 5,
+  settings: {
+    name: 'Test League',
+    size: 10,
+    scoringSettings: { scoringType: 'H2H_POINTS' },
+    rosterSettings: { lineupSlotCounts: {} },
+    scheduleSettings: {},
+  },
+  teams: [
+    {
+      id: 1,
+      location: 'Gerry',
+      nickname: 'Sluggers',
+      abbrev: 'GS',
+      owners: [{ displayName: 'Gerry G', firstName: 'Gerry' }],
+    },
+    {
+      id: 6,
+      name: 'Team 6',
+      abbrev: 'T6',
+      owners: [{ firstName: 'Mike' }],
+    },
+    {
+      id: 7,
+      location: 'The',
+      nickname: 'Aces',
+      abbrev: 'TA',
+      // No owners array — tests graceful fallback
+    },
+    {
+      id: 8,
+      name: 'Ghost Team',
+      abbrev: 'GT',
+      // Owner object exists but has no name fields — should not produce "Unknown"
+      owners: [{}],
+    },
+  ],
+};
+
+describe('espn cross-sport get_league_info teams array', () => {
+  const getCredentialsMock = getCredentials as MockedFunction<typeof getCredentials>;
+  const espnFetchMock = espnFetch as MockedFunction<typeof espnFetch>;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    getCredentialsMock.mockResolvedValue({ s2: 'token', swid: '{swid}' });
+  });
+
+  it.each(scenarios)('$label returns teams with ownerName and owners', async ({ sport, handlers }) => {
+    espnFetchMock.mockResolvedValue(
+      new Response(JSON.stringify(mockLeagueResponse), { status: 200 })
+    );
+
+    const params: ToolParams = { sport, league_id: '123', season_year: 2025 };
+    const result = await handlers.get_league_info({} as never, params, 'Bearer x', 'cid');
+
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      teams: Array<{
+        teamId: number;
+        teamName: string;
+        abbrev: string;
+        ownerName?: string;
+        owners?: string[];
+      }>;
+    };
+
+    expect(data.teams).toHaveLength(4);
+
+    // Team with displayName owner
+    expect(data.teams[0]).toEqual({
+      teamId: 1,
+      teamName: 'Gerry Sluggers',
+      abbrev: 'GS',
+      ownerName: 'Gerry G',
+      owners: ['Gerry G'],
+    });
+
+    // Team with only firstName owner
+    expect(data.teams[1]).toEqual({
+      teamId: 6,
+      teamName: 'Team 6',
+      abbrev: 'T6',
+      ownerName: 'Mike',
+      owners: ['Mike'],
+    });
+
+    // Team with no owners array
+    expect(data.teams[2]).toEqual({
+      teamId: 7,
+      teamName: 'The Aces',
+      abbrev: 'TA',
+      ownerName: undefined,
+      owners: undefined,
+    });
+
+    // Team with empty owner object — must not fabricate "Unknown"
+    expect(data.teams[3]).toEqual({
+      teamId: 8,
+      teamName: 'Ghost Team',
+      abbrev: 'GT',
+      ownerName: undefined,
+      owners: undefined,
+    });
+  });
+
+  it.each(scenarios)('$label requests mTeam view in API path', async ({ sport, handlers }) => {
+    espnFetchMock.mockResolvedValue(
+      new Response(JSON.stringify(mockLeagueResponse), { status: 200 })
+    );
+
+    const params: ToolParams = { sport, league_id: '123', season_year: 2025 };
+    await handlers.get_league_info({} as never, params, 'Bearer x', 'cid');
+
+    const fetchPath = espnFetchMock.mock.calls[0][0] as string;
+    expect(fetchPath).toContain('view=mSettings');
+    expect(fetchPath).toContain('view=mTeam');
+  });
+});

--- a/workers/espn-client/src/sports/__tests__/roster-owner.test.ts
+++ b/workers/espn-client/src/sports/__tests__/roster-owner.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi, type MockedFunction } from 'vitest';
+import { baseballHandlers } from '../baseball/handlers';
+import { basketballHandlers } from '../basketball/handlers';
+import { footballHandlers } from '../football/handlers';
+import { hockeyHandlers } from '../hockey/handlers';
+import type { ToolParams } from '../../types';
+import { getCredentials } from '../../shared/auth';
+import { espnFetch } from '../../shared/espn-api';
+
+vi.mock('../../shared/auth', () => ({
+  getCredentials: vi.fn(),
+}));
+
+vi.mock('../../shared/espn-api', async () => {
+  const actual = await vi.importActual('../../shared/espn-api') as Record<string, unknown>;
+  return {
+    ...actual,
+    espnFetch: vi.fn(),
+  };
+});
+
+const scenarios = [
+  { label: 'football', sport: 'football', handlers: footballHandlers },
+  { label: 'baseball', sport: 'baseball', handlers: baseballHandlers },
+  { label: 'basketball', sport: 'basketball', handlers: basketballHandlers },
+  { label: 'hockey', sport: 'hockey', handlers: hockeyHandlers },
+] as const;
+
+const mockRosterResponse = {
+  teams: [
+    {
+      id: 6,
+      name: 'Team 6',
+      owners: [{ displayName: 'Mike Johnson', firstName: 'Mike' }],
+      roster: {
+        entries: [
+          {
+            playerPoolEntry: {
+              player: {
+                id: 42,
+                fullName: 'Paul Skenes',
+                defaultPositionId: 1,
+                eligibleSlots: [0],
+                proTeamId: 1,
+              },
+            },
+            lineupSlotId: 0,
+          },
+        ],
+      },
+    },
+    {
+      id: 1,
+      location: 'Gerry',
+      nickname: 'Sluggers',
+      owners: [{ displayName: 'Gerry G' }],
+      roster: { entries: [] },
+    },
+  ],
+};
+
+describe('espn cross-sport get_roster ownerName', () => {
+  const getCredentialsMock = getCredentials as MockedFunction<typeof getCredentials>;
+  const espnFetchMock = espnFetch as MockedFunction<typeof espnFetch>;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    getCredentialsMock.mockResolvedValue({ s2: 'token', swid: '{swid}' });
+  });
+
+  it.each(scenarios)('$label includes ownerName in roster response', async ({ sport, handlers }) => {
+    espnFetchMock.mockResolvedValue(
+      new Response(JSON.stringify(mockRosterResponse), { status: 200 })
+    );
+
+    const params: ToolParams = { sport, league_id: '123', season_year: 2025, team_id: '6' };
+    const result = await handlers.get_roster({} as never, params, 'Bearer x', 'cid');
+
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      teamId: number;
+      teamName: string;
+      ownerName?: string;
+      roster: Array<{ name: string }>;
+    };
+
+    expect(data.teamId).toBe(6);
+    expect(data.teamName).toBe('Team 6');
+    expect(data.ownerName).toBe('Mike Johnson');
+    expect(data.roster).toHaveLength(1);
+    expect(data.roster[0].name).toBe('Paul Skenes');
+  });
+
+  it.each(scenarios)('$label requests mTeam view alongside mRoster', async ({ sport, handlers }) => {
+    espnFetchMock.mockResolvedValue(
+      new Response(JSON.stringify(mockRosterResponse), { status: 200 })
+    );
+
+    const params: ToolParams = { sport, league_id: '123', season_year: 2025, team_id: '6' };
+    await handlers.get_roster({} as never, params, 'Bearer x', 'cid');
+
+    const fetchPath = espnFetchMock.mock.calls[0][0] as string;
+    expect(fetchPath).toContain('view=mRoster');
+    expect(fetchPath).toContain('view=mTeam');
+  });
+
+  it.each(scenarios)('$label handles missing owners gracefully', async ({ sport, handlers }) => {
+    const noOwnerResponse = {
+      teams: [{
+        id: 3,
+        location: 'No',
+        nickname: 'Owner',
+        roster: { entries: [] },
+      }],
+    };
+
+    espnFetchMock.mockResolvedValue(
+      new Response(JSON.stringify(noOwnerResponse), { status: 200 })
+    );
+
+    const params: ToolParams = { sport, league_id: '123', season_year: 2025, team_id: '3' };
+    const result = await handlers.get_roster({} as never, params, 'Bearer x', 'cid');
+
+    expect(result.success).toBe(true);
+    const data = result.data as { ownerName?: string };
+    expect(data.ownerName).toBeUndefined();
+  });
+
+  it.each(scenarios)('$label skips empty owner objects and finds valid co-owner', async ({ sport, handlers }) => {
+    const emptyFirstOwnerResponse = {
+      teams: [{
+        id: 5,
+        name: 'Team 5',
+        owners: [{}, { displayName: 'Bob' }],
+        roster: { entries: [] },
+      }],
+    };
+
+    espnFetchMock.mockResolvedValue(
+      new Response(JSON.stringify(emptyFirstOwnerResponse), { status: 200 })
+    );
+
+    const params: ToolParams = { sport, league_id: '123', season_year: 2025, team_id: '5' };
+    const result = await handlers.get_roster({} as never, params, 'Bearer x', 'cid');
+
+    expect(result.success).toBe(true);
+    const data = result.data as { ownerName?: string };
+    expect(data.ownerName).toBe('Bob');
+  });
+});

--- a/workers/espn-client/src/sports/baseball/handlers.ts
+++ b/workers/espn-client/src/sports/baseball/handlers.ts
@@ -100,7 +100,7 @@ async function handleGetLeagueInfo(
   try {
     const credentials = await getCredentials(env, authHeader, correlationId);
 
-    const path = `/seasons/${season_year}/segments/0/leagues/${league_id}?view=mSettings`;
+    const path = `/seasons/${season_year}/segments/0/leagues/${league_id}?view=mSettings&view=mTeam`;
     const response = await espnFetch(path, GAME_ID, { credentials, timeout: 7000 });
 
     if (!response.ok) {
@@ -117,6 +117,20 @@ async function handleGetLeagueInfo(
       };
     }
 
+    const teams = (data.teams || []).map((team) => {
+      const ownerNames = team.owners?.map((o) => o.displayName || o.firstName).filter(Boolean) as string[] | undefined;
+      const hasOwners = ownerNames && ownerNames.length > 0;
+      return {
+        teamId: team.id,
+        teamName: team.location && team.nickname
+          ? `${team.location} ${team.nickname}`
+          : team.name || `Team ${team.id}`,
+        abbrev: team.abbrev,
+        ownerName: hasOwners ? ownerNames[0] : undefined,
+        owners: hasOwners ? ownerNames : undefined,
+      };
+    });
+
     return {
       success: true,
       data: {
@@ -128,6 +142,7 @@ async function handleGetLeagueInfo(
         currentMatchupPeriod: data.currentMatchupPeriod,
         seasonId: data.seasonId,
         segmentId: data.segmentId,
+        teams,
         scoringSettings: {
           type: data.settings.scoringSettings?.scoringType,
           matchupPeriods: data.settings.scoringSettings?.matchupPeriods,
@@ -314,7 +329,7 @@ async function handleGetRoster(
     const credentials = await getCredentials(env, authHeader, correlationId);
     requireCredentials(credentials, 'roster data');
 
-    let path = `/seasons/${season_year}/segments/0/leagues/${league_id}?view=mRoster`;
+    let path = `/seasons/${season_year}/segments/0/leagues/${league_id}?view=mRoster&view=mTeam`;
     if (week) {
       path += `&scoringPeriodId=${week}`;
     }
@@ -369,6 +384,8 @@ async function handleGetRoster(
       };
     });
 
+    const ownerName = team.owners?.map((o) => o.displayName || o.firstName).find(Boolean) || undefined;
+
     return {
       success: true,
       data: {
@@ -377,6 +394,7 @@ async function handleGetRoster(
         teamName: team.location && team.nickname
           ? `${team.location} ${team.nickname}`
           : team.name || `Team ${team.id}`,
+        ownerName,
         roster
       }
     };

--- a/workers/espn-client/src/sports/basketball/handlers.ts
+++ b/workers/espn-client/src/sports/basketball/handlers.ts
@@ -100,7 +100,7 @@ async function handleGetLeagueInfo(
   try {
     const credentials = await getCredentials(env, authHeader, correlationId);
 
-    const path = `/seasons/${season_year}/segments/0/leagues/${league_id}?view=mSettings`;
+    const path = `/seasons/${season_year}/segments/0/leagues/${league_id}?view=mSettings&view=mTeam`;
     const response = await espnFetch(path, GAME_ID, { credentials, timeout: 7000 });
 
     if (!response.ok) {
@@ -117,6 +117,20 @@ async function handleGetLeagueInfo(
       };
     }
 
+    const teams = (data.teams || []).map((team) => {
+      const ownerNames = team.owners?.map((o) => o.displayName || o.firstName).filter(Boolean) as string[] | undefined;
+      const hasOwners = ownerNames && ownerNames.length > 0;
+      return {
+        teamId: team.id,
+        teamName: team.location && team.nickname
+          ? `${team.location} ${team.nickname}`
+          : team.name || `Team ${team.id}`,
+        abbrev: team.abbrev,
+        ownerName: hasOwners ? ownerNames[0] : undefined,
+        owners: hasOwners ? ownerNames : undefined,
+      };
+    });
+
     return {
       success: true,
       data: {
@@ -128,6 +142,7 @@ async function handleGetLeagueInfo(
         currentMatchupPeriod: data.currentMatchupPeriod,
         seasonId: data.seasonId,
         segmentId: data.segmentId,
+        teams,
         scoringSettings: {
           type: data.settings.scoringSettings?.scoringType,
           matchupPeriods: data.settings.scoringSettings?.matchupPeriods,
@@ -314,7 +329,7 @@ async function handleGetRoster(
     const credentials = await getCredentials(env, authHeader, correlationId);
     requireCredentials(credentials, 'roster data');
 
-    let path = `/seasons/${season_year}/segments/0/leagues/${league_id}?view=mRoster`;
+    let path = `/seasons/${season_year}/segments/0/leagues/${league_id}?view=mRoster&view=mTeam`;
     if (week) {
       path += `&scoringPeriodId=${week}`;
     }
@@ -369,6 +384,8 @@ async function handleGetRoster(
       };
     });
 
+    const ownerName = team.owners?.map((o) => o.displayName || o.firstName).find(Boolean) || undefined;
+
     return {
       success: true,
       data: {
@@ -377,6 +394,7 @@ async function handleGetRoster(
         teamName: team.location && team.nickname
           ? `${team.location} ${team.nickname}`
           : team.name || `Team ${team.id}`,
+        ownerName,
         roster
       }
     };

--- a/workers/espn-client/src/sports/football/handlers.ts
+++ b/workers/espn-client/src/sports/football/handlers.ts
@@ -49,7 +49,7 @@ async function handleGetLeagueInfo(
   try {
     const credentials = await getCredentials(env, authHeader, correlationId);
 
-    const path = `/seasons/${season_year}/segments/0/leagues/${league_id}?view=mSettings`;
+    const path = `/seasons/${season_year}/segments/0/leagues/${league_id}?view=mSettings&view=mTeam`;
     const response = await espnFetch(path, GAME_ID, { credentials, timeout: 7000 });
 
     if (!response.ok) {
@@ -66,6 +66,20 @@ async function handleGetLeagueInfo(
       };
     }
 
+    const teams = (data.teams || []).map((team) => {
+      const ownerNames = team.owners?.map((o) => o.displayName || o.firstName).filter(Boolean) as string[] | undefined;
+      const hasOwners = ownerNames && ownerNames.length > 0;
+      return {
+        teamId: team.id,
+        teamName: team.location && team.nickname
+          ? `${team.location} ${team.nickname}`
+          : team.name || `Team ${team.id}`,
+        abbrev: team.abbrev,
+        ownerName: hasOwners ? ownerNames[0] : undefined,
+        owners: hasOwners ? ownerNames : undefined,
+      };
+    });
+
     return {
       success: true,
       data: {
@@ -77,6 +91,7 @@ async function handleGetLeagueInfo(
         currentMatchupPeriod: data.currentMatchupPeriod,
         seasonId: data.seasonId,
         segmentId: data.segmentId,
+        teams,
         scoringSettings: {
           type: data.settings.scoringSettings?.scoringType,
           matchupPeriods: data.settings.scoringSettings?.matchupPeriods,
@@ -263,7 +278,7 @@ async function handleGetRoster(
     const credentials = await getCredentials(env, authHeader, correlationId);
     requireCredentials(credentials, 'roster data');
 
-    let path = `/seasons/${season_year}/segments/0/leagues/${league_id}?view=mRoster`;
+    let path = `/seasons/${season_year}/segments/0/leagues/${league_id}?view=mRoster&view=mTeam`;
     if (week) {
       path += `&scoringPeriodId=${week}`;
     }
@@ -318,6 +333,8 @@ async function handleGetRoster(
       };
     });
 
+    const ownerName = team.owners?.map((o) => o.displayName || o.firstName).find(Boolean) || undefined;
+
     return {
       success: true,
       data: {
@@ -326,6 +343,7 @@ async function handleGetRoster(
         teamName: team.location && team.nickname
           ? `${team.location} ${team.nickname}`
           : team.name || `Team ${team.id}`,
+        ownerName,
         roster
       }
     };

--- a/workers/espn-client/src/sports/hockey/handlers.ts
+++ b/workers/espn-client/src/sports/hockey/handlers.ts
@@ -100,7 +100,7 @@ async function handleGetLeagueInfo(
   try {
     const credentials = await getCredentials(env, authHeader, correlationId);
 
-    const path = `/seasons/${season_year}/segments/0/leagues/${league_id}?view=mSettings`;
+    const path = `/seasons/${season_year}/segments/0/leagues/${league_id}?view=mSettings&view=mTeam`;
     const response = await espnFetch(path, GAME_ID, { credentials, timeout: 7000 });
 
     if (!response.ok) {
@@ -117,6 +117,20 @@ async function handleGetLeagueInfo(
       };
     }
 
+    const teams = (data.teams || []).map((team) => {
+      const ownerNames = team.owners?.map((o) => o.displayName || o.firstName).filter(Boolean) as string[] | undefined;
+      const hasOwners = ownerNames && ownerNames.length > 0;
+      return {
+        teamId: team.id,
+        teamName: team.location && team.nickname
+          ? `${team.location} ${team.nickname}`
+          : team.name || `Team ${team.id}`,
+        abbrev: team.abbrev,
+        ownerName: hasOwners ? ownerNames[0] : undefined,
+        owners: hasOwners ? ownerNames : undefined,
+      };
+    });
+
     return {
       success: true,
       data: {
@@ -128,6 +142,7 @@ async function handleGetLeagueInfo(
         currentMatchupPeriod: data.currentMatchupPeriod,
         seasonId: data.seasonId,
         segmentId: data.segmentId,
+        teams,
         scoringSettings: {
           type: data.settings.scoringSettings?.scoringType,
           matchupPeriods: data.settings.scoringSettings?.matchupPeriods,
@@ -314,7 +329,7 @@ async function handleGetRoster(
     const credentials = await getCredentials(env, authHeader, correlationId);
     requireCredentials(credentials, 'roster data');
 
-    let path = `/seasons/${season_year}/segments/0/leagues/${league_id}?view=mRoster`;
+    let path = `/seasons/${season_year}/segments/0/leagues/${league_id}?view=mRoster&view=mTeam`;
     if (week) {
       path += `&scoringPeriodId=${week}`;
     }
@@ -369,6 +384,8 @@ async function handleGetRoster(
       };
     });
 
+    const ownerName = team.owners?.map((o) => o.displayName || o.firstName).find(Boolean) || undefined;
+
     return {
       success: true,
       data: {
@@ -377,6 +394,7 @@ async function handleGetRoster(
         teamName: team.location && team.nickname
           ? `${team.location} ${team.nickname}`
           : team.name || `Team ${team.id}`,
+        ownerName,
         roster
       }
     };

--- a/workers/fantasy-mcp/src/mcp/tools.ts
+++ b/workers/fantasy-mcp/src/mcp/tools.ts
@@ -763,7 +763,7 @@ export function getUnifiedTools(): UnifiedTool[] {
       requiredScope: 'mcp:read',
       securitySchemes: buildSecuritySchemes('mcp:read'),
       openaiMeta: { invoking: 'Fetching league info\u2026', invoked: 'League info ready' },
-      description: `Get fantasy league information including settings, scoring type, roster configuration, and schedule. Use values from get_user_session. Read-only and safe to retry. Current date is ${currentDate}.`,
+      description: `Get fantasy league information including settings, scoring type, roster configuration, schedule, and a teams array listing each team with its owner name. Use this to enumerate teams and resolve team ownership before calling get_roster. The exact team fields vary by platform but all include ownerName. Use values from get_user_session. Read-only and safe to retry. Current date is ${currentDate}.`,
       inputSchema: {
         platform: z
           .enum(['espn', 'yahoo', 'sleeper'])
@@ -870,7 +870,7 @@ export function getUnifiedTools(): UnifiedTool[] {
       requiredScope: 'mcp:read',
       securitySchemes: buildSecuritySchemes('mcp:read'),
       openaiMeta: { invoking: 'Fetching roster\u2026', invoked: 'Roster ready' },
-      description: `Get detailed roster for a specific team including players, positions, and stats. Requires authentication. Use values from get_user_session. Read-only and safe to retry. Current date is ${currentDate}.`,
+      description: `Get detailed roster for a specific team including players, positions, stats, and ownerName. Requires authentication. Use values from get_user_session. Read-only and safe to retry. Current date is ${currentDate}.`,
       inputSchema: {
         platform: z
           .enum(['espn', 'yahoo', 'sleeper'])
@@ -909,7 +909,7 @@ export function getUnifiedTools(): UnifiedTool[] {
       requiredScope: 'mcp:read',
       securitySchemes: buildSecuritySchemes('mcp:read'),
       openaiMeta: { invoking: 'Searching free agents\u2026', invoked: 'Free agents ready' },
-      description: `Get available free agents, optionally filtered by position. Sorted by ownership percentage. Use this for waiver-wire availability only. Do not use percentOwned to infer who owns a player in the user's league; for ownership questions, verify team rosters via get_league_info + get_roster. Requires authentication. Use values from get_user_session. Read-only and safe to retry. Current date is ${currentDate}.`,
+      description: `Get available free agents, optionally filtered by position. Sorted by ownership percentage. Use this for waiver-wire availability only. Do not use percentOwned to infer who owns a player in the user's league; for ownership questions, use get_league_info (returns teams with ownerName) and get_roster. Requires authentication. Use values from get_user_session. Read-only and safe to retry. Current date is ${currentDate}.`,
       inputSchema: {
         platform: z
           .enum(['espn', 'yahoo', 'sleeper'])
@@ -954,7 +954,7 @@ export function getUnifiedTools(): UnifiedTool[] {
       requiredScope: 'mcp:read',
       securitySchemes: buildSecuritySchemes('mcp:read'),
       openaiMeta: { invoking: 'Searching players\u2026', invoked: 'Players ready' },
-      description: `Search for player identity by name across all roster statuses (rostered, free agent, waived). Returns identity fields plus market/global ownership context when available (market_percent_owned + ownership_scope). This is NOT league ownership data. Do not infer free-agent status or who owns a player in the user's league from market ownership values. To answer who owns a player in a league: call get_league_info to enumerate teams, then call get_roster per team and match player names. Use values from get_user_session. Read-only and safe to retry. Current date is ${currentDate}.`,
+      description: `Search for player identity by name across all roster statuses (rostered, free agent, waived). Returns identity fields plus market/global ownership context when available (market_percent_owned + ownership_scope). This is NOT league ownership data. Do not infer free-agent status or who owns a player in the user's league from market ownership values. To answer who owns a player in a league: call get_league_info (which returns a teams array with ownerName for each team), then call get_roster for specific teams to find the player. Use values from get_user_session. Read-only and safe to retry. Current date is ${currentDate}.`,
       inputSchema: {
         query: z
           .string()

--- a/workers/sleeper-client/src/shared/handlers/get-league-info.ts
+++ b/workers/sleeper-client/src/shared/handlers/get-league-info.ts
@@ -1,5 +1,5 @@
 import type { HandlerFn } from './types';
-import type { SleeperLeague } from '../../types';
+import type { SleeperLeague, SleeperLeagueUser, SleeperRoster } from '../../types';
 import { ErrorCode } from '@flaim/worker-shared';
 import { sleeperFetch, handleSleeperError } from '../sleeper-api';
 import { toExecuteErrorResponse } from './utils';
@@ -12,10 +12,30 @@ export function createGetLeagueInfoHandler(): HandlerFn {
     }
 
     try {
-      const response = await sleeperFetch(`/league/${league_id}`);
-      if (!response.ok) handleSleeperError(response);
+      const [leagueRes, rostersRes, usersRes] = await Promise.all([
+        sleeperFetch(`/league/${league_id}`),
+        sleeperFetch(`/league/${league_id}/rosters`),
+        sleeperFetch(`/league/${league_id}/users`),
+      ]);
 
-      const league: SleeperLeague = await response.json();
+      if (!leagueRes.ok) handleSleeperError(leagueRes);
+      if (!rostersRes.ok) handleSleeperError(rostersRes);
+      if (!usersRes.ok) handleSleeperError(usersRes);
+
+      const league: SleeperLeague = await leagueRes.json();
+      const rosters: SleeperRoster[] = await rostersRes.json();
+      const users: SleeperLeagueUser[] = await usersRes.json();
+
+      const userMap = new Map<string, string>();
+      for (const user of users) {
+        userMap.set(user.user_id, user.display_name);
+      }
+
+      const teams = rosters.map((roster) => ({
+        rosterId: roster.roster_id,
+        ownerId: roster.owner_id,
+        ownerName: userMap.get(roster.owner_id) || undefined,
+      }));
 
       return {
         success: true,
@@ -30,6 +50,7 @@ export function createGetLeagueInfoHandler(): HandlerFn {
           scoringSettings: league.scoring_settings,
           previousLeagueId: league.previous_league_id,
           draftId: league.draft_id,
+          teams,
         },
       };
     } catch (error) {

--- a/workers/sleeper-client/src/sports/__tests__/handlers-cross-sport.test.ts
+++ b/workers/sleeper-client/src/sports/__tests__/handlers-cross-sport.test.ts
@@ -59,18 +59,28 @@ describe('sleeper cross-sport handler characterization tests', () => {
 
   describe('get_league_info', () => {
     it.each(scenarios)('$label returns consistent league metadata shape', async ({ sport, handlers }) => {
-      mockFetch.mockResolvedValueOnce(jsonResponse({
-        league_id: '12345',
-        name: 'Test League',
-        sport: 'nfl',
-        season: '2025',
-        status: 'in_season',
-        total_rosters: 10,
-        roster_positions: ['QB', 'RB'],
-        scoring_settings: { pass_yd: 0.04 },
-        previous_league_id: null,
-        draft_id: 'draft_1',
-      }));
+      // get_league_info now makes 3 parallel fetches: league, rosters, users
+      mockFetch
+        .mockResolvedValueOnce(jsonResponse({
+          league_id: '12345',
+          name: 'Test League',
+          sport: 'nfl',
+          season: '2025',
+          status: 'in_season',
+          total_rosters: 10,
+          roster_positions: ['QB', 'RB'],
+          scoring_settings: { pass_yd: 0.04 },
+          previous_league_id: null,
+          draft_id: 'draft_1',
+        }))
+        .mockResolvedValueOnce(jsonResponse([
+          { roster_id: 1, owner_id: 'u1', players: [], starters: [], reserve: [], settings: { wins: 0, losses: 0, ties: 0, fpts: 0, fpts_decimal: 0 } },
+          { roster_id: 2, owner_id: 'u2', players: [], starters: [], reserve: [], settings: { wins: 0, losses: 0, ties: 0, fpts: 0, fpts_decimal: 0 } },
+        ]))
+        .mockResolvedValueOnce(jsonResponse([
+          { user_id: 'u1', display_name: 'Alice', avatar: null },
+          { user_id: 'u2', display_name: 'Bob', avatar: null },
+        ]));
 
       const params: ToolParams = { sport, league_id: '12345', season_year: 2025 };
       const result = await handlers.get_league_info({} as never, params);
@@ -80,6 +90,11 @@ describe('sleeper cross-sport handler characterization tests', () => {
       expect(data.leagueId).toBe('12345');
       expect(data.name).toBe('Test League');
       expect(data.totalRosters).toBe(10);
+
+      const teams = data.teams as Array<{ rosterId: number; ownerName?: string }>;
+      expect(teams).toHaveLength(2);
+      expect(teams[0]).toMatchObject({ rosterId: 1, ownerName: 'Alice' });
+      expect(teams[1]).toMatchObject({ rosterId: 2, ownerName: 'Bob' });
     });
   });
 

--- a/workers/yahoo-client/src/shared/handlers/get-league-info.ts
+++ b/workers/yahoo-client/src/shared/handlers/get-league-info.ts
@@ -1,9 +1,9 @@
 import type { HandlerFn, YahooHandlerContext } from './types';
 import { getYahooCredentials } from '../auth';
 import { yahooFetch, handleYahooError, requireCredentials } from '../yahoo-api';
-import { getPath, logStructure, unwrapLeague } from '../normalizers';
+import { asArray, getPath, logStructure, unwrapLeague, unwrapTeam } from '../normalizers';
 import { ErrorCode } from '@flaim/worker-shared';
-import { toExecuteErrorResponse, withLogLabel } from './utils';
+import { extractManagerName, toExecuteErrorResponse, withLogLabel } from './utils';
 
 export function createGetLeagueInfoHandler(config: YahooHandlerContext): HandlerFn {
   return async (env, params, authHeader, correlationId) => {
@@ -21,7 +21,7 @@ export function createGetLeagueInfoHandler(config: YahooHandlerContext): Handler
       const credentials = await getYahooCredentials(env, authHeader, correlationId);
       requireCredentials(credentials, 'get_league_info');
 
-      const response = await yahooFetch(`/league/${league_id}`, { credentials });
+      const response = await yahooFetch(`/league/${league_id}/teams`, { credentials });
       if (!response.ok) {
         handleYahooError(response);
       }
@@ -31,6 +31,21 @@ export function createGetLeagueInfoHandler(config: YahooHandlerContext): Handler
 
       const leagueArray = getPath(raw, ['fantasy_content', 'league']);
       const league = unwrapLeague(leagueArray);
+
+      // Extract teams from the /teams sub-resource
+      const teamsObj = getPath(league, ['teams']) as Record<string, unknown> | undefined;
+      const teamsArray = asArray(teamsObj);
+
+      const teams = teamsArray.map((teamWrapper: unknown) => {
+        const teamData = getPath(teamWrapper, ['team']) as unknown[];
+        const team = unwrapTeam(teamData);
+        return {
+          teamKey: team.team_key as string | undefined,
+          teamId: team.team_id as string | undefined,
+          teamName: team.name as string | undefined,
+          ownerName: extractManagerName(team),
+        };
+      });
 
       return {
         success: true,
@@ -46,6 +61,7 @@ export function createGetLeagueInfoHandler(config: YahooHandlerContext): Handler
           endWeek: league.end_week,
           isFinished: league.is_finished === 1,
           draftStatus: league.draft_status,
+          teams,
           ...config.extraLeagueFields?.(league),
         },
       };

--- a/workers/yahoo-client/src/shared/handlers/get-roster.ts
+++ b/workers/yahoo-client/src/shared/handlers/get-roster.ts
@@ -3,7 +3,7 @@ import { getYahooCredentials } from '../auth';
 import { yahooFetch, handleYahooError, requireCredentials } from '../yahoo-api';
 import { asArray, getPath, logStructure, unwrapTeam } from '../normalizers';
 import { ErrorCode } from '@flaim/worker-shared';
-import { extractPlayerMeta, toExecuteErrorResponse, withLogLabel } from './utils';
+import { extractManagerName, extractPlayerMeta, toExecuteErrorResponse, withLogLabel } from './utils';
 
 export function createGetRosterHandler(config: YahooHandlerContext): HandlerFn {
   return async (env, params, authHeader, correlationId) => {
@@ -63,6 +63,7 @@ export function createGetRosterHandler(config: YahooHandlerContext): HandlerFn {
         data: {
           teamKey: team.team_key,
           teamName: team.name,
+          ownerName: extractManagerName(team),
           week: week || 'current',
           players,
         },

--- a/workers/yahoo-client/src/shared/handlers/utils.ts
+++ b/workers/yahoo-client/src/shared/handlers/utils.ts
@@ -1,5 +1,6 @@
 import type { ExecuteResponse } from '../../types';
 import { extractErrorCode } from '@flaim/worker-shared';
+import { asArray } from '../normalizers';
 
 export function toExecuteErrorResponse(error: unknown): ExecuteResponse {
   return {
@@ -24,4 +25,23 @@ export function extractPlayerMeta(playerData: unknown[]): Record<string, unknown
 
 export function withLogLabel(baseLabel: string, suffix: string): string {
   return `${baseLabel}${suffix}`;
+}
+
+/**
+ * Extract the primary manager name from a Yahoo team metadata object.
+ * After unwrapTeam merges metadata, team.managers may be:
+ * - A native array: [{ manager: { nickname: "..." } }]
+ * - A Yahoo numeric-keyed object: { "0": { manager: { nickname: "..." } }, count: 1 }
+ * We use asArray() to normalize both forms.
+ */
+export function extractManagerName(team: Record<string, unknown>): string | undefined {
+  const raw = team.managers;
+  if (!raw || typeof raw !== 'object') return undefined;
+
+  const managersArray = asArray(raw as Record<string, unknown>);
+  if (managersArray.length === 0) return undefined;
+
+  const firstWrapper = managersArray[0] as Record<string, unknown> | undefined;
+  const manager = firstWrapper?.manager as Record<string, unknown> | undefined;
+  return (manager?.nickname as string) || undefined;
 }

--- a/workers/yahoo-client/src/sports/__tests__/handlers-cross-sport.test.ts
+++ b/workers/yahoo-client/src/sports/__tests__/handlers-cross-sport.test.ts
@@ -53,6 +53,31 @@ function buildLeagueInfoResponse(): unknown {
           is_finished: 0,
           draft_status: 'postdraft',
         },
+        {
+          teams: {
+            '0': {
+              team: [
+                [
+                  { team_key: '449.l.123.t.1' },
+                  { team_id: '1' },
+                  { name: 'Team A' },
+                  { managers: { '0': { manager: { manager_id: 'm1', nickname: 'Alice' } }, count: 1 } },
+                ],
+              ],
+            },
+            '1': {
+              team: [
+                [
+                  { team_key: '449.l.123.t.2' },
+                  { team_id: '2' },
+                  { name: 'Team B' },
+                  // No managers — tests graceful fallback
+                ],
+              ],
+            },
+            count: 2,
+          },
+        },
       ],
     },
   };
@@ -93,7 +118,11 @@ function buildRosterResponse(): unknown {
   return {
     fantasy_content: {
       team: [
-        [{ team_key: '449.l.123.t.1', name: 'Team A' }],
+        [
+          { team_key: '449.l.123.t.1' },
+          { name: 'Team A' },
+          { managers: { '0': { manager: { manager_id: 'm1', nickname: 'Alice' } }, count: 1 } },
+        ],
         {
           roster: {
             '0': {
@@ -199,6 +228,13 @@ describe('yahoo cross-sport handler characterization tests', () => {
       expect(data.currentWeek).toBe(5);
       expect(data.isFinished).toBe(false);
       expect(data.draftStatus).toBe('postdraft');
+
+      // Teams array with owner names from Yahoo's numeric-keyed managers
+      const teams = data.teams as Array<{ teamId?: string; teamName?: string; ownerName?: string }>;
+      expect(teams).toHaveLength(2);
+      expect(teams[0]).toMatchObject({ teamId: '1', teamName: 'Team A', ownerName: 'Alice' });
+      expect(teams[1]).toMatchObject({ teamId: '2', teamName: 'Team B' });
+      expect(teams[1].ownerName).toBeUndefined();
     });
 
     it('baseball includes startDate and endDate', async () => {
@@ -260,14 +296,16 @@ describe('yahoo cross-sport handler characterization tests', () => {
   });
 
   describe('get_roster', () => {
-    it.each(scenarios)('$label returns roster players with selected positions', async ({ sport, handlers }) => {
+    it.each(scenarios)('$label returns roster players with selected positions and ownerName', async ({ sport, handlers }) => {
       fetchMock.mockResolvedValue(jsonResponse(buildRosterResponse()));
 
       const params: ToolParams = { sport, league_id: '449.l.123', season_year: 2025, team_id: '449.l.123.t.1' };
       const result = await handlers.get_roster({} as never, params, 'Bearer x', `cid-${sport}`);
 
       expect(result.success).toBe(true);
-      const data = result.data as { players: Array<Record<string, unknown>> };
+      const data = result.data as { teamName: string; ownerName?: string; players: Array<Record<string, unknown>> };
+      expect(data.teamName).toBe('Team A');
+      expect(data.ownerName).toBe('Alice');
       expect(data.players).toHaveLength(1);
       expect(data.players[0]).toMatchObject({
         playerId: '101',


### PR DESCRIPTION
## Summary
- **`get_league_info`** now returns a `teams` array with `ownerName` on all three platforms (ESPN, Yahoo, Sleeper), so the model can resolve who owns a player without scanning every roster
- **`get_roster`** also includes `ownerName` for the requested team on all platforms
- MCP tool descriptions updated to describe the contract in platform-agnostic terms

### ESPN
- Adds `&view=mTeam` to league-info and roster API calls
- `get_league_info` returns `teams[]` with `teamId`, `teamName`, `abbrev`, `ownerName`, `owners`
- `get_roster` includes `ownerName`
- Owner extraction filters empty objects and picks the first valid name (no more fabricated `"Unknown"`)
- `get_league_info` and `get_roster` use identical extraction logic so they always agree

### Yahoo
- `get_league_info` switched from `/league/{id}` to `/league/{id}/teams` to include team+manager data
- `extractManagerName` helper uses `asArray()` to handle Yahoo's numeric-keyed manager format
- `get_roster` includes `ownerName` from team manager metadata

### Sleeper
- `get_league_info` now fetches rosters+users in parallel alongside league metadata
- Returns `teams[]` with `rosterId`, `ownerId`, `ownerName`
- `get_roster` already had `ownerName` — no change needed

### MCP tool descriptions
- `get_league_info`: "a teams array listing each team with its owner name. The exact team fields vary by platform but all include ownerName."
- Removed platform-specific field names from shared descriptions

## Test plan
- [x] ESPN: 91 tests pass (espn-client), including new `league-info-teams.test.ts` (8 tests) and `roster-owner.test.ts` (16 tests)
- [x] Yahoo: 98 tests pass (yahoo-client), updated cross-sport tests assert `teams` array and `ownerName`
- [x] Sleeper: 77 tests pass (sleeper-client), updated cross-sport tests assert `teams` array
- [x] fantasy-mcp: type-check clean
- [x] All four workers type-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)