### PR TITLE
GEO site architecture + preview environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,5 @@ docs/submissions/openai-screenshots/
 # Keys
 *.pem
 *.tgz
+.vercel
+.env*.local

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -258,7 +258,29 @@ Usually not needed since CI/CD handles it, but available for debugging:
 - **Workers**: Via `wrangler dev` locally, Cloudflare Dashboard in prod (see `workers/README.md`)
 - **GitHub Actions**: `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN` in repo secrets
 
-**Clerk keys are scoped by Vercel environment.** Production and Preview use separate Clerk instances with independently scoped environment variables in Vercel. See Notion (Platform + Infrastructure) for details.
+### Preview Environment
+
+Opening a PR triggers a full preview stack: Vercel preview deploy + all 5 Cloudflare Workers in `--env preview`. The preview chain is fully isolated from production at the worker level (preview workers bind to each other via service bindings).
+
+**Key differences from production:**
+
+| Layer | Production | Preview |
+|-------|-----------|---------|
+| Frontend | `flaim.app` (Vercel) | `flaim-git-{branch}-gerald-guggers-projects.vercel.app` |
+| Clerk | Production instance (`pk_live_`) | Development instance (`pk_test_`), separate user pool |
+| Workers | `auth-worker`, `fantasy-mcp`, etc. | `auth-worker-preview`, `fantasy-mcp-preview`, etc. |
+| Supabase | Shared (same instance) | Shared (same instance) |
+| Worker URLs | Custom domains (`api.flaim.app/*`) | `.workers.dev` URLs |
+
+**Vercel env vars are scoped by environment.** `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, `CLERK_SECRET_KEY`, `NEXT_PUBLIC_AUTH_WORKER_URL`, and `NEXT_PUBLIC_FANTASY_MCP_URL` each have separate Production and Preview values. Preview points to dev Clerk and preview worker URLs.
+
+**Auth-worker resolves frontend redirects dynamically in preview** — no static `FRONTEND_URL` needed. It reads the `Origin` header (OAuth consent) or stored `redirect_after` (Yahoo callback) and accepts any `flaim-*.vercel.app` origin.
+
+**Supabase is shared.** Preview and prod write to the same database. Clerk instance isolation prevents cross-contamination (dev Clerk user IDs never match prod user IDs). Preview testing may leave orphan rows keyed to dev Clerk IDs — these are inert and can be cleaned up periodically.
+
+**Triggering preview deploys:** Workers only deploy on PRs (not bare branch pushes). A PR must exist for GitHub Actions to run `deploy-workers.yml` with `--env preview`. Vercel deploys on any push.
+
+See Notion (Platform + Infrastructure) for decision rationale.
 
 ### DNS for Custom Routes
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -258,6 +258,8 @@ Usually not needed since CI/CD handles it, but available for debugging:
 - **Workers**: Via `wrangler dev` locally, Cloudflare Dashboard in prod (see `workers/README.md`)
 - **GitHub Actions**: `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN` in repo secrets
 
+**Clerk keys are scoped by Vercel environment.** Production and Preview use separate Clerk instances with independently scoped environment variables in Vercel. See Notion (Platform + Infrastructure) for details.
+
 ### DNS for Custom Routes
 
 Cloudflare DNS: `A` record, name `api`, IPv4 `192.0.2.1`, proxied (orange).

--- a/web/app/(site)/guide/espn/page.tsx
+++ b/web/app/(site)/guide/espn/page.tsx
@@ -13,6 +13,26 @@ export const metadata: Metadata = {
 export default function EspnGuidePage() {
   return (
     <div className="min-h-screen bg-background">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'HowTo',
+            name: 'Connect ESPN Fantasy to ChatGPT, Claude, or Gemini',
+            description: 'Step-by-step guide to connecting your ESPN fantasy leagues to AI assistants using Flaim.',
+            step: [
+              { '@type': 'HowToStep', name: 'Create a Flaim account', text: 'Create a Flaim account at flaim.app.' },
+              { '@type': 'HowToStep', name: 'Install the Chrome extension', text: 'Install the Flaim Chrome extension from the Chrome Web Store.' },
+              { '@type': 'HowToStep', name: 'Log in to ESPN', text: 'Log in to fantasy.espn.com in Chrome.' },
+              { '@type': 'HowToStep', name: 'Sync your leagues', text: 'Click the Flaim extension icon and hit Sync.' },
+              { '@type': 'HowToStep', name: 'Add Flaim to your AI assistant', text: 'Add the Flaim MCP server URL (https://api.flaim.app/mcp) to your AI assistant.' },
+              { '@type': 'HowToStep', name: 'Authorize', text: 'Sign in to Flaim and approve the connection.' },
+              { '@type': 'HowToStep', name: 'Start chatting', text: 'Start chatting about your league.' },
+            ],
+          }),
+        }}
+      />
       <div className="container max-w-2xl mx-auto py-12 px-4">
         <h1 className="text-3xl font-bold mb-4">Connect ESPN Fantasy to ChatGPT, Claude, or Gemini</h1>
         <p className="text-muted-foreground mb-8">

--- a/web/app/(site)/guide/espn/page.tsx
+++ b/web/app/(site)/guide/espn/page.tsx
@@ -42,7 +42,7 @@ export default function EspnGuidePage() {
         <section className="mb-10">
           <h2 className="text-xl font-semibold mb-3">What you need</h2>
           <ul className="list-disc list-inside text-muted-foreground space-y-1">
-            <li>A Flaim account (<a href="https://flaim.app" className="text-primary hover:underline">flaim.app</a>)</li>
+            <li>A Flaim account (<Link href="/" className="text-primary hover:underline">flaim.app</Link>)</li>
             <li>Google Chrome browser</li>
             <li>An active ESPN fantasy league</li>
           </ul>
@@ -51,7 +51,7 @@ export default function EspnGuidePage() {
         <section className="mb-10">
           <h2 className="text-xl font-semibold mb-3">Step by step</h2>
           <ol className="list-decimal list-inside text-muted-foreground space-y-2">
-            <li>Create a Flaim account at <a href="https://flaim.app" className="text-primary hover:underline">flaim.app</a></li>
+            <li>Create a Flaim account at <Link href="/" className="text-primary hover:underline">flaim.app</Link></li>
             <li>Install the Flaim Chrome extension from the Chrome Web Store</li>
             <li>Log in to fantasy.espn.com in Chrome</li>
             <li>Click the Flaim extension icon and hit Sync</li>

--- a/web/app/(site)/guide/espn/page.tsx
+++ b/web/app/(site)/guide/espn/page.tsx
@@ -1,0 +1,67 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Connect ESPN Fantasy to ChatGPT, Claude, or Gemini | Flaim',
+  description:
+    'Step-by-step guide to connecting your ESPN fantasy leagues to AI assistants using Flaim. Works with football, baseball, basketball, and hockey.',
+  alternates: {
+    canonical: 'https://flaim.app/guide/espn',
+  },
+};
+
+export default function EspnGuidePage() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="container max-w-2xl mx-auto py-12 px-4">
+        <h1 className="text-3xl font-bold mb-4">Connect ESPN Fantasy to ChatGPT, Claude, or Gemini</h1>
+        <p className="text-muted-foreground mb-8">
+          Flaim connects your ESPN fantasy leagues to AI assistants for read-only analysis. ESPN requires a Chrome extension to sync your league credentials — setup takes about 5 minutes.
+        </p>
+
+        <section className="mb-10">
+          <h2 className="text-xl font-semibold mb-3">What you need</h2>
+          <ul className="list-disc list-inside text-muted-foreground space-y-1">
+            <li>A Flaim account (<a href="https://flaim.app" className="text-primary hover:underline">flaim.app</a>)</li>
+            <li>Google Chrome browser</li>
+            <li>An active ESPN fantasy league</li>
+          </ul>
+        </section>
+
+        <section className="mb-10">
+          <h2 className="text-xl font-semibold mb-3">Step by step</h2>
+          <ol className="list-decimal list-inside text-muted-foreground space-y-2">
+            <li>Create a Flaim account at <a href="https://flaim.app" className="text-primary hover:underline">flaim.app</a></li>
+            <li>Install the Flaim Chrome extension from the Chrome Web Store</li>
+            <li>Log in to fantasy.espn.com in Chrome</li>
+            <li>Click the Flaim extension icon and hit Sync</li>
+            <li>Add the Flaim MCP server URL to your AI assistant: <code className="text-xs bg-muted px-1 py-0.5 rounded">https://api.flaim.app/mcp</code>{' '}
+              (<Link href="/guide" className="text-primary hover:underline">AI setup details</Link>)</li>
+            <li>Complete the OAuth authorization screen</li>
+            <li>Start chatting about your league</li>
+          </ol>
+        </section>
+
+        <section className="mb-10">
+          <h2 className="text-xl font-semibold mb-3">Why a Chrome extension?</h2>
+          <p className="text-muted-foreground">
+            ESPN doesn&apos;t offer a public API for fantasy data. The extension piggybacks on your active ESPN session to grab read-only league data. Your ESPN credentials are encrypted and stored securely — they are never shared with AI providers.
+          </p>
+        </section>
+
+        <section className="mb-10">
+          <h2 className="text-xl font-semibold mb-3">Supported sports</h2>
+          <p className="text-muted-foreground">
+            Football, baseball, basketball, and hockey.
+          </p>
+        </section>
+
+        <div className="pt-4 border-t">
+          <Link href="/guide" className="text-sm text-primary hover:underline">
+            &larr; Back to guide overview
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/app/(site)/guide/espn/page.tsx
+++ b/web/app/(site)/guide/espn/page.tsx
@@ -37,7 +37,7 @@ export default function EspnGuidePage() {
             <li>Click the Flaim extension icon and hit Sync</li>
             <li>Add the Flaim MCP server URL to your AI assistant: <code className="text-xs bg-muted px-1 py-0.5 rounded">https://api.flaim.app/mcp</code>{' '}
               (<Link href="/guide" className="text-primary hover:underline">AI setup details</Link>)</li>
-            <li>Complete the OAuth authorization screen</li>
+            <li>Sign in to Flaim and approve the connection</li>
             <li>Start chatting about your league</li>
           </ol>
         </section>

--- a/web/app/(site)/guide/page.tsx
+++ b/web/app/(site)/guide/page.tsx
@@ -1,0 +1,113 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'How to Connect Your Fantasy League to AI | Flaim',
+  description:
+    'Connect your ESPN, Yahoo, or Sleeper fantasy leagues to Claude, ChatGPT, or Gemini using Flaim. Setup takes about 5 minutes.',
+  alternates: {
+    canonical: 'https://flaim.app/guide',
+  },
+};
+
+export default function GuidePage() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="container max-w-2xl mx-auto py-12 px-4">
+        <h1 className="text-3xl font-bold mb-4">How to Connect Your Fantasy League to AI</h1>
+        <p className="text-muted-foreground mb-8">
+          You can connect your ESPN, Yahoo, or Sleeper fantasy leagues to Claude, ChatGPT, or Gemini using Flaim. Setup takes about 5 minutes. Once connected, your AI assistant can access your real league data — rosters, standings, matchups, free agents, and transactions — all read-only.
+        </p>
+
+        <section className="mb-10">
+          <h2 className="text-xl font-semibold mb-4">Choose your platform</h2>
+          <div className="grid gap-3">
+            <Link href="/guide/espn" className="block rounded-lg border bg-background p-4 hover:border-foreground/20 transition-colors">
+              <h3 className="font-semibold">ESPN</h3>
+              <p className="text-sm text-muted-foreground mt-1">
+                Requires the Flaim Chrome extension to sync your league credentials. Supports football, baseball, basketball, and hockey.
+              </p>
+            </Link>
+            <Link href="/guide/yahoo" className="block rounded-lg border bg-background p-4 hover:border-foreground/20 transition-colors">
+              <h3 className="font-semibold">Yahoo</h3>
+              <p className="text-sm text-muted-foreground mt-1">
+                Clean OAuth flow — no extension needed. Yahoo auto-discovers all your active leagues. Supports football, baseball, basketball, and hockey.
+              </p>
+            </Link>
+            <Link href="/guide/sleeper" className="block rounded-lg border bg-background p-4 hover:border-foreground/20 transition-colors">
+              <h3 className="font-semibold">Sleeper</h3>
+              <p className="text-sm text-muted-foreground mt-1">
+                Just your username — no extension, no OAuth to Sleeper. Currently supports football and basketball.
+              </p>
+            </Link>
+          </div>
+        </section>
+
+        <section className="mb-10">
+          <h2 className="text-xl font-semibold mb-3">Connect your AI assistant</h2>
+          <p className="text-muted-foreground mb-4">
+            After connecting your fantasy platform, add Flaim as an MCP server in your AI assistant using this URL:
+          </p>
+          <div className="rounded-lg border bg-muted p-3 mb-4">
+            <code className="text-sm">https://api.flaim.app/mcp</code>
+          </div>
+          <p className="text-muted-foreground mb-4">
+            Complete the OAuth authorization screen when prompted. Setup varies by assistant:
+          </p>
+          <ul className="space-y-3 text-sm text-muted-foreground">
+            <li>
+              <span className="font-medium text-foreground">Claude</span> — Add Flaim as a remote MCP server in your Claude settings.{' '}
+              <a href="https://support.anthropic.com/en/articles/11175166-how-can-i-use-integrations-connectors-in-claude" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">Anthropic&apos;s connector docs</a>
+            </li>
+            <li>
+              <span className="font-medium text-foreground">ChatGPT</span> — Add an MCP connection in ChatGPT settings.{' '}
+              <a href="https://platform.openai.com/docs/guides/tools/mcp" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">OpenAI&apos;s MCP docs</a>
+            </li>
+            <li>
+              <span className="font-medium text-foreground">Gemini CLI</span> — Run:{' '}
+              <code className="text-xs bg-muted px-1 py-0.5 rounded">gemini mcp add flaim https://api.flaim.app/mcp --transport http</code>{' '}
+              then <code className="text-xs bg-muted px-1 py-0.5 rounded">/mcp auth flaim</code>
+            </li>
+          </ul>
+        </section>
+
+        <section className="mb-10">
+          <h2 className="text-xl font-semibold mb-3">What you can ask</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            <div className="rounded-lg border bg-background p-3">
+              <p className="text-sm font-medium">&ldquo;Who should I start this week?&rdquo;</p>
+              <p className="text-xs text-muted-foreground mt-1">Pulls your real matchup and roster</p>
+            </div>
+            <div className="rounded-lg border bg-background p-3">
+              <p className="text-sm font-medium">&ldquo;Who&rsquo;s on the waiver wire?&rdquo;</p>
+              <p className="text-xs text-muted-foreground mt-1">Scans available free agents in your league</p>
+            </div>
+            <div className="rounded-lg border bg-background p-3">
+              <p className="text-sm font-medium">&ldquo;Show me the standings&rdquo;</p>
+              <p className="text-xs text-muted-foreground mt-1">Current standings across any of your leagues</p>
+            </div>
+            <div className="rounded-lg border bg-background p-3">
+              <p className="text-sm font-medium">&ldquo;What trades happened this week?&rdquo;</p>
+              <p className="text-xs text-muted-foreground mt-1">Recent transactions in your league</p>
+            </div>
+            <div className="rounded-lg border bg-background p-3">
+              <p className="text-sm font-medium">&ldquo;Who are the best available QBs?&rdquo;</p>
+              <p className="text-xs text-muted-foreground mt-1">Top free agents by position</p>
+            </div>
+            <div className="rounded-lg border bg-background p-3">
+              <p className="text-sm font-medium">&ldquo;What fantasy leagues do I have?&rdquo;</p>
+              <p className="text-xs text-muted-foreground mt-1">Lists all connected leagues across platforms</p>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold mb-3">How it works</h2>
+          <p className="text-muted-foreground">
+            Flaim sits between your fantasy platform and your AI assistant. It gives your AI read-only tools to pull your league data — rosters, standings, matchups, free agents, and transactions. Nothing is changed in your league. Flaim cannot trade, drop, or modify anything on your behalf.
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/web/app/(site)/guide/page.tsx
+++ b/web/app/(site)/guide/page.tsx
@@ -31,7 +31,7 @@ export default function GuidePage() {
             <Link href="/guide/yahoo" className="block rounded-lg border bg-background p-4 hover:border-foreground/20 transition-colors">
               <h3 className="font-semibold">Yahoo</h3>
               <p className="text-sm text-muted-foreground mt-1">
-                Clean OAuth flow — no extension needed. Yahoo auto-discovers all your active leagues. Supports football, baseball, basketball, and hockey.
+                No extension needed — just sign in with Yahoo. Auto-discovers all your active leagues. Supports football, baseball, basketball, and hockey.
               </p>
             </Link>
             <Link href="/guide/sleeper" className="block rounded-lg border bg-background p-4 hover:border-foreground/20 transition-colors">
@@ -46,22 +46,23 @@ export default function GuidePage() {
         <section className="mb-10">
           <h2 className="text-xl font-semibold mb-3">Connect your AI assistant</h2>
           <p className="text-muted-foreground mb-4">
-            After connecting your fantasy platform, add Flaim as an MCP server in your AI assistant using this URL:
+            After connecting your fantasy platform, add Flaim to your AI assistant. You&apos;ll need this server URL:
           </p>
           <div className="rounded-lg border bg-muted p-3 mb-4">
             <code className="text-sm">https://api.flaim.app/mcp</code>
           </div>
           <p className="text-muted-foreground mb-4">
-            Complete the OAuth authorization screen when prompted. Setup varies by assistant:
+            You&apos;ll see a Flaim authorization screen — sign in and approve, then you&apos;re all set. Here&apos;s how to add it in each assistant:
           </p>
           <ul className="space-y-3 text-sm text-muted-foreground">
             <li>
-              <span className="font-medium text-foreground">Claude</span> — Add Flaim as a remote MCP server in your Claude settings.{' '}
-              <a href="https://support.anthropic.com/en/articles/11175166-how-can-i-use-integrations-connectors-in-claude" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">Anthropic&apos;s connector docs</a>
+              <span className="font-medium text-foreground">Claude</span> — Add Flaim as an integration in your Claude settings.{' '}
+              <a href="https://support.anthropic.com/en/articles/11175166-how-can-i-use-integrations-connectors-in-claude" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">Claude&apos;s setup guide</a>
             </li>
             <li>
-              <span className="font-medium text-foreground">ChatGPT</span> — Add an MCP connection in ChatGPT settings.{' '}
-              <a href="https://platform.openai.com/docs/guides/tools/mcp" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">OpenAI&apos;s MCP docs</a>
+              <span className="font-medium text-foreground">ChatGPT</span> — Add Flaim as a connector in ChatGPT. The setup flow changes occasionally — check{' '}
+              <a href="https://help.openai.com/en/collections/11617038-connectors-in-chatgpt" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">OpenAI&apos;s connector docs</a>{' '}
+              for the latest steps.
             </li>
             <li>
               <span className="font-medium text-foreground">Gemini CLI</span> — Run:{' '}

--- a/web/app/(site)/guide/sleeper/page.tsx
+++ b/web/app/(site)/guide/sleeper/page.tsx
@@ -41,7 +41,7 @@ export default function SleeperGuidePage() {
         <section className="mb-10">
           <h2 className="text-xl font-semibold mb-3">What you need</h2>
           <ul className="list-disc list-inside text-muted-foreground space-y-1">
-            <li>A Flaim account (<a href="https://flaim.app" className="text-primary hover:underline">flaim.app</a>)</li>
+            <li>A Flaim account (<Link href="/" className="text-primary hover:underline">flaim.app</Link>)</li>
             <li>Your Sleeper username</li>
           </ul>
         </section>
@@ -49,7 +49,7 @@ export default function SleeperGuidePage() {
         <section className="mb-10">
           <h2 className="text-xl font-semibold mb-3">Step by step</h2>
           <ol className="list-decimal list-inside text-muted-foreground space-y-2">
-            <li>Create a Flaim account at <a href="https://flaim.app" className="text-primary hover:underline">flaim.app</a></li>
+            <li>Create a Flaim account at <Link href="/" className="text-primary hover:underline">flaim.app</Link></li>
             <li>Enter your Sleeper username on the Flaim homepage</li>
             <li>Flaim auto-discovers your leagues</li>
             <li>Add the Flaim MCP server URL to your AI assistant: <code className="text-xs bg-muted px-1 py-0.5 rounded">https://api.flaim.app/mcp</code>{' '}

--- a/web/app/(site)/guide/sleeper/page.tsx
+++ b/web/app/(site)/guide/sleeper/page.tsx
@@ -35,7 +35,7 @@ export default function SleeperGuidePage() {
             <li>Flaim auto-discovers your leagues</li>
             <li>Add the Flaim MCP server URL to your AI assistant: <code className="text-xs bg-muted px-1 py-0.5 rounded">https://api.flaim.app/mcp</code>{' '}
               (<Link href="/guide" className="text-primary hover:underline">AI setup details</Link>)</li>
-            <li>Complete the OAuth authorization screen</li>
+            <li>Sign in to Flaim and approve the connection</li>
             <li>Start chatting about your league</li>
           </ol>
         </section>

--- a/web/app/(site)/guide/sleeper/page.tsx
+++ b/web/app/(site)/guide/sleeper/page.tsx
@@ -43,7 +43,7 @@ export default function SleeperGuidePage() {
         <section className="mb-10">
           <h2 className="text-xl font-semibold mb-3">Supported sports</h2>
           <p className="text-muted-foreground">
-            Football and basketball. Baseball and hockey support is in progress.
+            Football and basketball.
           </p>
         </section>
 

--- a/web/app/(site)/guide/sleeper/page.tsx
+++ b/web/app/(site)/guide/sleeper/page.tsx
@@ -1,0 +1,58 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Connect Sleeper Fantasy to ChatGPT, Claude, or Gemini | Flaim',
+  description:
+    'Step-by-step guide to connecting your Sleeper fantasy leagues to AI assistants using Flaim. Just your username — no extension, no OAuth.',
+  alternates: {
+    canonical: 'https://flaim.app/guide/sleeper',
+  },
+};
+
+export default function SleeperGuidePage() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="container max-w-2xl mx-auto py-12 px-4">
+        <h1 className="text-3xl font-bold mb-4">Connect Sleeper Fantasy to ChatGPT, Claude, or Gemini</h1>
+        <p className="text-muted-foreground mb-8">
+          Flaim connects your Sleeper fantasy leagues to AI assistants for read-only analysis. Sleeper has a public API, so there&apos;s no extension and no OAuth to Sleeper — just enter your username. Setup takes a couple of minutes.
+        </p>
+
+        <section className="mb-10">
+          <h2 className="text-xl font-semibold mb-3">What you need</h2>
+          <ul className="list-disc list-inside text-muted-foreground space-y-1">
+            <li>A Flaim account (<a href="https://flaim.app" className="text-primary hover:underline">flaim.app</a>)</li>
+            <li>Your Sleeper username</li>
+          </ul>
+        </section>
+
+        <section className="mb-10">
+          <h2 className="text-xl font-semibold mb-3">Step by step</h2>
+          <ol className="list-decimal list-inside text-muted-foreground space-y-2">
+            <li>Create a Flaim account at <a href="https://flaim.app" className="text-primary hover:underline">flaim.app</a></li>
+            <li>Enter your Sleeper username on the Flaim homepage</li>
+            <li>Flaim auto-discovers your leagues</li>
+            <li>Add the Flaim MCP server URL to your AI assistant: <code className="text-xs bg-muted px-1 py-0.5 rounded">https://api.flaim.app/mcp</code>{' '}
+              (<Link href="/guide" className="text-primary hover:underline">AI setup details</Link>)</li>
+            <li>Complete the OAuth authorization screen</li>
+            <li>Start chatting about your league</li>
+          </ol>
+        </section>
+
+        <section className="mb-10">
+          <h2 className="text-xl font-semibold mb-3">Supported sports</h2>
+          <p className="text-muted-foreground">
+            Football and basketball. Baseball and hockey support is in progress.
+          </p>
+        </section>
+
+        <div className="pt-4 border-t">
+          <Link href="/guide" className="text-sm text-primary hover:underline">
+            &larr; Back to guide overview
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/app/(site)/guide/sleeper/page.tsx
+++ b/web/app/(site)/guide/sleeper/page.tsx
@@ -13,6 +13,25 @@ export const metadata: Metadata = {
 export default function SleeperGuidePage() {
   return (
     <div className="min-h-screen bg-background">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'HowTo',
+            name: 'Connect Sleeper Fantasy to ChatGPT, Claude, or Gemini',
+            description: 'Step-by-step guide to connecting your Sleeper fantasy leagues to AI assistants using Flaim.',
+            step: [
+              { '@type': 'HowToStep', name: 'Create a Flaim account', text: 'Create a Flaim account at flaim.app.' },
+              { '@type': 'HowToStep', name: 'Enter your Sleeper username', text: 'Enter your Sleeper username on the Flaim homepage.' },
+              { '@type': 'HowToStep', name: 'Leagues auto-discovered', text: 'Flaim auto-discovers your leagues.' },
+              { '@type': 'HowToStep', name: 'Add Flaim to your AI assistant', text: 'Add the Flaim MCP server URL (https://api.flaim.app/mcp) to your AI assistant.' },
+              { '@type': 'HowToStep', name: 'Authorize', text: 'Sign in to Flaim and approve the connection.' },
+              { '@type': 'HowToStep', name: 'Start chatting', text: 'Start chatting about your league.' },
+            ],
+          }),
+        }}
+      />
       <div className="container max-w-2xl mx-auto py-12 px-4">
         <h1 className="text-3xl font-bold mb-4">Connect Sleeper Fantasy to ChatGPT, Claude, or Gemini</h1>
         <p className="text-muted-foreground mb-8">

--- a/web/app/(site)/guide/yahoo/page.tsx
+++ b/web/app/(site)/guide/yahoo/page.tsx
@@ -13,6 +13,26 @@ export const metadata: Metadata = {
 export default function YahooGuidePage() {
   return (
     <div className="min-h-screen bg-background">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'HowTo',
+            name: 'Connect Yahoo Fantasy to ChatGPT, Claude, or Gemini',
+            description: 'Step-by-step guide to connecting your Yahoo fantasy leagues to AI assistants using Flaim.',
+            step: [
+              { '@type': 'HowToStep', name: 'Create a Flaim account', text: 'Create a Flaim account at flaim.app.' },
+              { '@type': 'HowToStep', name: 'Authenticate Yahoo', text: 'Click "Authenticate Yahoo" on the Flaim homepage.' },
+              { '@type': 'HowToStep', name: 'Sign in with Yahoo', text: 'Sign in with your Yahoo account and authorize Flaim.' },
+              { '@type': 'HowToStep', name: 'Leagues auto-discovered', text: 'Yahoo auto-discovers all your active leagues.' },
+              { '@type': 'HowToStep', name: 'Add Flaim to your AI assistant', text: 'Add the Flaim MCP server URL (https://api.flaim.app/mcp) to your AI assistant.' },
+              { '@type': 'HowToStep', name: 'Authorize', text: 'Sign in to Flaim and approve the connection.' },
+              { '@type': 'HowToStep', name: 'Start chatting', text: 'Start chatting about your league.' },
+            ],
+          }),
+        }}
+      />
       <div className="container max-w-2xl mx-auto py-12 px-4">
         <h1 className="text-3xl font-bold mb-4">Connect Yahoo Fantasy to ChatGPT, Claude, or Gemini</h1>
         <p className="text-muted-foreground mb-8">

--- a/web/app/(site)/guide/yahoo/page.tsx
+++ b/web/app/(site)/guide/yahoo/page.tsx
@@ -1,0 +1,59 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Connect Yahoo Fantasy to ChatGPT, Claude, or Gemini | Flaim',
+  description:
+    'Step-by-step guide to connecting your Yahoo fantasy leagues to AI assistants using Flaim. Standard OAuth — no extension needed.',
+  alternates: {
+    canonical: 'https://flaim.app/guide/yahoo',
+  },
+};
+
+export default function YahooGuidePage() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="container max-w-2xl mx-auto py-12 px-4">
+        <h1 className="text-3xl font-bold mb-4">Connect Yahoo Fantasy to ChatGPT, Claude, or Gemini</h1>
+        <p className="text-muted-foreground mb-8">
+          Flaim connects your Yahoo fantasy leagues to AI assistants for read-only analysis. Yahoo uses a standard OAuth flow — no extension needed. Setup takes about 5 minutes.
+        </p>
+
+        <section className="mb-10">
+          <h2 className="text-xl font-semibold mb-3">What you need</h2>
+          <ul className="list-disc list-inside text-muted-foreground space-y-1">
+            <li>A Flaim account (<a href="https://flaim.app" className="text-primary hover:underline">flaim.app</a>)</li>
+            <li>A Yahoo account with an active fantasy league</li>
+          </ul>
+        </section>
+
+        <section className="mb-10">
+          <h2 className="text-xl font-semibold mb-3">Step by step</h2>
+          <ol className="list-decimal list-inside text-muted-foreground space-y-2">
+            <li>Create a Flaim account at <a href="https://flaim.app" className="text-primary hover:underline">flaim.app</a></li>
+            <li>Click &ldquo;Authenticate Yahoo&rdquo; on the Flaim homepage</li>
+            <li>Sign in with your Yahoo account and authorize Flaim</li>
+            <li>Yahoo auto-discovers all your active leagues</li>
+            <li>Add the Flaim MCP server URL to your AI assistant: <code className="text-xs bg-muted px-1 py-0.5 rounded">https://api.flaim.app/mcp</code>{' '}
+              (<Link href="/guide" className="text-primary hover:underline">AI setup details</Link>)</li>
+            <li>Complete the OAuth authorization screen</li>
+            <li>Start chatting about your league</li>
+          </ol>
+        </section>
+
+        <section className="mb-10">
+          <h2 className="text-xl font-semibold mb-3">Supported sports</h2>
+          <p className="text-muted-foreground">
+            Football, baseball, basketball, and hockey.
+          </p>
+        </section>
+
+        <div className="pt-4 border-t">
+          <Link href="/guide" className="text-sm text-primary hover:underline">
+            &larr; Back to guide overview
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/app/(site)/guide/yahoo/page.tsx
+++ b/web/app/(site)/guide/yahoo/page.tsx
@@ -42,7 +42,7 @@ export default function YahooGuidePage() {
         <section className="mb-10">
           <h2 className="text-xl font-semibold mb-3">What you need</h2>
           <ul className="list-disc list-inside text-muted-foreground space-y-1">
-            <li>A Flaim account (<a href="https://flaim.app" className="text-primary hover:underline">flaim.app</a>)</li>
+            <li>A Flaim account (<Link href="/" className="text-primary hover:underline">flaim.app</Link>)</li>
             <li>A Yahoo account with an active fantasy league</li>
           </ul>
         </section>
@@ -50,7 +50,7 @@ export default function YahooGuidePage() {
         <section className="mb-10">
           <h2 className="text-xl font-semibold mb-3">Step by step</h2>
           <ol className="list-decimal list-inside text-muted-foreground space-y-2">
-            <li>Create a Flaim account at <a href="https://flaim.app" className="text-primary hover:underline">flaim.app</a></li>
+            <li>Create a Flaim account at <Link href="/" className="text-primary hover:underline">flaim.app</Link></li>
             <li>Click &ldquo;Authenticate Yahoo&rdquo; on the Flaim homepage</li>
             <li>Sign in with your Yahoo account and authorize Flaim</li>
             <li>Yahoo auto-discovers all your active leagues</li>

--- a/web/app/(site)/guide/yahoo/page.tsx
+++ b/web/app/(site)/guide/yahoo/page.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 export const metadata: Metadata = {
   title: 'Connect Yahoo Fantasy to ChatGPT, Claude, or Gemini | Flaim',
   description:
-    'Step-by-step guide to connecting your Yahoo fantasy leagues to AI assistants using Flaim. Standard OAuth — no extension needed.',
+    'Step-by-step guide to connecting your Yahoo fantasy leagues to AI assistants using Flaim. No extension needed — just sign in with Yahoo.',
   alternates: {
     canonical: 'https://flaim.app/guide/yahoo',
   },
@@ -16,7 +16,7 @@ export default function YahooGuidePage() {
       <div className="container max-w-2xl mx-auto py-12 px-4">
         <h1 className="text-3xl font-bold mb-4">Connect Yahoo Fantasy to ChatGPT, Claude, or Gemini</h1>
         <p className="text-muted-foreground mb-8">
-          Flaim connects your Yahoo fantasy leagues to AI assistants for read-only analysis. Yahoo uses a standard OAuth flow — no extension needed. Setup takes about 5 minutes.
+          Flaim connects your Yahoo fantasy leagues to AI assistants for read-only analysis. No extension needed — just sign in with your Yahoo account and Flaim handles the rest. Setup takes about 5 minutes.
         </p>
 
         <section className="mb-10">
@@ -36,7 +36,7 @@ export default function YahooGuidePage() {
             <li>Yahoo auto-discovers all your active leagues</li>
             <li>Add the Flaim MCP server URL to your AI assistant: <code className="text-xs bg-muted px-1 py-0.5 rounded">https://api.flaim.app/mcp</code>{' '}
               (<Link href="/guide" className="text-primary hover:underline">AI setup details</Link>)</li>
-            <li>Complete the OAuth authorization screen</li>
+            <li>Sign in to Flaim and approve the connection</li>
             <li>Start chatting about your league</li>
           </ol>
         </section>

--- a/web/app/(site)/layout.tsx
+++ b/web/app/(site)/layout.tsx
@@ -20,6 +20,8 @@ export default function SiteLayout({
             <div className="text-sm text-muted-foreground flex items-center justify-center gap-2">
               <a href="https://www.threads.com/@jdguggs10" target="_blank" rel="noopener noreferrer" className="underline hover:text-foreground">Built by Gerry</a>
               <span aria-hidden="true">·</span>
+              <Link href="/guide" className="underline hover:text-foreground">Guide</Link>
+              <span aria-hidden="true">·</span>
               <Link href="/privacy" className="underline hover:text-foreground">
                 Privacy
               </Link>

--- a/web/app/(site)/page.tsx
+++ b/web/app/(site)/page.tsx
@@ -26,6 +26,35 @@ export default function LandingPage() {
         </p>
       </section>
 
+      <p className="text-sm text-muted-foreground max-w-xl mx-auto text-center px-4 pb-2">
+        Flaim connects your ESPN, Yahoo, and Sleeper fantasy leagues to Claude, ChatGPT, and Gemini for read-only, league-specific analysis. Ask about your roster, matchups, standings, free agents, and transactions — using your actual league data.
+      </p>
+
+      {/* What you can ask */}
+      <section className="px-4 pb-4">
+        <div className="container max-w-xl mx-auto">
+          <h2 className="text-lg font-semibold text-center mb-3">What you can ask</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            <div className="rounded-lg border bg-background p-3">
+              <p className="text-sm font-medium">&ldquo;Who should I start this week?&rdquo;</p>
+              <p className="text-xs text-muted-foreground mt-1">Pulls your real matchup and roster</p>
+            </div>
+            <div className="rounded-lg border bg-background p-3">
+              <p className="text-sm font-medium">&ldquo;Who&rsquo;s on the waiver wire?&rdquo;</p>
+              <p className="text-xs text-muted-foreground mt-1">Scans available free agents in your league</p>
+            </div>
+            <div className="rounded-lg border bg-background p-3">
+              <p className="text-sm font-medium">&ldquo;How do I stack up against first place?&rdquo;</p>
+              <p className="text-xs text-muted-foreground mt-1">Compares your roster to the standings leader</p>
+            </div>
+            <div className="rounded-lg border bg-background p-3">
+              <p className="text-sm font-medium">&ldquo;What trades happened this week?&rdquo;</p>
+              <p className="text-xs text-muted-foreground mt-1">Shows recent transactions in your league</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
       {/* How It Works */}
       <section className="py-8 bg-muted">
         <div className="container max-w-xl mx-auto px-4">

--- a/web/app/(site)/page.tsx
+++ b/web/app/(site)/page.tsx
@@ -16,6 +16,49 @@ import { StepConnectAI } from '@/components/site/StepConnectAI';
 export default function LandingPage() {
   return (
     <div className="min-h-screen bg-background">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'FAQPage',
+            mainEntity: [
+              {
+                '@type': 'Question',
+                name: 'What does Flaim do?',
+                acceptedAnswer: {
+                  '@type': 'Answer',
+                  text: 'Flaim is a skill that turns your AI into a fantasy sports expert, and a connector to data from your actual fantasy leagues. It lets you ask Claude, ChatGPT, or Gemini about your actual roster, matchup, standings, transactions, available free agents, waiver wire, and more.',
+                },
+              },
+              {
+                '@type': 'Question',
+                name: 'Why a Chrome extension?',
+                acceptedAnswer: {
+                  '@type': 'Answer',
+                  text: 'You only need it if you have leagues at ESPN. Log in to fantasy.espn.com and the extension will piggyback on that session to auto-sync your leagues.',
+                },
+              },
+              {
+                '@type': 'Question',
+                name: 'How does Flaim connect to AI clients?',
+                acceptedAnswer: {
+                  '@type': 'Answer',
+                  text: 'Sync your league data to Flaim, and then Flaim connects that data to Claude, ChatGPT, or Gemini. Your Flaim account tells your AI about your leagues, team name, and season year, while also giving the AI dedicated tools to pull out league data.',
+                },
+              },
+              {
+                '@type': 'Question',
+                name: 'Any other tips or tricks?',
+                acceptedAnswer: {
+                  '@type': 'Answer',
+                  text: 'Set a default sport and default leagues at flaim.app/leagues to save yourself some repeated explanation. If the AI needs a nudge, just say "Use Flaim."',
+                },
+              },
+            ],
+          }),
+        }}
+      />
       {/* Hero */}
       <section className="py-8 px-4 text-center">
         <h1 className="text-4xl md:text-5xl font-bold mb-2">

--- a/web/app/(site)/page.tsx
+++ b/web/app/(site)/page.tsx
@@ -26,35 +26,6 @@ export default function LandingPage() {
         </p>
       </section>
 
-      <p className="text-sm text-muted-foreground max-w-xl mx-auto text-center px-4 pb-2">
-        Flaim connects your ESPN, Yahoo, and Sleeper fantasy leagues to Claude, ChatGPT, and Gemini for read-only, league-specific analysis. Ask about your roster, matchups, standings, free agents, and transactions — using your actual league data.
-      </p>
-
-      {/* What you can ask */}
-      <section className="px-4 pb-4">
-        <div className="container max-w-xl mx-auto">
-          <h2 className="text-lg font-semibold text-center mb-3">What you can ask</h2>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-            <div className="rounded-lg border bg-background p-3">
-              <p className="text-sm font-medium">&ldquo;Who should I start this week?&rdquo;</p>
-              <p className="text-xs text-muted-foreground mt-1">Pulls your real matchup and roster</p>
-            </div>
-            <div className="rounded-lg border bg-background p-3">
-              <p className="text-sm font-medium">&ldquo;Who&rsquo;s on the waiver wire?&rdquo;</p>
-              <p className="text-xs text-muted-foreground mt-1">Scans available free agents in your league</p>
-            </div>
-            <div className="rounded-lg border bg-background p-3">
-              <p className="text-sm font-medium">&ldquo;How do I stack up against first place?&rdquo;</p>
-              <p className="text-xs text-muted-foreground mt-1">Compares your roster to the standings leader</p>
-            </div>
-            <div className="rounded-lg border bg-background p-3">
-              <p className="text-sm font-medium">&ldquo;What trades happened this week?&rdquo;</p>
-              <p className="text-xs text-muted-foreground mt-1">Shows recent transactions in your league</p>
-            </div>
-          </div>
-        </div>
-      </section>
-
       {/* How It Works */}
       <section className="py-8 bg-muted">
         <div className="container max-w-xl mx-auto px-4">

--- a/web/app/api/connect/yahoo/authorize/route.ts
+++ b/web/app/api/connect/yahoo/authorize/route.ts
@@ -26,6 +26,7 @@ export async function GET() {
       redirect: 'manual',
       headers: {
         Authorization: `Bearer ${bearer}`,
+        'X-Forwarded-Origin': process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : '',
       },
     });
 

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -17,11 +17,11 @@ const geistMono = localFont({
 
 export const metadata: Metadata = {
   title: "Flaim Fantasy",
-  description: "Read-only fantasy analysis for ESPN, Yahoo, and Sleeper with unified league context for standings, rosters, matchups, and free agents",
+  description: "Flaim connects your ESPN, Yahoo, and Sleeper fantasy leagues to Claude, ChatGPT, and Gemini. Get AI analysis based on your real roster, matchups, standings, and waiver wire — read-only.",
   metadataBase: new URL('https://flaim.app'),
   openGraph: {
     title: "Flaim Fantasy",
-    description: "Read-only fantasy analysis for ESPN, Yahoo, and Sleeper with unified league context for standings, rosters, matchups, and free agents",
+    description: "Flaim connects your ESPN, Yahoo, and Sleeper fantasy leagues to Claude, ChatGPT, and Gemini. Get AI analysis based on your real roster, matchups, standings, and waiver wire — read-only.",
     url: "https://flaim.app",
     siteName: "Flaim",
     type: "website",
@@ -30,7 +30,7 @@ export const metadata: Metadata = {
   twitter: {
     card: "summary_large_image",
     title: "Flaim Fantasy",
-    description: "Read-only fantasy analysis for ESPN, Yahoo, and Sleeper with unified league context for standings, rosters, matchups, and free agents",
+    description: "Flaim connects your ESPN, Yahoo, and Sleeper fantasy leagues to Claude, ChatGPT, and Gemini. Get AI analysis based on your real roster, matchups, standings, and waiver wire — read-only.",
   },
   icons: {
     icon: [
@@ -55,6 +55,21 @@ export default function RootLayout({
   return (
       <html lang="en" suppressHydrationWarning>
         <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+          <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{
+              __html: JSON.stringify({
+                '@context': 'https://schema.org',
+                '@type': 'SoftwareApplication',
+                name: 'Flaim Fantasy',
+                description: 'Flaim connects your ESPN, Yahoo, and Sleeper fantasy leagues to Claude, ChatGPT, and Gemini for read-only, league-specific analysis.',
+                applicationCategory: 'SportsApplication',
+                operatingSystem: 'Web',
+                url: 'https://flaim.app',
+                author: { '@type': 'Person', name: 'Gerry' },
+              }),
+            }}
+          />
           <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange storageKey="flaim-theme">
             <ClerkThemeWrapper>
               {children}

--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -29,6 +29,30 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.7,
     },
     {
+      url: `${baseUrl}/guide`,
+      lastModified,
+      changeFrequency: 'monthly',
+      priority: 0.9,
+    },
+    {
+      url: `${baseUrl}/guide/espn`,
+      lastModified,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/guide/yahoo`,
+      lastModified,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/guide/sleeper`,
+      lastModified,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
       url: `${baseUrl}/inspirations`,
       lastModified,
       changeFrequency: 'monthly',

--- a/web/public/llms.txt
+++ b/web/public/llms.txt
@@ -1,0 +1,24 @@
+# Flaim Fantasy
+
+> Flaim connects your ESPN, Yahoo, and Sleeper fantasy leagues to Claude, ChatGPT, and Gemini for read-only, league-specific analysis.
+
+## What Flaim does
+
+- Read-only access to fantasy league data via AI assistants
+- Supports ESPN, Yahoo, Sleeper across football, baseball, basketball, hockey
+- 9 tools: roster, standings, matchups, free agents, transactions, league info, player search, league history, session info
+- Works with Claude, ChatGPT, and Gemini via MCP (Model Context Protocol)
+- Read-only — Flaim cannot trade, drop, or modify anything in your league
+
+## How to connect
+
+1. Create account at https://flaim.app
+2. Connect fantasy platforms (ESPN via Chrome extension, Yahoo via OAuth, Sleeper via username)
+3. Add MCP server URL https://api.flaim.app/mcp to your AI assistant
+
+## Links
+
+- Website: https://flaim.app
+- Setup guide: https://flaim.app/guide
+- GitHub: https://github.com/jdguggs10/flaim
+- Privacy: https://flaim.app/privacy

--- a/web/public/llms.txt
+++ b/web/public/llms.txt
@@ -6,7 +6,7 @@
 
 - Read-only access to fantasy league data via AI assistants
 - Supports ESPN and Yahoo across football, baseball, basketball, hockey
-- Supports Sleeper for football and basketball (baseball and hockey in progress)
+- Supports Sleeper for football and basketball
 - 9 tools: roster, standings, matchups, free agents, transactions, league info, player search, league history, session info
 - Works with Claude, ChatGPT, and Gemini via MCP (Model Context Protocol)
 - Read-only — Flaim cannot trade, drop, or modify anything in your league

--- a/web/public/llms.txt
+++ b/web/public/llms.txt
@@ -5,7 +5,8 @@
 ## What Flaim does
 
 - Read-only access to fantasy league data via AI assistants
-- Supports ESPN, Yahoo, Sleeper across football, baseball, basketball, hockey
+- Supports ESPN and Yahoo across football, baseball, basketball, hockey
+- Supports Sleeper for football and basketball (baseball and hockey in progress)
 - 9 tools: roster, standings, matchups, free agents, transactions, league info, player search, league history, session info
 - Works with Claude, ChatGPT, and Gemini via MCP (Model Context Protocol)
 - Read-only — Flaim cannot trade, drop, or modify anything in your league

--- a/web/public/robots.txt
+++ b/web/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://flaim.app/sitemap.xml

--- a/workers/auth-worker/src/__tests__/preview-url.test.ts
+++ b/workers/auth-worker/src/__tests__/preview-url.test.ts
@@ -26,6 +26,19 @@ describe('resolvePreviewOrigin', () => {
     expect(resolvePreviewOrigin(req)).toBe('https://flaim-git-feature-gerald-guggers-projects.vercel.app');
   });
 
+  it('uses X-Forwarded-Origin from Next.js API proxies', () => {
+    const req = makeRequest({ 'X-Forwarded-Origin': 'https://flaim-git-feature-gerald-guggers-projects.vercel.app' });
+    expect(resolvePreviewOrigin(req)).toBe('https://flaim-git-feature-gerald-guggers-projects.vercel.app');
+  });
+
+  it('prefers X-Forwarded-Origin over Origin', () => {
+    const req = makeRequest({
+      'X-Forwarded-Origin': 'https://flaim-git-preview-gerald-guggers-projects.vercel.app',
+      Origin: 'https://flaim-git-other-gerald-guggers-projects.vercel.app',
+    });
+    expect(resolvePreviewOrigin(req)).toBe('https://flaim-git-preview-gerald-guggers-projects.vercel.app');
+  });
+
   it('rejects non-Vercel origins', () => {
     const req = makeRequest({ Origin: 'https://evil.com' });
     expect(resolvePreviewOrigin(req)).toBeUndefined();

--- a/workers/auth-worker/src/__tests__/preview-url.test.ts
+++ b/workers/auth-worker/src/__tests__/preview-url.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { resolvePreviewOrigin, getFrontendUrl } from '../preview-url';
+
+function makeRequest(headers: Record<string, string> = {}): Request {
+  return new Request('https://example.com', { headers });
+}
+
+describe('resolvePreviewOrigin', () => {
+  it('returns origin for valid Vercel preview URL', () => {
+    const req = makeRequest({ Origin: 'https://flaim-git-my-branch-gerald-guggers-projects.vercel.app' });
+    expect(resolvePreviewOrigin(req)).toBe('https://flaim-git-my-branch-gerald-guggers-projects.vercel.app');
+  });
+
+  it('returns origin for base flaim.vercel.app', () => {
+    const req = makeRequest({ Origin: 'https://flaim.vercel.app' });
+    expect(resolvePreviewOrigin(req)).toBe('https://flaim.vercel.app');
+  });
+
+  it('returns origin for commit-hash style URLs', () => {
+    const req = makeRequest({ Origin: 'https://flaim-abc123def-gerald-guggers-projects.vercel.app' });
+    expect(resolvePreviewOrigin(req)).toBe('https://flaim-abc123def-gerald-guggers-projects.vercel.app');
+  });
+
+  it('falls back to Referer when Origin is absent', () => {
+    const req = makeRequest({ Referer: 'https://flaim-git-feature-gerald-guggers-projects.vercel.app/guide' });
+    expect(resolvePreviewOrigin(req)).toBe('https://flaim-git-feature-gerald-guggers-projects.vercel.app');
+  });
+
+  it('rejects non-Vercel origins', () => {
+    const req = makeRequest({ Origin: 'https://evil.com' });
+    expect(resolvePreviewOrigin(req)).toBeUndefined();
+  });
+
+  it('rejects similar but non-matching domains', () => {
+    const req = makeRequest({ Origin: 'https://notflaim.vercel.app' });
+    expect(resolvePreviewOrigin(req)).toBeUndefined();
+  });
+
+  it('rejects flaim subdomain spoofing', () => {
+    const req = makeRequest({ Origin: 'https://flaim.vercel.app.evil.com' });
+    expect(resolvePreviewOrigin(req)).toBeUndefined();
+  });
+
+  it('returns undefined when no Origin or Referer', () => {
+    const req = makeRequest({});
+    expect(resolvePreviewOrigin(req)).toBeUndefined();
+  });
+});
+
+describe('getFrontendUrl', () => {
+  it('uses FRONTEND_URL env var when set', () => {
+    expect(getFrontendUrl({ FRONTEND_URL: 'https://custom.example.com/' })).toBe('https://custom.example.com');
+  });
+
+  it('returns localhost for dev environment', () => {
+    expect(getFrontendUrl({ ENVIRONMENT: 'dev' })).toBe('http://localhost:3000');
+  });
+
+  it('returns localhost for development NODE_ENV', () => {
+    expect(getFrontendUrl({ NODE_ENV: 'development' })).toBe('http://localhost:3000');
+  });
+
+  it('resolves preview origin in preview environment', () => {
+    const req = makeRequest({ Origin: 'https://flaim-git-test-gerald-guggers-projects.vercel.app' });
+    expect(getFrontendUrl({ ENVIRONMENT: 'preview' }, req)).toBe('https://flaim-git-test-gerald-guggers-projects.vercel.app');
+  });
+
+  it('falls back to flaim.app in preview without valid origin', () => {
+    const req = makeRequest({ Origin: 'https://evil.com' });
+    expect(getFrontendUrl({ ENVIRONMENT: 'preview' }, req)).toBe('https://flaim.app');
+  });
+
+  it('falls back to flaim.app in preview without request', () => {
+    expect(getFrontendUrl({ ENVIRONMENT: 'preview' })).toBe('https://flaim.app');
+  });
+
+  it('returns flaim.app for prod', () => {
+    expect(getFrontendUrl({ ENVIRONMENT: 'prod' })).toBe('https://flaim.app');
+  });
+
+  it('FRONTEND_URL takes priority over preview origin', () => {
+    const req = makeRequest({ Origin: 'https://flaim-git-test.vercel.app' });
+    expect(getFrontendUrl({ FRONTEND_URL: 'https://override.com', ENVIRONMENT: 'preview' }, req)).toBe('https://override.com');
+  });
+});

--- a/workers/auth-worker/src/index-hono.ts
+++ b/workers/auth-worker/src/index-hono.ts
@@ -883,7 +883,7 @@ api.get('/connect/yahoo/authorize', async (c) => {
       error_description: authError || 'Authentication required',
     }, 401);
   }
-  return handleYahooAuthorize(c.env as YahooConnectEnv, userId, getCorsHeaders(c.req.raw));
+  return handleYahooAuthorize(c.env as YahooConnectEnv, userId, getCorsHeaders(c.req.raw), c.req.raw);
 });
 
 // Yahoo OAuth callback (public - Yahoo redirects here)

--- a/workers/auth-worker/src/oauth-handlers.ts
+++ b/workers/auth-worker/src/oauth-handlers.ts
@@ -107,12 +107,22 @@ function isLoopbackRedirectUri(uri: string): boolean {
 const OAUTH_CLIENT_ID = 'flaim-mcp';
 
 // Frontend URL for consent page
-const getFrontendUrl = (env: OAuthEnv): string => {
+const getFrontendUrl = (env: OAuthEnv, request?: Request): string => {
   if (env.FRONTEND_URL) {
     return env.FRONTEND_URL.replace(/\/$/, '');
   }
   if (env.ENVIRONMENT === 'dev' || env.NODE_ENV === 'development') {
     return 'http://localhost:3000';
+  }
+  // In preview, use the request origin if it's a Vercel preview URL
+  if (env.ENVIRONMENT === 'preview' && request) {
+    const origin = request.headers.get('Origin') || request.headers.get('Referer');
+    if (origin) {
+      const url = origin.startsWith('http') ? new URL(origin).origin : origin;
+      if (/^https:\/\/flaim(-[a-z0-9-]+)?\.vercel\.app$/.test(url)) {
+        return url;
+      }
+    }
   }
   return 'https://flaim.app';
 };
@@ -442,7 +452,7 @@ export async function handleAuthorize(request: Request, env: OAuthEnv): Promise<
   }
 
   // Build frontend consent URL
-  const frontendUrl = getFrontendUrl(env);
+  const frontendUrl = getFrontendUrl(env, request);
   const consentUrl = new URL(`${frontendUrl}/oauth/consent`);
 
   // Pass all OAuth params to frontend

--- a/workers/auth-worker/src/oauth-handlers.ts
+++ b/workers/auth-worker/src/oauth-handlers.ts
@@ -18,6 +18,7 @@
  */
 
 import { OAuthStorage } from './oauth-storage';
+import { getFrontendUrl } from './preview-url';
 
 // =============================================================================
 // TYPES
@@ -106,26 +107,6 @@ function isLoopbackRedirectUri(uri: string): boolean {
 // OAuth client ID (static for now, no DCR)
 const OAUTH_CLIENT_ID = 'flaim-mcp';
 
-// Frontend URL for consent page
-const getFrontendUrl = (env: OAuthEnv, request?: Request): string => {
-  if (env.FRONTEND_URL) {
-    return env.FRONTEND_URL.replace(/\/$/, '');
-  }
-  if (env.ENVIRONMENT === 'dev' || env.NODE_ENV === 'development') {
-    return 'http://localhost:3000';
-  }
-  // In preview, use the request origin if it's a Vercel preview URL
-  if (env.ENVIRONMENT === 'preview' && request) {
-    const origin = request.headers.get('Origin') || request.headers.get('Referer');
-    if (origin) {
-      const url = origin.startsWith('http') ? new URL(origin).origin : origin;
-      if (/^https:\/\/flaim(-[a-z0-9-]+)?\.vercel\.app$/.test(url)) {
-        return url;
-      }
-    }
-  }
-  return 'https://flaim.app';
-};
 
 // Base URL for OAuth endpoints (used in metadata)
 const getBaseUrl = (env: OAuthEnv): string => {

--- a/workers/auth-worker/src/preview-url.ts
+++ b/workers/auth-worker/src/preview-url.ts
@@ -1,0 +1,45 @@
+/**
+ * Vercel preview URL pattern. Matches:
+ *   - flaim.vercel.app
+ *   - flaim-git-branch-name-gerald-guggers-projects.vercel.app
+ *   - flaim-abc123def-gerald-guggers-projects.vercel.app
+ *
+ * Character class [a-z0-9-] is intentional — Vercel normalizes branch names
+ * to lowercase and converts underscores to hyphens.
+ */
+const VERCEL_PREVIEW_PATTERN = /^https:\/\/flaim(-[a-z0-9-]+)?\.vercel\.app$/;
+
+/**
+ * Extract a valid Vercel preview origin from a request.
+ * Returns the origin if it matches the preview URL pattern, undefined otherwise.
+ */
+export function resolvePreviewOrigin(request: Request): string | undefined {
+  const origin = request.headers.get('Origin') || request.headers.get('Referer');
+  if (!origin) return undefined;
+  const url = origin.startsWith('http') ? new URL(origin).origin : origin;
+  return VERCEL_PREVIEW_PATTERN.test(url) ? url : undefined;
+}
+
+interface FrontendUrlEnv {
+  FRONTEND_URL?: string;
+  ENVIRONMENT?: string;
+  NODE_ENV?: string;
+}
+
+/**
+ * Resolve the frontend URL for OAuth redirects.
+ * Priority: FRONTEND_URL env var > localhost (dev) > preview origin > flaim.app
+ */
+export function getFrontendUrl(env: FrontendUrlEnv, request?: Request): string {
+  if (env.FRONTEND_URL) {
+    return env.FRONTEND_URL.replace(/\/$/, '');
+  }
+  if (env.ENVIRONMENT === 'dev' || env.NODE_ENV === 'development') {
+    return 'http://localhost:3000';
+  }
+  if (env.ENVIRONMENT === 'preview' && request) {
+    const previewOrigin = resolvePreviewOrigin(request);
+    if (previewOrigin) return previewOrigin;
+  }
+  return 'https://flaim.app';
+}

--- a/workers/auth-worker/src/preview-url.ts
+++ b/workers/auth-worker/src/preview-url.ts
@@ -14,7 +14,10 @@ const VERCEL_PREVIEW_PATTERN = /^https:\/\/flaim(-[a-z0-9-]+)?\.vercel\.app$/;
  * Returns the origin if it matches the preview URL pattern, undefined otherwise.
  */
 export function resolvePreviewOrigin(request: Request): string | undefined {
-  const origin = request.headers.get('Origin') || request.headers.get('Referer');
+  // Check X-Forwarded-Origin first (set by Next.js API proxies), then standard headers
+  const origin = request.headers.get('X-Forwarded-Origin')
+    || request.headers.get('Origin')
+    || request.headers.get('Referer');
   if (!origin) return undefined;
   const url = origin.startsWith('http') ? new URL(origin).origin : origin;
   return VERCEL_PREVIEW_PATTERN.test(url) ? url : undefined;

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -18,6 +18,7 @@
  */
 
 import { YahooStorage } from './yahoo-storage';
+import { getFrontendUrl, resolvePreviewOrigin } from './preview-url';
 
 // =============================================================================
 // TYPES
@@ -64,28 +65,7 @@ function getCallbackUrl(env: YahooConnectEnv): string {
   return 'https://api.flaim.app/auth/connect/yahoo/callback';
 }
 
-/**
- * Get the frontend URL for redirects after OAuth flow
- */
-function getFrontendUrl(env: YahooConnectEnv, request?: Request): string {
-  if (env.FRONTEND_URL) {
-    return env.FRONTEND_URL.replace(/\/$/, '');
-  }
-  if (env.ENVIRONMENT === 'dev' || env.NODE_ENV === 'development') {
-    return 'http://localhost:3000';
-  }
-  // In preview, use the request origin if it's a Vercel preview URL
-  if (env.ENVIRONMENT === 'preview' && request) {
-    const origin = request.headers.get('Origin') || request.headers.get('Referer');
-    if (origin) {
-      const url = origin.startsWith('http') ? new URL(origin).origin : origin;
-      if (/^https:\/\/flaim(-[a-z0-9-]+)?\.vercel\.app$/.test(url)) {
-        return url;
-      }
-    }
-  }
-  return 'https://flaim.app';
-}
+// getFrontendUrl imported from ./preview-url
 
 /**
  * Generate a random nonce for CSRF protection
@@ -126,16 +106,9 @@ export async function handleYahooAuthorize(
     const state = `${userId}:${nonce}`;
 
     // In preview, store the frontend origin so the callback can redirect back
-    let redirectAfter: string | undefined;
-    if (env.ENVIRONMENT === 'preview' && request) {
-      const origin = request.headers.get('Origin') || request.headers.get('Referer');
-      if (origin) {
-        const url = origin.startsWith('http') ? new URL(origin).origin : origin;
-        if (/^https:\/\/flaim(-[a-z0-9-]+)?\.vercel\.app$/.test(url)) {
-          redirectAfter = url;
-        }
-      }
-    }
+    const redirectAfter = (env.ENVIRONMENT === 'preview' && request)
+      ? resolvePreviewOrigin(request)
+      : undefined;
 
     // Store state for validation in callback
     await storage.createPlatformOAuthState({

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -67,12 +67,22 @@ function getCallbackUrl(env: YahooConnectEnv): string {
 /**
  * Get the frontend URL for redirects after OAuth flow
  */
-function getFrontendUrl(env: YahooConnectEnv): string {
+function getFrontendUrl(env: YahooConnectEnv, request?: Request): string {
   if (env.FRONTEND_URL) {
     return env.FRONTEND_URL.replace(/\/$/, '');
   }
   if (env.ENVIRONMENT === 'dev' || env.NODE_ENV === 'development') {
     return 'http://localhost:3000';
+  }
+  // In preview, use the request origin if it's a Vercel preview URL
+  if (env.ENVIRONMENT === 'preview' && request) {
+    const origin = request.headers.get('Origin') || request.headers.get('Referer');
+    if (origin) {
+      const url = origin.startsWith('http') ? new URL(origin).origin : origin;
+      if (/^https:\/\/flaim(-[a-z0-9-]+)?\.vercel\.app$/.test(url)) {
+        return url;
+      }
+    }
   }
   return 'https://flaim.app';
 }
@@ -105,7 +115,8 @@ function maskUserId(userId: string): string {
 export async function handleYahooAuthorize(
   env: YahooConnectEnv,
   userId: string,
-  corsHeaders: Record<string, string>
+  corsHeaders: Record<string, string>,
+  request?: Request
 ): Promise<Response> {
   try {
     const storage = YahooStorage.fromEnvironment(env);
@@ -114,12 +125,25 @@ export async function handleYahooAuthorize(
     const nonce = generateNonce();
     const state = `${userId}:${nonce}`;
 
+    // In preview, store the frontend origin so the callback can redirect back
+    let redirectAfter: string | undefined;
+    if (env.ENVIRONMENT === 'preview' && request) {
+      const origin = request.headers.get('Origin') || request.headers.get('Referer');
+      if (origin) {
+        const url = origin.startsWith('http') ? new URL(origin).origin : origin;
+        if (/^https:\/\/flaim(-[a-z0-9-]+)?\.vercel\.app$/.test(url)) {
+          redirectAfter = url;
+        }
+      }
+    }
+
     // Store state for validation in callback
     await storage.createPlatformOAuthState({
       state,
       clerkUserId: userId,
       platform: 'yahoo',
       expiresInSeconds: 600, // 10 minutes
+      redirectAfter,
     });
 
     // Build Yahoo OAuth URL
@@ -170,7 +194,7 @@ export async function handleYahooCallback(
   const state = url.searchParams.get('state');
   const errorParam = url.searchParams.get('error');
 
-  const frontendUrl = getFrontendUrl(env);
+  let frontendUrl = getFrontendUrl(env);
 
   // Helper for error redirects
   const errorRedirect = (error: string, description?: string) => {
@@ -213,6 +237,11 @@ export async function handleYahooCallback(
     }
 
     const { clerkUserId } = stateData;
+
+    // Use stored redirect origin for preview deployments
+    if (stateData.redirectAfter) {
+      frontendUrl = stateData.redirectAfter;
+    }
 
     // Exchange code for tokens
     const tokenResponse = await exchangeCodeForTokens(code, env);

--- a/workers/auth-worker/wrangler.jsonc
+++ b/workers/auth-worker/wrangler.jsonc
@@ -108,8 +108,7 @@
       // Note: SUPABASE_URL and SUPABASE_SERVICE_KEY set via Cloudflare secrets
       "vars": {
         "NODE_ENV": "production",
-        "ENVIRONMENT": "preview",
-        "FRONTEND_URL": "https://flaim.app"
+        "ENVIRONMENT": "preview"
       }
     },
     // Development environment (local)


### PR DESCRIPTION
## Summary
- Add guide pages for GEO (guide overview, ESPN, Yahoo, Sleeper) with HowTo JSON-LD
- Add FAQPage JSON-LD to homepage, SoftwareApplication JSON-LD to root layout
- Update meta description, add sitemap routes, robots.txt, llms.txt
- Add Guide link to footer
- Split Clerk keys for preview (dev instance) vs production
- Dynamic frontend URL resolution in auth-worker for preview deploys
- Update ARCHITECTURE.md deployment docs

## Test plan
- [ ] Verify all guide pages render on preview
- [ ] Verify Clerk sign-in works on preview URL
- [ ] Verify production site unchanged at flaim.app
- [ ] Validate JSON-LD with Google Rich Results Test
- [ ] Check sitemap includes new routes
- [ ] Verify llms.txt accessible at /llms.txt

🤖 Generated with [Claude Code](https://claude.com/claude-code)