### PR TITLE
FLA-55: Centralize OAuth redirect URI validation in @flaim/worker-shared

### DIFF
--- a/web/app/(site)/oauth/consent/page.tsx
+++ b/web/app/(site)/oauth/consent/page.tsx
@@ -5,59 +5,10 @@ import { useSearchParams, useRouter } from 'next/navigation';
 import { useAuth, SignIn } from '@clerk/nextjs';
 import ConsentScreen from '@/components/site/connectors/ConsentScreen';
 import { Loader2 } from 'lucide-react';
+import { isValidRedirectUri } from '@flaim/worker-shared';
 
 // League checking removed - OAuth consent should work regardless of fantasy setup
 // Tools handle missing configuration gracefully when called
-
-// Must stay in sync with workers/auth-worker/src/oauth-handlers.ts isValidRedirectUri()
-const ALLOWED_REDIRECT_HOSTS = [
-  'claude.ai',
-  'claude.com',
-  'cdn.claude.ai',
-  'chatgpt.com',
-  'platform.openai.com',
-  'gemini.google.com',
-  'perplexity.ai',
-  'perplexity.com',
-  'vscode.dev',
-];
-
-const ALLOWED_LOOPBACK_PATHS = new Set([
-  '/callback',
-  '/oauth/callback',
-  '/oauth2callback',
-  '/windsurf-auth-callback',
-]);
-
-function isAllowedRedirectUri(uri: string): boolean {
-  try {
-    const url = new URL(uri);
-
-    // HTTPS host allowlist (covers Claude, ChatGPT, OpenAI, Gemini, Perplexity, VS Code)
-    if (url.protocol === 'https:') {
-      return ALLOWED_REDIRECT_HOSTS.some(
-        host => url.hostname === host || url.hostname.endsWith('.' + host)
-      );
-    }
-
-    // Loopback callbacks for desktop/CLI apps (RFC 8252)
-    if (url.protocol === 'http:') {
-      const isLoopback = url.hostname === 'localhost' || url.hostname === '127.0.0.1';
-      const isCallback = ALLOWED_LOOPBACK_PATHS.has(url.pathname);
-      const isClean = !url.search && !url.hash;
-      return isLoopback && isCallback && isClean;
-    }
-
-    // Cursor IDE custom URI scheme
-    if (uri.startsWith('cursor://anysphere.cursor-')) {
-      return uri.includes('/oauth/') && uri.endsWith('/callback') && !uri.includes('?') && !uri.includes('#');
-    }
-
-    return false;
-  } catch {
-    return false;
-  }
-}
 
 function LoadingFallback() {
   return (
@@ -92,7 +43,7 @@ function OAuthConsentContent() {
   // Validate required params
   const isValidRequest = oauthParams.redirectUri
     && oauthParams.codeChallenge
-    && isAllowedRedirectUri(oauthParams.redirectUri);
+    && isValidRedirectUri(oauthParams.redirectUri);
 
   // League checking removed - tools handle missing configuration when called
 
@@ -134,7 +85,7 @@ function OAuthConsentContent() {
 
   // Handle "Deny" - redirect to Claude with error
   const handleDeny = () => {
-    if (oauthParams.redirectUri && isAllowedRedirectUri(oauthParams.redirectUri)) {
+    if (oauthParams.redirectUri && isValidRedirectUri(oauthParams.redirectUri)) {
       const url = new URL(oauthParams.redirectUri);
       url.searchParams.set('error', 'access_denied');
       url.searchParams.set('error_description', 'User denied the authorization request');

--- a/web/app/(site)/oauth/consent/page.tsx
+++ b/web/app/(site)/oauth/consent/page.tsx
@@ -86,13 +86,19 @@ function OAuthConsentContent() {
   // Handle "Deny" - redirect to Claude with error
   const handleDeny = () => {
     if (oauthParams.redirectUri && isValidRedirectUri(oauthParams.redirectUri)) {
-      const url = new URL(oauthParams.redirectUri);
-      url.searchParams.set('error', 'access_denied');
-      url.searchParams.set('error_description', 'User denied the authorization request');
-      if (oauthParams.state) {
-        url.searchParams.set('state', oauthParams.state);
+      try {
+        const url = new URL(oauthParams.redirectUri);
+        url.searchParams.set('error', 'access_denied');
+        url.searchParams.set('error_description', 'User denied the authorization request');
+        if (oauthParams.state) {
+          url.searchParams.set('state', oauthParams.state);
+        }
+        window.location.href = url.toString();
+      } catch {
+        // URI passed validation but browser URL API can't parse it (e.g. cursor://).
+        // Custom-scheme clients handle the error on their end via timeout.
+        router.push('/');
       }
-      window.location.href = url.toString();
     } else {
       router.push('/');
     }

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
+  transpilePackages: ['@flaim/worker-shared'],
   devIndicators: false,
   async redirects() {
     return [

--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@flaim/worker-shared": "*",
+    "@flaim/worker-shared": "workspace:*",
     "@clerk/nextjs": "^6.36.7",
     "@clerk/themes": "^2.4.51",
     "@radix-ui/react-dialog": "^1.1.14",

--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@flaim/worker-shared": "workspace:*",
+    "@flaim/worker-shared": "*",
     "@clerk/nextjs": "^6.36.7",
     "@clerk/themes": "^2.4.51",
     "@radix-ui/react-dialog": "^1.1.14",

--- a/web/package.json
+++ b/web/package.json
@@ -12,6 +12,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@flaim/worker-shared": "*",
     "@clerk/nextjs": "^6.36.7",
     "@clerk/themes": "^2.4.51",
     "@radix-ui/react-dialog": "^1.1.14",

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -25,6 +25,10 @@
     "paths": {
       "@/*": ["./*"],
       "@/components/ui": ["components/ui"],
+      // Intentionally points at the single browser-safe file, not the package root.
+      // workers/shared/src/index.ts pulls in types.ts which uses Cloudflare's Fetcher
+      // type — not available in the web environment. If you add more web imports from
+      // @flaim/worker-shared, extend this alias rather than switching to the package root.
       "@flaim/worker-shared": ["../workers/shared/src/oauth-redirect"]
     }
   },

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -24,7 +24,8 @@
     ],
     "paths": {
       "@/*": ["./*"],
-      "@/components/ui": ["components/ui"]
+      "@/components/ui": ["components/ui"],
+      "@flaim/worker-shared": ["../workers/shared/src/oauth-redirect"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],

--- a/workers/README.md
+++ b/workers/README.md
@@ -173,6 +173,7 @@ Note: `espn-client` is called internally via service binding for MCP traffic, bu
 | 424 from Responses API | MCP transport/protocol mismatch | Ensure `server_url` is `https://api.flaim.app/mcp`, calls are POST-based, and deployed `fantasy-mcp` includes stream-mode MCP responses plus non-POST `405` handling |
 | `EMFILE: too many open files, watch` | File descriptor limit too low for dev watchers | Run `ulimit -n 8192` (or higher) and restart `wrangler dev` |
 | `EPERM` writing Wrangler logs/registry | Global Wrangler directory not writable | Use `WRANGLER_LOG_PATH` + `WRANGLER_REGISTRY_PATH` env vars |
+| Worker logs missing from CF Observability despite `observability.enabled: true` | `observability.enabled` alone does not enable console.log capture | Add `"logs": { "enabled": true, "head_sampling_rate": 1 }` sub-key inside `observability` in every env block of `wrangler.jsonc` |
 
 ## Architecture
 

--- a/workers/auth-worker/src/__tests__/oauth-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/oauth-handlers.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { handleAuthorize, handleClientRegistration, handleMetadataDiscovery, isValidRedirectUri, validateOAuthToken } from '../oauth-handlers';
+import { handleAuthorize, handleClientRegistration, handleMetadataDiscovery, validateOAuthToken } from '../oauth-handlers';
+import { isValidRedirectUri } from '@flaim/worker-shared';
 import { handleToken } from '../oauth-handlers';
 import { OAuthStorage } from '../oauth-storage';
 import type { OAuthEnv } from '../oauth-handlers';

--- a/workers/auth-worker/src/oauth-handlers.ts
+++ b/workers/auth-worker/src/oauth-handlers.ts
@@ -19,6 +19,8 @@
 
 import { OAuthStorage } from './oauth-storage';
 import { getFrontendUrl } from './preview-url';
+import { isValidRedirectUri } from '@flaim/worker-shared';
+export { isValidRedirectUri };
 
 // =============================================================================
 // TYPES
@@ -57,56 +59,8 @@ interface TokenRequest {
 // CONFIGURATION
 // =============================================================================
 
-// Claude OAuth callback URLs (allowlist these)
-// Static allowlist for known OAuth redirect URIs.
-// Dynamic patterns (ChatGPT connectors, Cursor, loopback) are handled by
-// dedicated validators below — see isValidRedirectUri().
-const ALLOWED_REDIRECT_URIS = [
-  // Claude.ai web + Claude Desktop (both route through claude.ai)
-  'https://claude.ai/api/mcp/auth_callback',
-  'https://claude.com/api/mcp/auth_callback',
-  // ChatGPT MCP connectors (dynamic per-app paths matched below)
-  'https://chatgpt.com/connector_platform_oauth_redirect',
-  'https://platform.openai.com/apps-manage/oauth',
-  // Perplexity custom connectors (pattern matched below for all subdomains)
-  // VS Code / GitHub Copilot
-  'http://127.0.0.1:33418',
-  'https://vscode.dev/redirect',
-  // For local development/testing (MCP Inspector, etc.)
-  'http://localhost:3000/oauth/callback',
-  'http://localhost:6274/oauth/callback',
-];
-
-// Check if a redirect URI is a valid loopback callback (RFC 8252).
-// Accepts dynamic ports on localhost/127.0.0.1 with known callback paths.
-// Covers: Claude Code, Gemini CLI, Windsurf, and other MCP CLI/desktop clients.
-const ALLOWED_LOOPBACK_PATHS = new Set([
-  '/callback',              // Claude Code
-  '/oauth/callback',        // Claude Code (alt), MCP Inspector
-  '/oauth2callback',        // Gemini CLI
-  '/windsurf-auth-callback', // Windsurf
-]);
-
-function isLoopbackRedirectUri(uri: string): boolean {
-  try {
-    const parsed = new URL(uri);
-    // Check for http scheme (required for loopback)
-    if (parsed.protocol !== 'http:') return false;
-    // Check for loopback hostname
-    const isLoopback = parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1';
-    // Check path against known callback paths
-    const isCallback = ALLOWED_LOOPBACK_PATHS.has(parsed.pathname);
-    // Reject URIs with query strings or fragments (prevent open redirect)
-    const isClean = !parsed.search && !parsed.hash;
-    return isLoopback && isCallback && isClean;
-  } catch {
-    return false;
-  }
-}
-
 // OAuth client ID (static for now, no DCR)
 const OAUTH_CLIENT_ID = 'flaim-mcp';
-
 
 // Base URL for OAuth endpoints (used in metadata)
 const getBaseUrl = (env: OAuthEnv): string => {
@@ -119,75 +73,6 @@ const getBaseUrl = (env: OAuthEnv): string => {
 // =============================================================================
 // UTILITIES
 // =============================================================================
-
-export function isValidRedirectUri(uri: string): boolean {
-  // Exact match against static allowlist
-  if (ALLOWED_REDIRECT_URIS.includes(uri)) return true;
-
-  // ChatGPT dev-mode apps generate unique per-app callback paths
-  if (isChatGptConnectorUri(uri)) return true;
-
-  // Perplexity uses multiple domains (www.perplexity.ai, www.perplexity.com, enterprise.perplexity.ai, etc.)
-  if (isPerplexityRedirectUri(uri)) return true;
-
-  // Cursor IDE uses a custom URI scheme
-  if (isCursorRedirectUri(uri)) return true;
-
-  // Dynamic loopback URIs for CLI/desktop apps (RFC 8252)
-  return isLoopbackRedirectUri(uri);
-}
-
-// ChatGPT Actions/connectors generate dynamic per-app callback paths
-function isChatGptConnectorUri(uri: string): boolean {
-  try {
-    const parsed = new URL(uri);
-    return (
-      parsed.protocol === 'https:' &&
-      parsed.hostname === 'chatgpt.com' &&
-      parsed.pathname.startsWith('/connector/oauth/') &&
-      !parsed.search &&
-      !parsed.hash
-    );
-  } catch {
-    return false;
-  }
-}
-
-// Perplexity uses multiple domains/subdomains (www.perplexity.ai, www.perplexity.com,
-// enterprise.perplexity.ai, etc.) — match any *.perplexity.{ai,com} with the known path.
-function isPerplexityRedirectUri(uri: string): boolean {
-  try {
-    const parsed = new URL(uri);
-    if (parsed.protocol !== 'https:') return false;
-    const host = parsed.hostname;
-    const isPerplexity =
-      (host === 'perplexity.ai' || host.endsWith('.perplexity.ai') ||
-       host === 'perplexity.com' || host.endsWith('.perplexity.com'));
-    const isCallbackPath = parsed.pathname === '/rest/connections/oauth_callback';
-    return isPerplexity && isCallbackPath && !parsed.search && !parsed.hash;
-  } catch {
-    return false;
-  }
-}
-
-// Cursor IDE uses cursor:// custom URI scheme for MCP OAuth
-// Pattern: cursor://anysphere.cursor-mcp/oauth/{id}/callback
-function isCursorRedirectUri(uri: string): boolean {
-  try {
-    // URL constructor doesn't handle custom schemes well, so parse manually
-    if (!uri.startsWith('cursor://')) return false;
-    const withoutScheme = uri.slice('cursor://'.length);
-    // Must start with known Cursor host prefix
-    if (!withoutScheme.startsWith('anysphere.cursor-')) return false;
-    // Must end with /callback and contain /oauth/
-    if (!withoutScheme.includes('/oauth/') || !withoutScheme.endsWith('/callback')) return false;
-    // Reject query strings or fragments
-    if (uri.includes('?') || uri.includes('#')) return false;
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 function buildErrorRedirect(redirectUri: string, error: string, description: string, state?: string): string {
   const url = new URL(redirectUri);

--- a/workers/auth-worker/src/oauth-handlers.ts
+++ b/workers/auth-worker/src/oauth-handlers.ts
@@ -20,7 +20,6 @@
 import { OAuthStorage } from './oauth-storage';
 import { getFrontendUrl } from './preview-url';
 import { isValidRedirectUri } from '@flaim/worker-shared';
-export { isValidRedirectUri };
 
 // =============================================================================
 // TYPES

--- a/workers/auth-worker/wrangler.jsonc
+++ b/workers/auth-worker/wrangler.jsonc
@@ -5,18 +5,7 @@
   // Enable Cloudflare Workers Logs/Observability
   "observability": {
     "enabled": true,
-    "head_sampling_rate": 1,
-    "logs": {
-      "enabled": true,
-      "head_sampling_rate": 1,
-      "persist": true,
-      "invocation_logs": true
-    },
-    "traces": {
-      "enabled": true,
-      "persist": true,
-      "head_sampling_rate": 1
-    }
+    "head_sampling_rate": 1
   },
   // Required secrets (set via `wrangler secret put` or Cloudflare dashboard):
   // - SUPABASE_URL
@@ -30,6 +19,10 @@
     "prod": {
       "name": "auth-worker",
       "workers_dev": true, // Enable .workers.dev URL for worker-to-worker calls
+      "observability": {
+        "enabled": true,
+        "head_sampling_rate": 1
+      },
       // Cloudflare native rate limiting is configured per-environment.
       "ratelimits": [
         {
@@ -83,6 +76,10 @@
     "preview": {
       "name": "auth-worker-preview",
       "workers_dev": true, // Also keep workers.dev URL available
+      "observability": {
+        "enabled": true,
+        "head_sampling_rate": 1
+      },
       "ratelimits": [
         {
           "name": "TOKEN_RATE_LIMITER",

--- a/workers/auth-worker/wrangler.jsonc
+++ b/workers/auth-worker/wrangler.jsonc
@@ -5,7 +5,11 @@
   // Enable Cloudflare Workers Logs/Observability
   "observability": {
     "enabled": true,
-    "head_sampling_rate": 1
+    "head_sampling_rate": 1,
+    "logs": {
+      "enabled": true,
+      "head_sampling_rate": 1
+    }
   },
   // Required secrets (set via `wrangler secret put` or Cloudflare dashboard):
   // - SUPABASE_URL

--- a/workers/espn-client/wrangler.jsonc
+++ b/workers/espn-client/wrangler.jsonc
@@ -5,7 +5,11 @@
   // Enable Cloudflare Workers Logs/Observability
   "observability": {
     "enabled": true,
-    "head_sampling_rate": 1
+    "head_sampling_rate": 1,
+    "logs": {
+      "enabled": true,
+      "head_sampling_rate": 1
+    }
   },
   // Environment configurations
   "env": {

--- a/workers/espn-client/wrangler.jsonc
+++ b/workers/espn-client/wrangler.jsonc
@@ -5,18 +5,7 @@
   // Enable Cloudflare Workers Logs/Observability
   "observability": {
     "enabled": true,
-    "head_sampling_rate": 1,
-    "logs": {
-      "enabled": true,
-      "head_sampling_rate": 1,
-      "persist": true,
-      "invocation_logs": true
-    },
-    "traces": {
-      "enabled": true,
-      "persist": true,
-      "head_sampling_rate": 1
-    }
+    "head_sampling_rate": 1
   },
   // Environment configurations
   "env": {
@@ -24,6 +13,10 @@
     "prod": {
       "name": "espn-client",
       "workers_dev": false,
+      "observability": {
+        "enabled": true,
+        "head_sampling_rate": 1
+      },
       "kv_namespaces": [
         { "binding": "ESPN_PLAYERS_CACHE", "id": "8aed89c806d34c53aa5edf53c26f9d32", "preview_id": "ed5d96feef944254af880eafe9c131b3" }
       ],
@@ -42,6 +35,10 @@
     "preview": {
       "name": "espn-client-preview",
       "workers_dev": false,
+      "observability": {
+        "enabled": true,
+        "head_sampling_rate": 1
+      },
       "kv_namespaces": [
         { "binding": "ESPN_PLAYERS_CACHE", "id": "ed5d96feef944254af880eafe9c131b3", "preview_id": "ed5d96feef944254af880eafe9c131b3" }
       ],

--- a/workers/fantasy-mcp/wrangler.jsonc
+++ b/workers/fantasy-mcp/wrangler.jsonc
@@ -5,7 +5,11 @@
   // Enable Cloudflare Workers Logs/Observability
   "observability": {
     "enabled": true,
-    "head_sampling_rate": 1
+    "head_sampling_rate": 1,
+    "logs": {
+      "enabled": true,
+      "head_sampling_rate": 1
+    }
   },
   // Environment configurations
   "env": {

--- a/workers/fantasy-mcp/wrangler.jsonc
+++ b/workers/fantasy-mcp/wrangler.jsonc
@@ -5,18 +5,7 @@
   // Enable Cloudflare Workers Logs/Observability
   "observability": {
     "enabled": true,
-    "head_sampling_rate": 1,
-    "logs": {
-      "enabled": true,
-      "head_sampling_rate": 1,
-      "persist": true,
-      "invocation_logs": true
-    },
-    "traces": {
-      "enabled": true,
-      "persist": true,
-      "head_sampling_rate": 1
-    }
+    "head_sampling_rate": 1
   },
   // Environment configurations
   "env": {
@@ -24,6 +13,10 @@
     "prod": {
       "name": "fantasy-mcp",
       "workers_dev": true,
+      "observability": {
+        "enabled": true,
+        "head_sampling_rate": 1
+      },
       "routes": [
         {
           "pattern": "api.flaim.app/fantasy/*",
@@ -67,6 +60,10 @@
     "preview": {
       "name": "fantasy-mcp-preview",
       "workers_dev": true,
+      "observability": {
+        "enabled": true,
+        "head_sampling_rate": 1
+      },
       // Service bindings for platform workers
       "services": [
         { "binding": "ESPN", "service": "espn-client-preview" },

--- a/workers/shared/src/index.ts
+++ b/workers/shared/src/index.ts
@@ -61,3 +61,6 @@ export {
   withCorrelationId,
   withEvalHeaders,
 } from './tracing.js';
+
+// OAuth redirect URI validation
+export { isValidRedirectUri } from './oauth-redirect.js';

--- a/workers/shared/src/oauth-redirect.ts
+++ b/workers/shared/src/oauth-redirect.ts
@@ -83,21 +83,14 @@ function isPerplexityRedirectUri(uri: string): boolean {
 
 // Cursor IDE uses cursor:// custom URI scheme for MCP OAuth
 // Pattern: cursor://anysphere.cursor-mcp/oauth/{id}/callback
+// Uses string operations only — URL constructor does not handle custom schemes.
 function isCursorRedirectUri(uri: string): boolean {
-  try {
-    // URL constructor doesn't handle custom schemes well, so parse manually
-    if (!uri.startsWith('cursor://')) return false;
-    const withoutScheme = uri.slice('cursor://'.length);
-    // Must start with known Cursor host prefix
-    if (!withoutScheme.startsWith('anysphere.cursor-')) return false;
-    // Must end with /callback and contain /oauth/
-    if (!withoutScheme.includes('/oauth/') || !withoutScheme.endsWith('/callback')) return false;
-    // Reject query strings or fragments
-    if (uri.includes('?') || uri.includes('#')) return false;
-    return true;
-  } catch {
-    return false;
-  }
+  if (!uri.startsWith('cursor://')) return false;
+  const withoutScheme = uri.slice('cursor://'.length);
+  if (!withoutScheme.startsWith('anysphere.cursor-')) return false;
+  if (!withoutScheme.includes('/oauth/') || !withoutScheme.endsWith('/callback')) return false;
+  if (uri.includes('?') || uri.includes('#')) return false;
+  return true;
 }
 
 export function isValidRedirectUri(uri: string): boolean {

--- a/workers/shared/src/oauth-redirect.ts
+++ b/workers/shared/src/oauth-redirect.ts
@@ -1,0 +1,118 @@
+/**
+ * OAuth redirect URI validation — shared across auth-worker and web.
+ * Browser-safe: URL, Set, string ops only — zero imports.
+ * RFC 9700: exact-match + locked structural checks.
+ * RFC 8252: dynamic loopback port acceptance.
+ */
+
+const ALLOWED_REDIRECT_URIS = [
+  // Claude.ai web + Claude Desktop (both route through claude.ai)
+  'https://claude.ai/api/mcp/auth_callback',
+  'https://claude.com/api/mcp/auth_callback',
+  // ChatGPT MCP connectors (dynamic per-app paths matched below)
+  'https://chatgpt.com/connector_platform_oauth_redirect',
+  'https://platform.openai.com/apps-manage/oauth',
+  // Perplexity custom connectors (pattern matched below for all subdomains)
+  // VS Code / GitHub Copilot
+  'http://127.0.0.1:33418',
+  'https://vscode.dev/redirect',
+  // For local development/testing (MCP Inspector, etc.)
+  'http://localhost:3000/oauth/callback',
+  'http://localhost:6274/oauth/callback',
+];
+
+// Check if a redirect URI is a valid loopback callback (RFC 8252).
+// Accepts dynamic ports on localhost/127.0.0.1 with known callback paths.
+// Covers: Claude Code, Gemini CLI, Windsurf, and other MCP CLI/desktop clients.
+const ALLOWED_LOOPBACK_PATHS = new Set([
+  '/callback',              // Claude Code
+  '/oauth/callback',        // Claude Code (alt), MCP Inspector
+  '/oauth2callback',        // Gemini CLI
+  '/windsurf-auth-callback', // Windsurf
+]);
+
+function isLoopbackRedirectUri(uri: string): boolean {
+  try {
+    const parsed = new URL(uri);
+    // Check for http scheme (required for loopback)
+    if (parsed.protocol !== 'http:') return false;
+    // Check for loopback hostname
+    const isLoopback = parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1';
+    // Check path against known callback paths
+    const isCallback = ALLOWED_LOOPBACK_PATHS.has(parsed.pathname);
+    // Reject URIs with query strings or fragments (prevent open redirect)
+    const isClean = !parsed.search && !parsed.hash;
+    return isLoopback && isCallback && isClean;
+  } catch {
+    return false;
+  }
+}
+
+// ChatGPT Actions/connectors generate dynamic per-app callback paths
+function isChatGptConnectorUri(uri: string): boolean {
+  try {
+    const parsed = new URL(uri);
+    return (
+      parsed.protocol === 'https:' &&
+      parsed.hostname === 'chatgpt.com' &&
+      parsed.pathname.startsWith('/connector/oauth/') &&
+      !parsed.search &&
+      !parsed.hash
+    );
+  } catch {
+    return false;
+  }
+}
+
+// Perplexity uses multiple domains/subdomains (www.perplexity.ai, www.perplexity.com,
+// enterprise.perplexity.ai, etc.) — match any *.perplexity.{ai,com} with the known path.
+function isPerplexityRedirectUri(uri: string): boolean {
+  try {
+    const parsed = new URL(uri);
+    if (parsed.protocol !== 'https:') return false;
+    const host = parsed.hostname;
+    const isPerplexity =
+      (host === 'perplexity.ai' || host.endsWith('.perplexity.ai') ||
+       host === 'perplexity.com' || host.endsWith('.perplexity.com'));
+    const isCallbackPath = parsed.pathname === '/rest/connections/oauth_callback';
+    return isPerplexity && isCallbackPath && !parsed.search && !parsed.hash;
+  } catch {
+    return false;
+  }
+}
+
+// Cursor IDE uses cursor:// custom URI scheme for MCP OAuth
+// Pattern: cursor://anysphere.cursor-mcp/oauth/{id}/callback
+function isCursorRedirectUri(uri: string): boolean {
+  try {
+    // URL constructor doesn't handle custom schemes well, so parse manually
+    if (!uri.startsWith('cursor://')) return false;
+    const withoutScheme = uri.slice('cursor://'.length);
+    // Must start with known Cursor host prefix
+    if (!withoutScheme.startsWith('anysphere.cursor-')) return false;
+    // Must end with /callback and contain /oauth/
+    if (!withoutScheme.includes('/oauth/') || !withoutScheme.endsWith('/callback')) return false;
+    // Reject query strings or fragments
+    if (uri.includes('?') || uri.includes('#')) return false;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function isValidRedirectUri(uri: string): boolean {
+  // Exact match against static allowlist
+  if (ALLOWED_REDIRECT_URIS.includes(uri)) return true;
+
+  // ChatGPT dev-mode apps generate unique per-app callback paths
+  if (isChatGptConnectorUri(uri)) return true;
+
+  // Perplexity uses multiple domains (www.perplexity.ai, www.perplexity.com, enterprise.perplexity.ai, etc.)
+  if (isPerplexityRedirectUri(uri)) return true;
+
+  // Cursor IDE uses a custom URI scheme
+  if (isCursorRedirectUri(uri)) return true;
+
+  // Dynamic loopback URIs for CLI/desktop apps (RFC 8252)
+  return isLoopbackRedirectUri(uri);
+}

--- a/workers/sleeper-client/wrangler.jsonc
+++ b/workers/sleeper-client/wrangler.jsonc
@@ -5,7 +5,11 @@
   // Enable Cloudflare Workers Logs/Observability
   "observability": {
     "enabled": true,
-    "head_sampling_rate": 1
+    "head_sampling_rate": 1,
+    "logs": {
+      "enabled": true,
+      "head_sampling_rate": 1
+    }
   },
   "env": {
     "prod": {

--- a/workers/sleeper-client/wrangler.jsonc
+++ b/workers/sleeper-client/wrangler.jsonc
@@ -2,20 +2,19 @@
   "name": "sleeper-client",
   "main": "src/index.ts",
   "compatibility_date": "2024-12-01",
+  // Enable Cloudflare Workers Logs/Observability
   "observability": {
     "enabled": true,
-    "head_sampling_rate": 1,
-    "logs": {
-      "enabled": true,
-      "head_sampling_rate": 1,
-      "persist": true,
-      "invocation_logs": true
-    }
+    "head_sampling_rate": 1
   },
   "env": {
     "prod": {
       "name": "sleeper-client",
       "workers_dev": false,
+      "observability": {
+        "enabled": true,
+        "head_sampling_rate": 1
+      },
       "kv_namespaces": [
         { "binding": "SLEEPER_PLAYERS_CACHE", "id": "b34c0c797b7b4e1285458361694b8d5e", "preview_id": "81df4492a52c456c9f6362a5cc5a5816" }
       ],
@@ -31,6 +30,10 @@
     "preview": {
       "name": "sleeper-client-preview",
       "workers_dev": false,
+      "observability": {
+        "enabled": true,
+        "head_sampling_rate": 1
+      },
       "kv_namespaces": [
         { "binding": "SLEEPER_PLAYERS_CACHE", "id": "81df4492a52c456c9f6362a5cc5a5816", "preview_id": "81df4492a52c456c9f6362a5cc5a5816" }
       ],

--- a/workers/yahoo-client/wrangler.jsonc
+++ b/workers/yahoo-client/wrangler.jsonc
@@ -2,20 +2,19 @@
   "name": "yahoo-client",
   "main": "src/index.ts",
   "compatibility_date": "2024-12-01",
+  // Enable Cloudflare Workers Logs/Observability
   "observability": {
     "enabled": true,
-    "head_sampling_rate": 1,
-    "logs": {
-      "enabled": true,
-      "head_sampling_rate": 1,
-      "persist": true,
-      "invocation_logs": true
-    }
+    "head_sampling_rate": 1
   },
   "env": {
     "prod": {
       "name": "yahoo-client",
       "workers_dev": false,
+      "observability": {
+        "enabled": true,
+        "head_sampling_rate": 1
+      },
       "services": [
         { "binding": "AUTH_WORKER", "service": "auth-worker" }
       ],
@@ -28,6 +27,10 @@
     "preview": {
       "name": "yahoo-client-preview",
       "workers_dev": false,
+      "observability": {
+        "enabled": true,
+        "head_sampling_rate": 1
+      },
       "services": [
         { "binding": "AUTH_WORKER", "service": "auth-worker-preview" }
       ],

--- a/workers/yahoo-client/wrangler.jsonc
+++ b/workers/yahoo-client/wrangler.jsonc
@@ -5,7 +5,11 @@
   // Enable Cloudflare Workers Logs/Observability
   "observability": {
     "enabled": true,
-    "head_sampling_rate": 1
+    "head_sampling_rate": 1,
+    "logs": {
+      "enabled": true,
+      "head_sampling_rate": 1
+    }
   },
   "env": {
     "prod": {


### PR DESCRIPTION
## Summary

- Moves `isValidRedirectUri()` to `workers/shared/src/oauth-redirect.ts` — a browser-safe module with zero imports
- Web consent page's loose hostname-based `isAllowedRedirectUri()` replaced with the strict shared validator
- The deny path (`handleDeny`) now uses the same RFC 9700-compliant exact-match + structural checks as the server
- Auth-worker removes its local copy (~127 lines) and imports from shared, re-exporting for test compatibility

**Security fix:** `handleDeny()` does a bare `window.location.href` redirect with no server involvement — the frontend check was the only open-redirect defense on that path. The old web check accepted any path on allowed hostnames (e.g. `https://claude.ai/evil` would pass). Both surfaces now use identical validation.

**Also fixed in this branch:** `handleDeny` now catches `new URL()` throws for `cursor://` URIs (which pass validation via string ops but may throw in the browser URL API), with a `router.push('/')` fallback.

**Pre-existing issues filed:** FLA-87 (handleAllow crash screen), FLA-88 (buildErrorRedirect 500 for custom schemes in auth-worker).

## Test plan

- [ ] Merge to `preview` and verify OAuth consent flow at `preview.flaim.app/oauth/consent` with Claude, ChatGPT, and a loopback client
- [ ] Confirm Deny path redirects correctly (no open redirect, no dead button)
- [ ] Auth-worker tests: 187/187 pass (`cd workers/auth-worker && npm test`)
- [ ] Shared type-check clean (`cd workers/shared && npm run type-check`)

## Notes

- `web/tsconfig.json` path alias points to `oauth-redirect` directly (not package root) to avoid pulling in Cloudflare's `Fetcher` type — documented with a comment
- `transpilePackages: ['@flaim/worker-shared']` added to `web/next.config.ts` since the shared package ships raw TypeScript

🤖 Generated with [Claude Code](https://claude.com/claude-code)