### PR TITLE
Remove public_ prefix from Supabase table name references

### DIFF
--- a/web/lib/server/public-chat-cache.ts
+++ b/web/lib/server/public-chat-cache.ts
@@ -55,7 +55,7 @@ async function readCacheEntry(cacheKey: string): Promise<PublicChatCacheEntry | 
   }
 
   const { supabaseUrl, supabaseServiceKey } = getSupabaseConfig();
-  const url = new URL(`${supabaseUrl}/rest/v1/public_chat_context_cache`);
+  const url = new URL(`${supabaseUrl}/rest/v1/chat_context_cache`);
   url.searchParams.set("cache_key", `eq.${cacheKey}`);
   url.searchParams.set("select", "cache_key,context_text,expires_at,updated_at");
   url.searchParams.set("limit", "1");
@@ -89,7 +89,7 @@ async function writeCacheEntry(input: {
   }
 
   const { supabaseUrl, supabaseServiceKey } = getSupabaseConfig();
-  const response = await fetch(`${supabaseUrl}/rest/v1/public_chat_context_cache`, {
+  const response = await fetch(`${supabaseUrl}/rest/v1/chat_context_cache`, {
     method: "POST",
     headers: {
       apikey: supabaseServiceKey,

--- a/web/lib/server/public-demo-answer-cache.ts
+++ b/web/lib/server/public-demo-answer-cache.ts
@@ -192,7 +192,7 @@ export async function getCachedPublicDemoAnswer(input: {
 
   const { supabaseUrl, supabaseServiceKey } = getSupabaseConfig();
   const cacheKey = buildPublicDemoAnswerCacheKey(input.presetId, input.sport);
-  const url = new URL(`${supabaseUrl}/rest/v1/public_demo_answer_cache`);
+  const url = new URL(`${supabaseUrl}/rest/v1/demo_answer_cache`);
   url.searchParams.set("cache_key", `eq.${cacheKey}`);
   url.searchParams.set(
     "select",
@@ -252,7 +252,7 @@ export async function getLatestPublicDemoRefreshFailure(input: {
   }
 
   const { supabaseUrl, supabaseServiceKey } = getSupabaseConfig();
-  const url = new URL(`${supabaseUrl}/rest/v1/public_demo_refresh_runs`);
+  const url = new URL(`${supabaseUrl}/rest/v1/demo_refresh_runs`);
   url.searchParams.set("preset_id", `eq.${input.presetId}`);
   url.searchParams.set("sport", `eq.${input.sport}`);
   url.searchParams.set(

--- a/workers/auth-worker/src/public-chat-storage.ts
+++ b/workers/auth-worker/src/public-chat-storage.ts
@@ -92,7 +92,7 @@ export class PublicChatStorage {
 
   async recordRejectedRun(input: RecordRejectedPublicChatRunInput): Promise<void> {
     const { error } = await this.supabase
-      .from('public_chat_runs')
+      .from('chat_runs')
       .insert({
         visitor_key: input.visitorKey,
         preset_id: input.presetId,


### PR DESCRIPTION
## Summary

Renames four table references across the web app and auth-worker to match a coordinated Supabase schema migration:

| Old table name | New table name |
|---|---|
| `public_demo_answer_cache` | `demo_answer_cache` |
| `public_demo_refresh_runs` | `demo_refresh_runs` |
| `public_chat_context_cache` | `chat_context_cache` |
| `public_chat_runs` | `chat_runs` |

The `public_` prefix is redundant — the schema already provides namespacing, and every other table in the database follows the unprefixed convention.

Note: the Postgres function names (`acquire_public_chat_run`, `complete_public_chat_run`) are **not** renamed here — their bodies are updated as part of the Supabase DDL migration, but their names are unchanged so auth-worker RPC calls continue to work.

## Files changed

- `web/lib/server/public-chat-cache.ts` — 2 references (`chat_context_cache`)
- `web/lib/server/public-demo-answer-cache.ts` — 2 references (`demo_answer_cache`, `demo_refresh_runs`)
- `workers/auth-worker/src/public-chat-storage.ts` — 1 reference (`chat_runs`)

## ⚠️ Merge sequence — read before merging

This PR must be coordinated with [flaim-demo#3](https://github.com/jdguggs10/flaim-demo/pull/3) and the Supabase DDL migration.

**Required order:**
1. Merge this PR → wait for Vercel + auth-worker to deploy (~3-5 min)
2. Merge flaim-demo PR → wait for Pi to deploy (~2-3 min)
3. Immediately run Supabase DDL migration (ALTER TABLE renames + function body updates)

The window between step 2 and 3 is the only breakage window (~1-2 min).

## Test plan

- [x] `npx tsc --noEmit` — no source errors
- [ ] Merge in coordination with flaim-demo#3 and DDL migration
- [ ] Confirm homepage demo tiles load after deploy
- [ ] Confirm auth-worker `acquire_public_chat_run` RPC succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)