### PR TITLE
Fix Yahoo refresh lease race handling

### DIFF
--- a/workers/auth-worker/src/__tests__/extension-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/extension-handlers.test.ts
@@ -1,0 +1,230 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  handleSyncCredentials,
+  handleGetExtensionStatus,
+  handleGetConnection,
+  type ExtensionEnv,
+} from '../extension-handlers';
+import { EspnSupabaseStorage } from '../supabase-storage';
+
+vi.mock('../supabase-storage', () => ({
+  EspnSupabaseStorage: {
+    fromEnvironment: vi.fn(),
+  },
+}));
+
+const env: ExtensionEnv = {
+  SUPABASE_URL: 'https://example.supabase.co',
+  SUPABASE_SERVICE_KEY: 'test-key',
+  NODE_ENV: 'test',
+  ENVIRONMENT: 'test',
+};
+
+const corsHeaders = { 'Access-Control-Allow-Origin': '*' };
+const userId = 'user_abc123';
+
+const VALID_SWID = '{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}';
+const VALID_S2 = 'A'.repeat(60);
+
+describe('handleSyncCredentials', () => {
+  let mockStorage: {
+    setCredentials: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStorage = { setCredentials: vi.fn().mockResolvedValue(true) };
+    vi.mocked(EspnSupabaseStorage.fromEnvironment).mockReturnValue(
+      mockStorage as unknown as EspnSupabaseStorage
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns 200 and stores valid credentials', async () => {
+    const req = new Request('https://api.flaim.app/extension/sync', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ swid: VALID_SWID, s2: VALID_S2 }),
+    });
+
+    const res = await handleSyncCredentials(req, env, userId, corsHeaders);
+    expect(res.status).toBe(200);
+
+    const body = await res.json() as { success?: boolean };
+    expect(body.success).toBe(true);
+    expect(mockStorage.setCredentials).toHaveBeenCalledWith(userId, VALID_SWID, VALID_S2);
+  });
+
+  it('returns 400 when swid is missing', async () => {
+    const req = new Request('https://api.flaim.app/extension/sync', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ s2: VALID_S2 }),
+    });
+
+    const res = await handleSyncCredentials(req, env, userId, corsHeaders);
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error?: string };
+    expect(body.error).toBe('invalid_request');
+  });
+
+  it('returns 400 when s2 is missing', async () => {
+    const req = new Request('https://api.flaim.app/extension/sync', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ swid: VALID_SWID }),
+    });
+
+    const res = await handleSyncCredentials(req, env, userId, corsHeaders);
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error?: string };
+    expect(body.error).toBe('invalid_request');
+  });
+
+  it('returns 400 for invalid SWID format (no curly braces)', async () => {
+    const req = new Request('https://api.flaim.app/extension/sync', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ swid: 'A1B2C3D4-E5F6-7890-ABCD-EF1234567890', s2: VALID_S2 }),
+    });
+
+    const res = await handleSyncCredentials(req, env, userId, corsHeaders);
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error_description?: string };
+    expect(body.error_description).toContain('SWID');
+  });
+
+  it('returns 400 for s2 that is too short', async () => {
+    const req = new Request('https://api.flaim.app/extension/sync', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ swid: VALID_SWID, s2: 'tooshort' }),
+    });
+
+    const res = await handleSyncCredentials(req, env, userId, corsHeaders);
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error_description?: string };
+    expect(body.error_description).toContain('espn_s2');
+  });
+
+  it('returns 500 when storage fails to save', async () => {
+    mockStorage.setCredentials.mockResolvedValue(false);
+
+    const req = new Request('https://api.flaim.app/extension/sync', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ swid: VALID_SWID, s2: VALID_S2 }),
+    });
+
+    const res = await handleSyncCredentials(req, env, userId, corsHeaders);
+    expect(res.status).toBe(500);
+    const body = await res.json() as { error?: string };
+    expect(body.error).toBe('server_error');
+  });
+});
+
+describe('handleGetExtensionStatus', () => {
+  let mockStorage: {
+    hasCredentials: ReturnType<typeof vi.fn>;
+    getCredentialMetadata: ReturnType<typeof vi.fn>;
+    getUserPreferences: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStorage = {
+      hasCredentials: vi.fn().mockResolvedValue(true),
+      getCredentialMetadata: vi.fn().mockResolvedValue({ hasCredentials: true, lastUpdated: '2025-01-01T00:00:00Z' }),
+      getUserPreferences: vi.fn().mockResolvedValue({
+        defaultSport: 'football',
+        defaultFootball: null,
+        defaultBaseball: null,
+        defaultBasketball: null,
+        defaultHockey: null,
+      }),
+    };
+    vi.mocked(EspnSupabaseStorage.fromEnvironment).mockReturnValue(
+      mockStorage as unknown as EspnSupabaseStorage
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns connected status with credentials and preferences', async () => {
+    const res = await handleGetExtensionStatus(env, userId, corsHeaders);
+    expect(res.status).toBe(200);
+
+    const body = await res.json() as {
+      success?: boolean;
+      connected?: boolean;
+      hasCredentials?: boolean;
+      lastSync?: string | null;
+      preferences?: { defaultSport?: string };
+    };
+    expect(body.success).toBe(true);
+    expect(body.connected).toBe(true);
+    expect(body.hasCredentials).toBe(true);
+    expect(body.lastSync).toBe('2025-01-01T00:00:00Z');
+    expect(body.preferences?.defaultSport).toBe('football');
+  });
+
+  it('returns hasCredentials false when no credentials stored', async () => {
+    mockStorage.hasCredentials.mockResolvedValue(false);
+    mockStorage.getCredentialMetadata.mockResolvedValue({ hasCredentials: false });
+
+    const res = await handleGetExtensionStatus(env, userId, corsHeaders);
+    expect(res.status).toBe(200);
+
+    const body = await res.json() as { hasCredentials?: boolean };
+    expect(body.hasCredentials).toBe(false);
+  });
+});
+
+describe('handleGetConnection', () => {
+  let mockStorage: {
+    hasCredentials: ReturnType<typeof vi.fn>;
+    getCredentialMetadata: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStorage = {
+      hasCredentials: vi.fn().mockResolvedValue(true),
+      getCredentialMetadata: vi.fn().mockResolvedValue({ hasCredentials: true, lastUpdated: '2025-06-01T00:00:00Z' }),
+    };
+    vi.mocked(EspnSupabaseStorage.fromEnvironment).mockReturnValue(
+      mockStorage as unknown as EspnSupabaseStorage
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns connected=true when credentials exist', async () => {
+    const res = await handleGetConnection(env, userId, corsHeaders);
+    expect(res.status).toBe(200);
+
+    const body = await res.json() as { success?: boolean; connected?: boolean; token?: null; lastSync?: string };
+    expect(body.success).toBe(true);
+    expect(body.connected).toBe(true);
+    expect(body.token).toBeNull();
+    expect(body.lastSync).toBe('2025-06-01T00:00:00Z');
+  });
+
+  it('returns connected=false when no credentials exist', async () => {
+    mockStorage.hasCredentials.mockResolvedValue(false);
+    mockStorage.getCredentialMetadata.mockResolvedValue(null);
+
+    const res = await handleGetConnection(env, userId, corsHeaders);
+    expect(res.status).toBe(200);
+
+    const body = await res.json() as { connected?: boolean };
+    expect(body.connected).toBe(false);
+  });
+});

--- a/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
@@ -520,7 +520,7 @@ describe('yahoo-connect-handlers', () => {
       expect(mockFetch).not.toHaveBeenCalled();
     });
 
-    it('loser: lease expires before winner writes, token still stale → refresh_failed', async () => {
+    it('loser: lease expires before winner writes, then reacquires and refreshes', async () => {
       const stale = {
         clerkUserId: 'user_123',
         accessToken: 'old-token',
@@ -531,15 +531,131 @@ describe('yahoo-connect-handlers', () => {
         refreshLeaseExpiresAt: new Date(Date.now() - 1), // already expired — skips loop
       };
 
-      mockStorage.getYahooCredentials.mockResolvedValue(stale);
+      mockStorage.getYahooCredentials
+        .mockResolvedValueOnce(stale)
+        .mockResolvedValueOnce(stale);
+      mockStorage.acquireRefreshLease
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true);
+      mockStorage.updateYahooCredentials.mockResolvedValue(true);
+      mockFetch.mockResolvedValue(
+        new Response(
+          JSON.stringify({ access_token: 'recovered-token', refresh_token: 'new-refresh', expires_in: 3600 }),
+          { status: 200 }
+        )
+      );
+
+      const response = await handleYahooCredentials(env, 'user_123', corsHeaders);
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.access_token).toBe('recovered-token');
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('loser: stale pre-race lease rereads current winner lease before waiting', async () => {
+      const stalePreRaceLease = {
+        clerkUserId: 'user_123',
+        accessToken: 'old-token',
+        refreshToken: 'old-refresh',
+        expiresAt: new Date(Date.now() + 2 * 60 * 1000),
+        needsRefresh: true,
+        refreshLeaseOwner: 'expired-owner',
+        refreshLeaseExpiresAt: new Date(Date.now() - 1),
+      };
+      const currentWinnerLease = {
+        clerkUserId: 'user_123',
+        accessToken: 'old-token',
+        refreshToken: 'old-refresh',
+        expiresAt: new Date(Date.now() + 2 * 60 * 1000),
+        needsRefresh: true,
+        refreshLeaseOwner: 'new-owner',
+        refreshLeaseExpiresAt: new Date(Date.now() + 30_000),
+      };
+      const fresh = {
+        clerkUserId: 'user_123',
+        accessToken: 'fresh-from-winner',
+        refreshToken: 'fresh-refresh',
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+        needsRefresh: false,
+      };
+
+      mockStorage.getYahooCredentials
+        .mockResolvedValueOnce(stalePreRaceLease)
+        .mockResolvedValueOnce(currentWinnerLease)
+        .mockResolvedValueOnce(fresh);
       mockStorage.acquireRefreshLease.mockResolvedValue(false);
 
       const response = await handleYahooCredentials(env, 'user_123', corsHeaders);
 
-      expect(response.status).toBe(401);
+      expect(response.status).toBe(200);
       const body = (await response.json()) as Record<string, unknown>;
-      expect(body.error).toBe('refresh_failed');
+      expect(body.access_token).toBe('fresh-from-winner');
       expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('winner: owner-guarded write fails, stale reread retries safely instead of writing unguarded', async () => {
+      const leaseHeldByOther = {
+        clerkUserId: 'user_123',
+        accessToken: 'old-token',
+        refreshToken: 'old-refresh',
+        expiresAt: new Date(Date.now() + 2 * 60 * 1000),
+        needsRefresh: true,
+        refreshLeaseOwner: 'other-owner',
+        refreshLeaseExpiresAt: new Date(Date.now() + 30_000),
+      };
+      const fresh = {
+        clerkUserId: 'user_123',
+        accessToken: 'fresh-token',
+        refreshToken: 'fresh-refresh',
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+        needsRefresh: false,
+      };
+
+      mockStorage.getYahooCredentials
+        .mockResolvedValueOnce({
+          clerkUserId: 'user_123',
+          accessToken: 'old-token',
+          refreshToken: 'old-refresh',
+          expiresAt: new Date(Date.now() + 2 * 60 * 1000),
+          needsRefresh: true,
+        })
+        .mockResolvedValueOnce(leaseHeldByOther)
+        .mockResolvedValueOnce(fresh);
+      mockStorage.acquireRefreshLease
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(false);
+      mockStorage.updateYahooCredentials.mockResolvedValue(false);
+      mockFetch.mockResolvedValue(
+        new Response(
+          JSON.stringify({ access_token: 'winner-token', refresh_token: 'new-refresh', expires_in: 3600 }),
+          { status: 200 }
+        )
+      );
+
+      const response = await handleYahooCredentials(env, 'user_123', corsHeaders);
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.access_token).toBe('fresh-token');
+      expect(mockStorage.updateYahooCredentials).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns server_error when lease acquisition storage call fails', async () => {
+      mockStorage.getYahooCredentials.mockResolvedValue({
+        clerkUserId: 'user_123',
+        accessToken: 'old-access-token',
+        refreshToken: 'refresh-token',
+        expiresAt: new Date(Date.now() + 2 * 60 * 1000),
+        needsRefresh: true,
+      });
+      mockStorage.acquireRefreshLease.mockRejectedValue(new Error('db unavailable'));
+
+      const response = await handleYahooCredentials(env, 'user_123', corsHeaders);
+
+      expect(response.status).toBe(500);
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.error).toBe('server_error');
     });
   });
 

--- a/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
@@ -4,6 +4,7 @@ import {
   handleYahooCallback,
   handleYahooCredentials,
   handleYahooDisconnect,
+  handleYahooDiscover,
   handleYahooStatus,
   type YahooConnectEnv,
 } from '../yahoo-connect-handlers';
@@ -40,10 +41,13 @@ describe('yahoo-connect-handlers', () => {
     saveYahooCredentials: ReturnType<typeof vi.fn>;
     getYahooCredentials: ReturnType<typeof vi.fn>;
     updateYahooCredentials: ReturnType<typeof vi.fn>;
+    acquireRefreshLease: ReturnType<typeof vi.fn>;
+    releaseRefreshLease: ReturnType<typeof vi.fn>;
     deleteYahooCredentials: ReturnType<typeof vi.fn>;
     deleteAllYahooLeagues: ReturnType<typeof vi.fn>;
     hasYahooCredentials: ReturnType<typeof vi.fn>;
     getYahooLeagues: ReturnType<typeof vi.fn>;
+    upsertYahooLeague: ReturnType<typeof vi.fn>;
   };
 
   beforeEach(() => {
@@ -54,11 +58,14 @@ describe('yahoo-connect-handlers', () => {
       consumePlatformOAuthState: vi.fn(),
       saveYahooCredentials: vi.fn().mockResolvedValue(undefined),
       getYahooCredentials: vi.fn(),
-      updateYahooCredentials: vi.fn().mockResolvedValue(undefined),
+      updateYahooCredentials: vi.fn().mockResolvedValue(true),
+      acquireRefreshLease: vi.fn().mockResolvedValue(true),
+      releaseRefreshLease: vi.fn().mockResolvedValue(undefined),
       deleteYahooCredentials: vi.fn().mockResolvedValue(undefined),
       deleteAllYahooLeagues: vi.fn().mockResolvedValue(undefined),
       hasYahooCredentials: vi.fn(),
       getYahooLeagues: vi.fn(),
+      upsertYahooLeague: vi.fn().mockResolvedValue('league-id'),
     };
 
     vi.mocked(YahooStorage.fromEnvironment).mockReturnValue(mockStorage as unknown as YahooStorage);
@@ -307,13 +314,14 @@ describe('yahoo-connect-handlers', () => {
       const body = (await response.json()) as Record<string, unknown>;
       expect(body.access_token).toBe('new-access-token');
 
-      // Verify credentials were updated
+      // Verify credentials were updated (3rd arg is the lease ownerId)
       expect(mockStorage.updateYahooCredentials).toHaveBeenCalledWith(
         'user_123',
         expect.objectContaining({
           accessToken: 'new-access-token',
           refreshToken: 'new-refresh-token',
-        })
+        }),
+        expect.any(String)
       );
     });
 
@@ -393,6 +401,146 @@ describe('yahoo-connect-handlers', () => {
       expect(body.access_token).toBe('fresh-access-token');
       expect(mockStorage.updateYahooCredentials).not.toHaveBeenCalled();
     });
+
+    it('winner: lease acquired, refresh succeeds, write lands', async () => {
+      mockStorage.getYahooCredentials.mockResolvedValue({
+        clerkUserId: 'user_123',
+        accessToken: 'old-access-token',
+        refreshToken: 'refresh-token',
+        expiresAt: new Date(Date.now() + 2 * 60 * 1000),
+        needsRefresh: true,
+      });
+      mockStorage.acquireRefreshLease.mockResolvedValue(true);
+      mockStorage.updateYahooCredentials.mockResolvedValue(true);
+      mockFetch.mockResolvedValue(
+        new Response(
+          JSON.stringify({ access_token: 'winner-token', refresh_token: 'new-refresh', expires_in: 3600 }),
+          { status: 200 }
+        )
+      );
+
+      const response = await handleYahooCredentials(env, 'user_123', corsHeaders);
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.access_token).toBe('winner-token');
+      expect(mockStorage.acquireRefreshLease).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('winner: Yahoo timeout (AbortError) releases lease and returns refresh_failed', async () => {
+      mockStorage.getYahooCredentials.mockResolvedValue({
+        clerkUserId: 'user_123',
+        accessToken: 'old-access-token',
+        refreshToken: 'refresh-token',
+        expiresAt: new Date(Date.now() + 2 * 60 * 1000),
+        needsRefresh: true,
+      });
+      mockStorage.acquireRefreshLease.mockResolvedValue(true);
+
+      const abortError = new DOMException('The operation was aborted', 'AbortError');
+      mockFetch.mockRejectedValue(abortError);
+
+      let capturedOwnerId: string | undefined;
+      mockStorage.acquireRefreshLease.mockImplementation(
+        (_userId: string, ownerId: string) => {
+          capturedOwnerId = ownerId;
+          return Promise.resolve(true);
+        }
+      );
+
+      const response = await handleYahooCredentials(env, 'user_123', corsHeaders);
+
+      expect(response.status).toBe(401);
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.error).toBe('refresh_failed');
+      expect(mockStorage.releaseRefreshLease).toHaveBeenCalledWith('user_123', capturedOwnerId);
+    });
+
+    it('winner: owner-guarded write returns false, reread shows fresh token', async () => {
+      mockStorage.getYahooCredentials
+        .mockResolvedValueOnce({
+          clerkUserId: 'user_123',
+          accessToken: 'old-access-token',
+          refreshToken: 'refresh-token',
+          expiresAt: new Date(Date.now() + 2 * 60 * 1000),
+          needsRefresh: true,
+        })
+        .mockResolvedValueOnce({
+          clerkUserId: 'user_123',
+          accessToken: 'concurrent-fresh-token',
+          refreshToken: 'concurrent-refresh',
+          expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+          needsRefresh: false,
+        });
+      mockStorage.acquireRefreshLease.mockResolvedValue(true);
+      mockStorage.updateYahooCredentials.mockResolvedValue(false); // owner guard failed
+      mockFetch.mockResolvedValue(
+        new Response(
+          JSON.stringify({ access_token: 'winner-token', refresh_token: 'new-refresh', expires_in: 3600 }),
+          { status: 200 }
+        )
+      );
+
+      const response = await handleYahooCredentials(env, 'user_123', corsHeaders);
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.access_token).toBe('concurrent-fresh-token');
+    });
+
+    it('loser: lease not acquired, winner finishes before deadline', async () => {
+      const stale = {
+        clerkUserId: 'user_123',
+        accessToken: 'old-token',
+        refreshToken: 'old-refresh',
+        expiresAt: new Date(Date.now() + 2 * 60 * 1000),
+        needsRefresh: true,
+        refreshLeaseOwner: 'other-owner',
+        refreshLeaseExpiresAt: new Date(Date.now() + 30_000),
+      };
+      const fresh = {
+        clerkUserId: 'user_123',
+        accessToken: 'fresh-token',
+        refreshToken: 'fresh-refresh',
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+        needsRefresh: false,
+      };
+
+      mockStorage.getYahooCredentials
+        .mockResolvedValueOnce(stale)  // initial read
+        .mockResolvedValueOnce(fresh); // first poll
+      mockStorage.acquireRefreshLease.mockResolvedValue(false);
+
+      const response = await handleYahooCredentials(env, 'user_123', corsHeaders);
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.access_token).toBe('fresh-token');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('loser: lease expires before winner writes, token still stale → refresh_failed', async () => {
+      const stale = {
+        clerkUserId: 'user_123',
+        accessToken: 'old-token',
+        refreshToken: 'old-refresh',
+        expiresAt: new Date(Date.now() + 2 * 60 * 1000),
+        needsRefresh: true,
+        refreshLeaseOwner: 'other-owner',
+        refreshLeaseExpiresAt: new Date(Date.now() - 1), // already expired — skips loop
+      };
+
+      mockStorage.getYahooCredentials.mockResolvedValue(stale);
+      mockStorage.acquireRefreshLease.mockResolvedValue(false);
+
+      const response = await handleYahooCredentials(env, 'user_123', corsHeaders);
+
+      expect(response.status).toBe(401);
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.error).toBe('refresh_failed');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
   });
 
   // ===========================================================================
@@ -463,6 +611,54 @@ describe('yahoo-connect-handlers', () => {
       expect(body.connected).toBe(false);
       expect(body.leagueCount).toBe(0);
       expect(body.lastUpdated).toBeUndefined();
+    });
+  });
+
+  // ===========================================================================
+  // handleYahooDiscover Tests (refresh lease)
+  // ===========================================================================
+
+  describe('handleYahooDiscover (refresh lease)', () => {
+    it('loser waits and proceeds with fresh token after winner finishes', async () => {
+      const stale = {
+        clerkUserId: 'user_123',
+        accessToken: 'old-token',
+        refreshToken: 'old-refresh',
+        expiresAt: new Date(Date.now() + 2 * 60 * 1000),
+        needsRefresh: true,
+        refreshLeaseOwner: 'other-owner',
+        refreshLeaseExpiresAt: new Date(Date.now() + 30_000),
+      };
+      const fresh = {
+        clerkUserId: 'user_123',
+        accessToken: 'fresh-token',
+        refreshToken: 'fresh-refresh',
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+        needsRefresh: false,
+      };
+
+      // discover handler reads credentials once; getValidYahooAccessToken reads again then polls
+      mockStorage.getYahooCredentials
+        .mockResolvedValueOnce(stale)  // initial check in handler
+        .mockResolvedValueOnce(stale)  // initial read inside getValidYahooAccessToken
+        .mockResolvedValueOnce(fresh); // first poll in loser loop
+      mockStorage.acquireRefreshLease.mockResolvedValue(false);
+
+      // Mock Yahoo API discovery response
+      mockFetch.mockResolvedValue(
+        new Response(
+          JSON.stringify({ fantasy_content: { users: { count: 0 } } }),
+          { status: 200 }
+        )
+      );
+
+      const response = await handleYahooDiscover(env, 'user_123', corsHeaders);
+
+      expect(response.status).toBe(200);
+      // Discovery succeeded with the fresh token; Yahoo API fetch was called once (for discovery)
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.success).toBe(true);
     });
   });
 });

--- a/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
@@ -353,6 +353,46 @@ describe('yahoo-connect-handlers', () => {
       const body = (await response.json()) as Record<string, unknown>;
       expect(body.error).toBe('refresh_failed');
     });
+
+    it('uses newer stored credentials when a concurrent refresh already succeeded', async () => {
+      const originalUpdatedAt = new Date('2026-04-10T13:50:00Z');
+      const refreshedUpdatedAt = new Date('2026-04-10T13:50:05Z');
+
+      mockStorage.getYahooCredentials
+        .mockResolvedValueOnce({
+          clerkUserId: 'user_123',
+          accessToken: 'old-access-token',
+          refreshToken: 'stale-refresh-token',
+          expiresAt: new Date(Date.now() + 2 * 60 * 1000),
+          needsRefresh: true,
+          updatedAt: originalUpdatedAt,
+        })
+        .mockResolvedValueOnce({
+          clerkUserId: 'user_123',
+          accessToken: 'fresh-access-token',
+          refreshToken: 'fresh-refresh-token',
+          expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+          needsRefresh: false,
+          updatedAt: refreshedUpdatedAt,
+        });
+
+      mockFetch.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            error: 'invalid_grant',
+            error_description: 'Refresh token already used',
+          }),
+          { status: 400 }
+        )
+      );
+
+      const response = await handleYahooCredentials(env, 'user_123', corsHeaders);
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.access_token).toBe('fresh-access-token');
+      expect(mockStorage.updateYahooCredentials).not.toHaveBeenCalled();
+    });
   });
 
   // ===========================================================================

--- a/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
@@ -360,6 +360,7 @@ describe('yahoo-connect-handlers', () => {
       expect(response.status).toBe(401);
       const body = (await response.json()) as Record<string, unknown>;
       expect(body.error).toBe('refresh_failed');
+      expect(body.error_description).toBe('Refresh token expired');
     });
 
     it('uses newer stored credentials when a concurrent refresh already succeeded', async () => {
@@ -455,6 +456,28 @@ describe('yahoo-connect-handlers', () => {
       const body = (await response.json()) as Record<string, unknown>;
       expect(body.error).toBe('refresh_failed');
       expect(mockStorage.releaseRefreshLease).toHaveBeenCalledWith('user_123', capturedOwnerId);
+    });
+
+    it('winner: lease release failure after timeout still returns refresh_failed', async () => {
+      mockStorage.getYahooCredentials.mockResolvedValue({
+        clerkUserId: 'user_123',
+        accessToken: 'old-access-token',
+        refreshToken: 'refresh-token',
+        expiresAt: new Date(Date.now() + 2 * 60 * 1000),
+        needsRefresh: true,
+      });
+      mockStorage.acquireRefreshLease.mockResolvedValue(true);
+      mockStorage.releaseRefreshLease.mockRejectedValue(new Error('release failed'));
+
+      const abortError = new DOMException('The operation was aborted', 'AbortError');
+      mockFetch.mockRejectedValue(abortError);
+
+      const response = await handleYahooCredentials(env, 'user_123', corsHeaders);
+
+      expect(response.status).toBe(401);
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.error).toBe('refresh_failed');
+      expect(body.error_description).toBe('Failed to refresh access token');
     });
 
     it('winner: owner-guarded write returns false, reread shows fresh token', async () => {
@@ -753,10 +776,9 @@ describe('yahoo-connect-handlers', () => {
         needsRefresh: false,
       };
 
-      // discover handler reads credentials once; getValidYahooAccessToken reads again then polls
+      // discover handler reads credentials once, then the helper polls from the live lease state
       mockStorage.getYahooCredentials
         .mockResolvedValueOnce(stale)  // initial check in handler
-        .mockResolvedValueOnce(stale)  // initial read inside getValidYahooAccessToken
         .mockResolvedValueOnce(fresh); // first poll in loser loop
       mockStorage.acquireRefreshLease.mockResolvedValue(false);
 
@@ -773,8 +795,36 @@ describe('yahoo-connect-handlers', () => {
       expect(response.status).toBe(200);
       // Discovery succeeded with the fresh token; Yahoo API fetch was called once (for discovery)
       expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockStorage.getYahooCredentials).toHaveBeenCalledTimes(2);
       const body = (await response.json()) as Record<string, unknown>;
       expect(body.success).toBe(true);
+    });
+
+    it('returns Yahoo refresh error description from discovery path', async () => {
+      mockStorage.getYahooCredentials.mockResolvedValue({
+        clerkUserId: 'user_123',
+        accessToken: 'old-token',
+        refreshToken: 'bad-refresh',
+        expiresAt: new Date(Date.now() + 2 * 60 * 1000),
+        needsRefresh: true,
+      });
+      mockStorage.acquireRefreshLease.mockResolvedValue(true);
+      mockFetch.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            error: 'invalid_grant',
+            error_description: 'Refresh token already used',
+          }),
+          { status: 400 }
+        )
+      );
+
+      const response = await handleYahooDiscover(env, 'user_123', corsHeaders);
+
+      expect(response.status).toBe(401);
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.error).toBe('refresh_failed');
+      expect(body.error_description).toBe('Refresh token already used');
     });
   });
 });

--- a/workers/auth-worker/src/__tests__/yahoo-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-storage.test.ts
@@ -11,6 +11,7 @@ const mockEq = vi.fn();
 const mockSingle = vi.fn();
 const mockUpsert = vi.fn();
 const mockIs = vi.fn();
+const mockOr = vi.fn();
 
 vi.mock('@supabase/supabase-js', () => ({
   createClient: () => ({
@@ -42,6 +43,7 @@ describe('YahooStorage', () => {
     });
     mockEq.mockReturnValue({
       eq: mockEq,
+      or: mockOr,
       single: mockSingle,
       select: mockSelect,
       delete: mockDelete,
@@ -62,6 +64,9 @@ describe('YahooStorage', () => {
     mockIs.mockReturnValue({
       eq: mockEq,
       single: mockSingle,
+    });
+    mockOr.mockReturnValue({
+      select: mockSelect,
     });
   });
 
@@ -345,6 +350,68 @@ describe('YahooStorage', () => {
       );
 
       expect(result).toBe(false);
+    });
+  });
+
+  describe('acquireRefreshLease', () => {
+    it('returns true when the lease update succeeds', async () => {
+      mockSelect.mockResolvedValue({ data: [{ clerk_user_id: 'user_123' }], error: null });
+
+      const result = await storage.acquireRefreshLease('user_123', 'owner-1', 30_000);
+
+      expect(result).toBe(true);
+      expect(mockUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          refresh_lease_owner: 'owner-1',
+        })
+      );
+      expect(mockOr).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns false when another owner already holds the lease', async () => {
+      mockSelect.mockResolvedValue({ data: [], error: null });
+
+      const result = await storage.acquireRefreshLease('user_123', 'owner-1', 30_000);
+
+      expect(result).toBe(false);
+    });
+
+    it('throws when lease acquisition hits a storage error', async () => {
+      mockSelect.mockResolvedValue({ data: null, error: { message: 'DB down' } });
+
+      await expect(
+        storage.acquireRefreshLease('user_123', 'owner-1', 30_000)
+      ).rejects.toThrow('Failed to acquire Yahoo refresh lease');
+    });
+  });
+
+  describe('releaseRefreshLease', () => {
+    it('clears the lease only for the current owner', async () => {
+      await storage.releaseRefreshLease('user_123', 'owner-1');
+
+      expect(mockUpdate).toHaveBeenCalledWith({
+        refresh_lease_owner: null,
+        refresh_lease_expires_at: null,
+      });
+      expect(mockEq).toHaveBeenNthCalledWith(1, 'clerk_user_id', 'user_123');
+      expect(mockEq).toHaveBeenNthCalledWith(2, 'refresh_lease_owner', 'owner-1');
+    });
+
+    it('throws when lease release hits a storage error', async () => {
+      mockEq
+        .mockReturnValueOnce({
+          eq: mockEq,
+          or: mockOr,
+          single: mockSingle,
+          select: mockSelect,
+          delete: mockDelete,
+          is: mockIs,
+        })
+        .mockReturnValueOnce({ error: { message: 'release failed' } });
+
+      await expect(
+        storage.releaseRefreshLease('user_123', 'owner-1')
+      ).rejects.toThrow('Failed to release Yahoo refresh lease');
     });
   });
 

--- a/workers/auth-worker/src/__tests__/yahoo-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-storage.test.ts
@@ -310,22 +310,41 @@ describe('YahooStorage', () => {
   });
 
   describe('updateYahooCredentials', () => {
-    it('updates tokens after refresh', async () => {
-      mockEq.mockReturnValue({ error: null });
+    it('updates tokens after refresh and returns true when a row is updated', async () => {
+      mockSelect.mockResolvedValue({ data: [{ clerk_user_id: 'user_123' }], error: null });
 
-      await storage.updateYahooCredentials('user_123', {
+      const result = await storage.updateYahooCredentials('user_123', {
         accessToken: 'new-access-token',
         refreshToken: 'new-refresh-token',
         expiresAt: new Date('2026-01-24T14:00:00Z'),
       });
 
+      expect(result).toBe(true);
       expect(mockFrom).toHaveBeenCalledWith('yahoo_credentials');
       expect(mockUpdate).toHaveBeenCalledWith(
         expect.objectContaining({
           access_token: 'new-access-token',
           refresh_token: 'new-refresh-token',
+          refresh_lease_owner: null,
+          refresh_lease_expires_at: null,
         })
       );
+    });
+
+    it('returns false when owner guard rejects the write (0 rows updated)', async () => {
+      mockSelect.mockResolvedValue({ data: [], error: null });
+
+      const result = await storage.updateYahooCredentials(
+        'user_123',
+        {
+          accessToken: 'new-token',
+          refreshToken: 'new-refresh',
+          expiresAt: new Date('2026-01-24T14:00:00Z'),
+        },
+        'some-owner-id'
+      );
+
+      expect(result).toBe(false);
     });
   });
 

--- a/workers/auth-worker/src/__tests__/yahoo-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-storage.test.ts
@@ -366,6 +366,7 @@ describe('YahooStorage', () => {
         })
       );
       expect(mockOr).toHaveBeenCalledTimes(1);
+      expect(mockOr).toHaveBeenCalledWith(expect.stringContaining('refresh_lease_expires_at.is.null'));
     });
 
     it('returns false when another owner already holds the lease', async () => {

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -52,6 +52,10 @@ const YAHOO_AUTH_URL = 'https://api.login.yahoo.com/oauth2/request_auth';
 const YAHOO_TOKEN_URL = 'https://api.login.yahoo.com/oauth2/get_token';
 const YAHOO_SCOPE = 'fspt-r'; // Fantasy Sports read access
 
+const LEASE_TTL_MS       = 30_000;
+const REFRESH_TIMEOUT_MS = 20_000; // must be < LEASE_TTL_MS
+const POLL_INTERVAL_MS   =    300;
+
 /**
  * Get the OAuth callback URL based on environment
  */
@@ -95,6 +99,121 @@ function looksLikeNewerCredentials(
   }
 
   return false;
+}
+
+const sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
+
+// =============================================================================
+// TOKEN ACQUISITION
+// =============================================================================
+
+type GetTokenResult =
+  | { accessToken: string; expiresIn: number }
+  | { error: string };
+
+/**
+ * Get a valid Yahoo access token for the given user, refreshing if needed.
+ *
+ * Uses a DB lease to ensure only one Worker calls Yahoo's token endpoint at a
+ * time for a given user. Other concurrent callers wait and pick up the freshly
+ * written token when the winner finishes.
+ */
+async function getValidYahooAccessToken(
+  storage: YahooStorage,
+  userId: string,
+  env: YahooConnectEnv
+): Promise<GetTokenResult> {
+  const credentials = await storage.getYahooCredentials(userId);
+  if (!credentials) {
+    return { error: 'not_connected' };
+  }
+  if (!credentials.needsRefresh) {
+    const expiresIn = Math.floor((credentials.expiresAt.getTime() - Date.now()) / 1000);
+    return { accessToken: credentials.accessToken, expiresIn };
+  }
+
+  const ownerId = crypto.randomUUID();
+  const won = await storage.acquireRefreshLease(userId, ownerId, LEASE_TTL_MS);
+
+  if (!won) {
+    // LOSER PATH: poll until winner writes fresh credentials or lease expires
+    const deadline =
+      credentials.refreshLeaseExpiresAt?.getTime() ?? (Date.now() + LEASE_TTL_MS);
+    while (Date.now() < deadline) {
+      await sleep(POLL_INTERVAL_MS + Math.floor(Math.random() * 100));
+      const latest = await storage.getYahooCredentials(userId);
+      if (latest && !latest.needsRefresh) {
+        const expiresIn = Math.floor((latest.expiresAt.getTime() - Date.now()) / 1000);
+        return { accessToken: latest.accessToken, expiresIn };
+      }
+      if (
+        !latest?.refreshLeaseOwner ||
+        (latest.refreshLeaseExpiresAt && latest.refreshLeaseExpiresAt.getTime() < Date.now())
+      ) {
+        break;
+      }
+    }
+    const final = await storage.getYahooCredentials(userId);
+    if (final && !final.needsRefresh) {
+      const expiresIn = Math.floor((final.expiresAt.getTime() - Date.now()) / 1000);
+      return { accessToken: final.accessToken, expiresIn };
+    }
+    return { error: 'refresh_failed' };
+  }
+
+  // WINNER PATH: call Yahoo and write the result
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REFRESH_TIMEOUT_MS);
+  let result: YahooTokenResponse;
+  try {
+    result = await refreshAccessToken(credentials.refreshToken, env, controller.signal);
+    clearTimeout(timer);
+  } catch {
+    clearTimeout(timer);
+    await storage.releaseRefreshLease(userId, ownerId);
+    return { error: 'refresh_failed' };
+  }
+
+  if (result.error) {
+    clearTimeout(timer);
+    await storage.releaseRefreshLease(userId, ownerId);
+    // Reread fallback: another isolate may have already refreshed successfully
+    const latest = await storage.getYahooCredentials(userId);
+    if (latest && !latest.needsRefresh && looksLikeNewerCredentials(credentials, latest)) {
+      console.log(`[yahoo-connect] Using concurrently refreshed token for user ${maskUserId(userId)}`);
+      const expiresIn = Math.floor((latest.expiresAt.getTime() - Date.now()) / 1000);
+      return { accessToken: latest.accessToken, expiresIn };
+    }
+    return { error: 'refresh_failed' };
+  }
+
+  const expiresAt = new Date(Date.now() + result.expires_in * 1000);
+  const wrote = await storage.updateYahooCredentials(
+    userId,
+    { accessToken: result.access_token, refreshToken: result.refresh_token, expiresAt },
+    ownerId
+  );
+
+  if (wrote) {
+    console.log(`[yahoo-connect] Token refreshed for user ${maskUserId(userId)}`);
+    return { accessToken: result.access_token, expiresIn: result.expires_in };
+  }
+
+  // Owner guard failed — lease expired mid-write; check if another winner wrote fresh creds
+  const latest = await storage.getYahooCredentials(userId);
+  if (latest && !latest.needsRefresh) {
+    const expiresIn = Math.floor((latest.expiresAt.getTime() - Date.now()) / 1000);
+    return { accessToken: latest.accessToken, expiresIn };
+  }
+
+  // Still stale — write unconditionally as last resort
+  await storage.updateYahooCredentials(userId, {
+    accessToken: result.access_token,
+    refreshToken: result.refresh_token,
+    expiresAt,
+  });
+  console.warn(`[yahoo-connect] Lease expired mid-write for user ${maskUserId(userId)} — wrote unconditionally`);
+  return { accessToken: result.access_token, expiresIn: result.expires_in };
 }
 
 // =============================================================================
@@ -286,105 +405,37 @@ export async function handleYahooCredentials(
 ): Promise<Response> {
   try {
     const storage = YahooStorage.fromEnvironment(env);
+    const result = await getValidYahooAccessToken(storage, userId, env);
 
-    // Get current credentials
-    const credentials = await storage.getYahooCredentials(userId);
-
-    if (!credentials) {
+    if ('error' in result) {
+      if (result.error === 'not_connected') {
+        return new Response(
+          JSON.stringify({
+            error: 'not_connected',
+            error_description: 'User is not connected to Yahoo',
+          }),
+          {
+            status: 404,
+            headers: { 'Content-Type': 'application/json', ...corsHeaders },
+          }
+        );
+      }
       return new Response(
         JSON.stringify({
-          error: 'not_connected',
-          error_description: 'User is not connected to Yahoo',
+          error: 'refresh_failed',
+          error_description: 'Failed to refresh access token',
         }),
         {
-          status: 404,
+          status: 401,
           headers: { 'Content-Type': 'application/json', ...corsHeaders },
         }
       );
     }
 
-    // If token needs refresh, attempt to refresh it
-    if (credentials.needsRefresh) {
-      console.log(`[yahoo-connect] Token needs refresh for user ${maskUserId(userId)}`);
-
-      const refreshResult = await refreshAccessToken(credentials.refreshToken, env);
-
-      if (refreshResult.error) {
-        console.error(`[yahoo-connect] Token refresh failed: ${refreshResult.error}`);
-
-        // Yahoo refresh tokens appear to be single-use. Concurrent requests can race:
-        // one request refreshes and stores new credentials while a sibling request
-        // tries to reuse the old refresh token and gets an error. Re-read storage and
-        // use the newer token if another request already refreshed successfully.
-        const latestCredentials = await storage.getYahooCredentials(userId);
-        if (
-          latestCredentials &&
-          !latestCredentials.needsRefresh &&
-          looksLikeNewerCredentials(credentials, latestCredentials)
-        ) {
-          console.log(`[yahoo-connect] Using concurrently refreshed token for user ${maskUserId(userId)}`);
-          const latestExpiresIn = Math.floor((latestCredentials.expiresAt.getTime() - Date.now()) / 1000);
-          return new Response(
-            JSON.stringify({
-              access_token: latestCredentials.accessToken,
-              expires_in: latestExpiresIn,
-            }),
-            {
-              status: 200,
-              headers: {
-                'Content-Type': 'application/json',
-                'Cache-Control': 'no-store',
-                ...corsHeaders,
-              },
-            }
-          );
-        }
-
-        return new Response(
-          JSON.stringify({
-            error: 'refresh_failed',
-            error_description: refreshResult.error_description || 'Failed to refresh access token',
-          }),
-          {
-            status: 401,
-            headers: { 'Content-Type': 'application/json', ...corsHeaders },
-          }
-        );
-      }
-
-      // Update stored credentials
-      const expiresAt = new Date(Date.now() + refreshResult.expires_in * 1000);
-      await storage.updateYahooCredentials(userId, {
-        accessToken: refreshResult.access_token,
-        refreshToken: refreshResult.refresh_token,
-        expiresAt,
-      });
-
-      console.log(`[yahoo-connect] Token refreshed for user ${maskUserId(userId)}`);
-
-      return new Response(
-        JSON.stringify({
-          access_token: refreshResult.access_token,
-          expires_in: refreshResult.expires_in,
-        }),
-        {
-          status: 200,
-          headers: {
-            'Content-Type': 'application/json',
-            'Cache-Control': 'no-store',
-            ...corsHeaders,
-          },
-        }
-      );
-    }
-
-    // Return current token
-    const expiresIn = Math.floor((credentials.expiresAt.getTime() - Date.now()) / 1000);
-
     return new Response(
       JSON.stringify({
-        access_token: credentials.accessToken,
-        expires_in: expiresIn,
+        access_token: result.accessToken,
+        expires_in: result.expiresIn,
       }),
       {
         status: 200,
@@ -546,7 +597,8 @@ async function exchangeCodeForTokens(
  */
 async function refreshAccessToken(
   refreshToken: string,
-  env: YahooConnectEnv
+  env: YahooConnectEnv,
+  signal?: AbortSignal
 ): Promise<YahooTokenResponse> {
   const credentials = btoa(`${env.YAHOO_CLIENT_ID}:${env.YAHOO_CLIENT_SECRET}`);
 
@@ -560,6 +612,7 @@ async function refreshAccessToken(
       grant_type: 'refresh_token',
       refresh_token: refreshToken,
     }).toString(),
+    signal,
   });
 
   const data = (await response.json()) as YahooTokenResponse;
@@ -636,14 +689,12 @@ export async function handleYahooDiscover(
     let accessToken = credentials.accessToken;
     if (credentials.needsRefresh) {
       console.log(`[yahoo-connect] Refreshing token before discovery for user ${maskUserId(userId)}`);
-      const refreshResult = await refreshAccessToken(credentials.refreshToken, env);
-
-      if (refreshResult.error) {
-        console.error(`[yahoo-connect] Token refresh failed: ${refreshResult.error}`);
+      const tokenResult = await getValidYahooAccessToken(storage, userId, env);
+      if ('error' in tokenResult) {
         return new Response(
           JSON.stringify({
             error: 'refresh_failed',
-            error_description: refreshResult.error_description || 'Failed to refresh access token',
+            error_description: 'Failed to refresh access token',
           }),
           {
             status: 401,
@@ -651,16 +702,7 @@ export async function handleYahooDiscover(
           }
         );
       }
-
-      // Update stored credentials
-      const expiresAt = new Date(Date.now() + refreshResult.expires_in * 1000);
-      await storage.updateYahooCredentials(userId, {
-        accessToken: refreshResult.access_token,
-        refreshToken: refreshResult.refresh_token,
-        expiresAt,
-      });
-
-      accessToken = refreshResult.access_token;
+      accessToken = tokenResult.accessToken;
     }
 
     // Call Yahoo API to discover leagues

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -82,6 +82,21 @@ function maskUserId(userId: string): string {
   return `${userId.substring(0, 8)}...`;
 }
 
+function looksLikeNewerCredentials(
+  original: { accessToken: string; refreshToken: string; updatedAt?: Date },
+  latest: { accessToken: string; refreshToken: string; updatedAt?: Date }
+): boolean {
+  if (latest.accessToken !== original.accessToken || latest.refreshToken !== original.refreshToken) {
+    return true;
+  }
+
+  if (latest.updatedAt && original.updatedAt) {
+    return latest.updatedAt.getTime() > original.updatedAt.getTime();
+  }
+
+  return false;
+}
+
 // =============================================================================
 // HANDLERS
 // =============================================================================
@@ -296,6 +311,35 @@ export async function handleYahooCredentials(
 
       if (refreshResult.error) {
         console.error(`[yahoo-connect] Token refresh failed: ${refreshResult.error}`);
+
+        // Yahoo refresh tokens appear to be single-use. Concurrent requests can race:
+        // one request refreshes and stores new credentials while a sibling request
+        // tries to reuse the old refresh token and gets an error. Re-read storage and
+        // use the newer token if another request already refreshed successfully.
+        const latestCredentials = await storage.getYahooCredentials(userId);
+        if (
+          latestCredentials &&
+          !latestCredentials.needsRefresh &&
+          looksLikeNewerCredentials(credentials, latestCredentials)
+        ) {
+          console.log(`[yahoo-connect] Using concurrently refreshed token for user ${maskUserId(userId)}`);
+          const latestExpiresIn = Math.floor((latestCredentials.expiresAt.getTime() - Date.now()) / 1000);
+          return new Response(
+            JSON.stringify({
+              access_token: latestCredentials.accessToken,
+              expires_in: latestExpiresIn,
+            }),
+            {
+              status: 200,
+              headers: {
+                'Content-Type': 'application/json',
+                'Cache-Control': 'no-store',
+                ...corsHeaders,
+              },
+            }
+          );
+        }
+
         return new Response(
           JSON.stringify({
             error: 'refresh_failed',

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -110,7 +110,7 @@ const sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, m
 
 type GetTokenResult =
   | { accessToken: string; expiresIn: number }
-  | { error: string };
+  | { error: string; errorDescription?: string };
 
 type RetryTokenResult =
   | GetTokenResult
@@ -129,7 +129,7 @@ function leaseExpired(credentials: { refreshLeaseOwner?: string; refreshLeaseExp
   }
   return credentials.refreshLeaseExpiresAt
     ? credentials.refreshLeaseExpiresAt.getTime() <= Date.now()
-    : false;
+    : true;
 }
 
 async function waitForFreshCredentialsOrLeaseClear(
@@ -140,11 +140,6 @@ async function waitForFreshCredentialsOrLeaseClear(
   let latest: YahooCredentials | null = credentials;
 
   while (latest && !leaseExpired(latest)) {
-    const deadline = latest.refreshLeaseExpiresAt?.getTime() ?? (Date.now() + LEASE_TTL_MS);
-    if (Date.now() >= deadline) {
-      return { retry: true, credentials: latest };
-    }
-
     await sleep(POLL_INTERVAL_MS + Math.floor(Math.random() * 100));
     latest = await storage.getYahooCredentials(userId);
 
@@ -178,9 +173,10 @@ async function waitForFreshCredentialsOrLeaseClear(
 async function getValidYahooAccessToken(
   storage: YahooStorage,
   userId: string,
-  env: YahooConnectEnv
+  env: YahooConnectEnv,
+  initialCredentials?: YahooCredentials
 ): Promise<GetTokenResult> {
-  let credentials = await storage.getYahooCredentials(userId);
+  let credentials = initialCredentials ?? await storage.getYahooCredentials(userId);
   if (!credentials) {
     return { error: 'not_connected' };
   }
@@ -226,19 +222,30 @@ async function getValidYahooAccessToken(
       result = await refreshAccessToken(credentials.refreshToken, env, controller.signal);
     } catch {
       clearTimeout(timer);
-      await storage.releaseRefreshLease(userId, ownerId);
-      return { error: 'refresh_failed' };
+      try {
+        await storage.releaseRefreshLease(userId, ownerId);
+      } catch (releaseError) {
+        console.warn('[yahoo-connect] Failed to release Yahoo refresh lease after refresh exception:', releaseError);
+      }
+      return { error: 'refresh_failed', errorDescription: 'Failed to refresh access token' };
     }
     clearTimeout(timer);
 
     if (result.error) {
-      await storage.releaseRefreshLease(userId, ownerId);
+      try {
+        await storage.releaseRefreshLease(userId, ownerId);
+      } catch (releaseError) {
+        console.warn('[yahoo-connect] Failed to release Yahoo refresh lease after Yahoo refresh error:', releaseError);
+      }
       const latest = await storage.getYahooCredentials(userId);
       if (latest && !latest.needsRefresh && looksLikeNewerCredentials(credentials, latest)) {
         console.log(`[yahoo-connect] Using concurrently refreshed token for user ${maskUserId(userId)}`);
         return toTokenResult(latest);
       }
-      return { error: 'refresh_failed' };
+      return {
+        error: 'refresh_failed',
+        errorDescription: result.error_description || 'Failed to refresh access token',
+      };
     }
 
     const expiresAt = new Date(Date.now() + result.expires_in * 1000);
@@ -477,7 +484,7 @@ export async function handleYahooCredentials(
       return new Response(
         JSON.stringify({
           error: 'refresh_failed',
-          error_description: 'Failed to refresh access token',
+          error_description: result.errorDescription || 'Failed to refresh access token',
         }),
         {
           status: 401,
@@ -743,12 +750,12 @@ export async function handleYahooDiscover(
     let accessToken = credentials.accessToken;
     if (credentials.needsRefresh) {
       console.log(`[yahoo-connect] Refreshing token before discovery for user ${maskUserId(userId)}`);
-      const tokenResult = await getValidYahooAccessToken(storage, userId, env);
+      const tokenResult = await getValidYahooAccessToken(storage, userId, env, credentials);
       if ('error' in tokenResult) {
         return new Response(
           JSON.stringify({
             error: 'refresh_failed',
-            error_description: 'Failed to refresh access token',
+            error_description: tokenResult.errorDescription || 'Failed to refresh access token',
           }),
           {
             status: 401,

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -17,7 +17,7 @@
  * For the PROVIDER side (issuing tokens TO AI clients), see oauth-handlers.ts.
  */
 
-import { YahooStorage } from './yahoo-storage';
+import { YahooStorage, type YahooCredentials } from './yahoo-storage';
 import { getFrontendUrl, resolvePreviewOrigin } from './preview-url';
 
 // =============================================================================
@@ -55,6 +55,7 @@ const YAHOO_SCOPE = 'fspt-r'; // Fantasy Sports read access
 const LEASE_TTL_MS       = 30_000;
 const REFRESH_TIMEOUT_MS = 20_000; // must be < LEASE_TTL_MS
 const POLL_INTERVAL_MS   =    300;
+const MAX_REFRESH_ATTEMPTS = 3;
 
 /**
  * Get the OAuth callback URL based on environment
@@ -111,6 +112,62 @@ type GetTokenResult =
   | { accessToken: string; expiresIn: number }
   | { error: string };
 
+type RetryTokenResult =
+  | GetTokenResult
+  | { retry: true; credentials: YahooCredentials };
+
+function toTokenResult(credentials: { accessToken: string; expiresAt: Date }): GetTokenResult {
+  return {
+    accessToken: credentials.accessToken,
+    expiresIn: Math.floor((credentials.expiresAt.getTime() - Date.now()) / 1000),
+  };
+}
+
+function leaseExpired(credentials: { refreshLeaseOwner?: string; refreshLeaseExpiresAt?: Date } | null): boolean {
+  if (!credentials?.refreshLeaseOwner) {
+    return true;
+  }
+  return credentials.refreshLeaseExpiresAt
+    ? credentials.refreshLeaseExpiresAt.getTime() <= Date.now()
+    : false;
+}
+
+async function waitForFreshCredentialsOrLeaseClear(
+  storage: YahooStorage,
+  userId: string,
+  credentials: YahooCredentials
+): Promise<RetryTokenResult> {
+  let latest: YahooCredentials | null = credentials;
+
+  while (latest && !leaseExpired(latest)) {
+    const deadline = latest.refreshLeaseExpiresAt?.getTime() ?? (Date.now() + LEASE_TTL_MS);
+    if (Date.now() >= deadline) {
+      return { retry: true, credentials: latest };
+    }
+
+    await sleep(POLL_INTERVAL_MS + Math.floor(Math.random() * 100));
+    latest = await storage.getYahooCredentials(userId);
+
+    if (!latest) {
+      return { error: 'not_connected' };
+    }
+    if (!latest.needsRefresh) {
+      return toTokenResult(latest);
+    }
+    if (leaseExpired(latest)) {
+      return { retry: true, credentials: latest };
+    }
+  }
+
+  if (!latest) {
+    return { error: 'not_connected' };
+  }
+  if (!latest.needsRefresh) {
+    return toTokenResult(latest);
+  }
+  return { retry: true, credentials: latest };
+}
+
 /**
  * Get a valid Yahoo access token for the given user, refreshing if needed.
  *
@@ -123,97 +180,94 @@ async function getValidYahooAccessToken(
   userId: string,
   env: YahooConnectEnv
 ): Promise<GetTokenResult> {
-  const credentials = await storage.getYahooCredentials(userId);
+  let credentials = await storage.getYahooCredentials(userId);
   if (!credentials) {
     return { error: 'not_connected' };
   }
-  if (!credentials.needsRefresh) {
-    const expiresIn = Math.floor((credentials.expiresAt.getTime() - Date.now()) / 1000);
-    return { accessToken: credentials.accessToken, expiresIn };
-  }
 
-  const ownerId = crypto.randomUUID();
-  const won = await storage.acquireRefreshLease(userId, ownerId, LEASE_TTL_MS);
+  for (let attempt = 0; attempt < MAX_REFRESH_ATTEMPTS; attempt++) {
+    if (!credentials.needsRefresh) {
+      return toTokenResult(credentials);
+    }
 
-  if (!won) {
-    // LOSER PATH: poll until winner writes fresh credentials or lease expires
-    const deadline =
-      credentials.refreshLeaseExpiresAt?.getTime() ?? (Date.now() + LEASE_TTL_MS);
-    while (Date.now() < deadline) {
-      await sleep(POLL_INTERVAL_MS + Math.floor(Math.random() * 100));
+    const ownerId = crypto.randomUUID();
+    const won = await storage.acquireRefreshLease(userId, ownerId, LEASE_TTL_MS);
+
+    if (!won) {
       const latest = await storage.getYahooCredentials(userId);
-      if (latest && !latest.needsRefresh) {
-        const expiresIn = Math.floor((latest.expiresAt.getTime() - Date.now()) / 1000);
-        return { accessToken: latest.accessToken, expiresIn };
+      if (!latest) {
+        return { error: 'not_connected' };
       }
-      if (
-        !latest?.refreshLeaseOwner ||
-        (latest.refreshLeaseExpiresAt && latest.refreshLeaseExpiresAt.getTime() < Date.now())
-      ) {
-        break;
+      if (!latest.needsRefresh) {
+        return toTokenResult(latest);
       }
-    }
-    const final = await storage.getYahooCredentials(userId);
-    if (final && !final.needsRefresh) {
-      const expiresIn = Math.floor((final.expiresAt.getTime() - Date.now()) / 1000);
-      return { accessToken: final.accessToken, expiresIn };
-    }
-    return { error: 'refresh_failed' };
-  }
+      if (leaseExpired(latest)) {
+        credentials = latest;
+        continue;
+      }
 
-  // WINNER PATH: call Yahoo and write the result
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), REFRESH_TIMEOUT_MS);
-  let result: YahooTokenResponse;
-  try {
-    result = await refreshAccessToken(credentials.refreshToken, env, controller.signal);
-    clearTimeout(timer);
-  } catch {
-    clearTimeout(timer);
-    await storage.releaseRefreshLease(userId, ownerId);
-    return { error: 'refresh_failed' };
-  }
+      const loserResult = await waitForFreshCredentialsOrLeaseClear(
+        storage,
+        userId,
+        latest
+      );
 
-  if (result.error) {
+      if ('retry' in loserResult) {
+        credentials = loserResult.credentials;
+        continue;
+      }
+      return loserResult;
+    }
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), REFRESH_TIMEOUT_MS);
+    let result: YahooTokenResponse;
+    try {
+      result = await refreshAccessToken(credentials.refreshToken, env, controller.signal);
+    } catch {
+      clearTimeout(timer);
+      await storage.releaseRefreshLease(userId, ownerId);
+      return { error: 'refresh_failed' };
+    }
     clearTimeout(timer);
-    await storage.releaseRefreshLease(userId, ownerId);
-    // Reread fallback: another isolate may have already refreshed successfully
+
+    if (result.error) {
+      await storage.releaseRefreshLease(userId, ownerId);
+      const latest = await storage.getYahooCredentials(userId);
+      if (latest && !latest.needsRefresh && looksLikeNewerCredentials(credentials, latest)) {
+        console.log(`[yahoo-connect] Using concurrently refreshed token for user ${maskUserId(userId)}`);
+        return toTokenResult(latest);
+      }
+      return { error: 'refresh_failed' };
+    }
+
+    const expiresAt = new Date(Date.now() + result.expires_in * 1000);
+    const wrote = await storage.updateYahooCredentials(
+      userId,
+      { accessToken: result.access_token, refreshToken: result.refresh_token, expiresAt },
+      ownerId
+    );
+
+    if (wrote) {
+      console.log(`[yahoo-connect] Token refreshed for user ${maskUserId(userId)}`);
+      return { accessToken: result.access_token, expiresIn: result.expires_in };
+    }
+
     const latest = await storage.getYahooCredentials(userId);
-    if (latest && !latest.needsRefresh && looksLikeNewerCredentials(credentials, latest)) {
-      console.log(`[yahoo-connect] Using concurrently refreshed token for user ${maskUserId(userId)}`);
-      const expiresIn = Math.floor((latest.expiresAt.getTime() - Date.now()) / 1000);
-      return { accessToken: latest.accessToken, expiresIn };
+    if (!latest) {
+      return { error: 'not_connected' };
     }
-    return { error: 'refresh_failed' };
+    if (!latest.needsRefresh) {
+      return toTokenResult(latest);
+    }
+    credentials = latest;
   }
 
-  const expiresAt = new Date(Date.now() + result.expires_in * 1000);
-  const wrote = await storage.updateYahooCredentials(
-    userId,
-    { accessToken: result.access_token, refreshToken: result.refresh_token, expiresAt },
-    ownerId
-  );
-
-  if (wrote) {
-    console.log(`[yahoo-connect] Token refreshed for user ${maskUserId(userId)}`);
-    return { accessToken: result.access_token, expiresIn: result.expires_in };
-  }
-
-  // Owner guard failed — lease expired mid-write; check if another winner wrote fresh creds
   const latest = await storage.getYahooCredentials(userId);
   if (latest && !latest.needsRefresh) {
-    const expiresIn = Math.floor((latest.expiresAt.getTime() - Date.now()) / 1000);
-    return { accessToken: latest.accessToken, expiresIn };
+    return toTokenResult(latest);
   }
-
-  // Still stale — write unconditionally as last resort
-  await storage.updateYahooCredentials(userId, {
-    accessToken: result.access_token,
-    refreshToken: result.refresh_token,
-    expiresAt,
-  });
-  console.warn(`[yahoo-connect] Lease expired mid-write for user ${maskUserId(userId)} — wrote unconditionally`);
-  return { accessToken: result.access_token, expiresIn: result.expires_in };
+  return { error: 'refresh_failed' };
 }
 
 // =============================================================================

--- a/workers/auth-worker/src/yahoo-storage.ts
+++ b/workers/auth-worker/src/yahoo-storage.ts
@@ -305,7 +305,7 @@ export class YahooStorage {
         refresh_lease_expires_at: expiresAt,
       })
       .eq('clerk_user_id', clerkUserId)
-      .or(`refresh_lease_owner.is.null,refresh_lease_expires_at.lt.${now}`)
+      .or(`refresh_lease_owner.is.null,refresh_lease_expires_at.lt.${now},refresh_lease_expires_at.is.null`)
       .select('clerk_user_id');
 
     if (error) {

--- a/workers/auth-worker/src/yahoo-storage.ts
+++ b/workers/auth-worker/src/yahoo-storage.ts
@@ -44,6 +44,8 @@ export interface YahooCredentials {
   yahooGuid?: string;
   needsRefresh: boolean;
   updatedAt?: Date;
+  refreshLeaseOwner?: string;
+  refreshLeaseExpiresAt?: Date;
 }
 
 export interface SaveCredentialsParams {
@@ -208,7 +210,7 @@ export class YahooStorage {
   async getYahooCredentials(clerkUserId: string): Promise<YahooCredentials | null> {
     const { data, error } = await this.supabase
       .from('yahoo_credentials')
-      .select('clerk_user_id, access_token, refresh_token, expires_at, yahoo_guid, updated_at')
+      .select('clerk_user_id, access_token, refresh_token, expires_at, yahoo_guid, updated_at, refresh_lease_owner, refresh_lease_expires_at')
       .eq('clerk_user_id', clerkUserId)
       .single();
 
@@ -227,37 +229,97 @@ export class YahooStorage {
       yahooGuid: data.yahoo_guid || undefined,
       needsRefresh,
       updatedAt: data.updated_at ? new Date(data.updated_at) : undefined,
+      refreshLeaseOwner: data.refresh_lease_owner ?? undefined,
+      refreshLeaseExpiresAt: data.refresh_lease_expires_at
+        ? new Date(data.refresh_lease_expires_at)
+        : undefined,
     };
   }
 
   /**
-   * Update Yahoo credentials after token refresh
+   * Update Yahoo credentials after token refresh.
+   *
+   * When ownerId is provided the update is guarded: only rows where
+   * refresh_lease_owner matches ownerId are updated (prevents a stale winner
+   * from overwriting a newer refresh). Returns true if a row was updated,
+   * false if the owner guard rejected the write.
    */
   async updateYahooCredentials(
     clerkUserId: string,
-    params: UpdateCredentialsParams
-  ): Promise<void> {
-    const updateData: Record<string, string> = {
+    params: UpdateCredentialsParams,
+    ownerId?: string
+  ): Promise<boolean> {
+    const updateData: Record<string, string | null> = {
       access_token: params.accessToken,
       expires_at: params.expiresAt.toISOString(),
       updated_at: new Date().toISOString(),
+      refresh_lease_owner: null,
+      refresh_lease_expires_at: null,
     };
 
     if (params.refreshToken) {
       updateData.refresh_token = params.refreshToken;
     }
 
-    const { error } = await this.supabase
+    let query = this.supabase
       .from('yahoo_credentials')
       .update(updateData)
       .eq('clerk_user_id', clerkUserId);
+
+    if (ownerId) {
+      query = query.eq('refresh_lease_owner', ownerId);
+    }
+
+    const { data, error } = await query.select('clerk_user_id');
 
     if (error) {
       console.error('[yahoo-storage] Failed to update Yahoo credentials:', error);
       throw new Error('Failed to update Yahoo credentials');
     }
 
-    console.log(`[yahoo-storage] Updated Yahoo credentials for user ${maskUserId(clerkUserId)}`);
+    const updated = (data?.length ?? 0) > 0;
+    if (updated) {
+      console.log(`[yahoo-storage] Updated Yahoo credentials for user ${maskUserId(clerkUserId)}`);
+    }
+    return updated;
+  }
+
+  /**
+   * Atomically acquire the refresh lease for a user.
+   *
+   * The update only succeeds if no other owner holds an unexpired lease
+   * (refresh_lease_owner IS NULL OR refresh_lease_expires_at < now).
+   * Returns true if this caller won the lease, false if another holder beat them.
+   */
+  async acquireRefreshLease(
+    clerkUserId: string,
+    ownerId: string,
+    ttlMs: number
+  ): Promise<boolean> {
+    const expiresAt = new Date(Date.now() + ttlMs).toISOString();
+    const now = new Date().toISOString();
+    const { data, error } = await this.supabase
+      .from('yahoo_credentials')
+      .update({
+        refresh_lease_owner: ownerId,
+        refresh_lease_expires_at: expiresAt,
+      })
+      .eq('clerk_user_id', clerkUserId)
+      .or(`refresh_lease_owner.is.null,refresh_lease_expires_at.lt.${now}`)
+      .select('clerk_user_id');
+    return !error && (data?.length ?? 0) > 0;
+  }
+
+  /**
+   * Release the refresh lease for a user.
+   * Only clears the lease if this caller still owns it.
+   */
+  async releaseRefreshLease(clerkUserId: string, ownerId: string): Promise<void> {
+    await this.supabase
+      .from('yahoo_credentials')
+      .update({ refresh_lease_owner: null, refresh_lease_expires_at: null })
+      .eq('clerk_user_id', clerkUserId)
+      .eq('refresh_lease_owner', ownerId);
   }
 
   /**

--- a/workers/auth-worker/src/yahoo-storage.ts
+++ b/workers/auth-worker/src/yahoo-storage.ts
@@ -307,7 +307,13 @@ export class YahooStorage {
       .eq('clerk_user_id', clerkUserId)
       .or(`refresh_lease_owner.is.null,refresh_lease_expires_at.lt.${now}`)
       .select('clerk_user_id');
-    return !error && (data?.length ?? 0) > 0;
+
+    if (error) {
+      console.error('[yahoo-storage] Failed to acquire Yahoo refresh lease:', error);
+      throw new Error('Failed to acquire Yahoo refresh lease');
+    }
+
+    return (data?.length ?? 0) > 0;
   }
 
   /**
@@ -315,11 +321,16 @@ export class YahooStorage {
    * Only clears the lease if this caller still owns it.
    */
   async releaseRefreshLease(clerkUserId: string, ownerId: string): Promise<void> {
-    await this.supabase
+    const { error } = await this.supabase
       .from('yahoo_credentials')
       .update({ refresh_lease_owner: null, refresh_lease_expires_at: null })
       .eq('clerk_user_id', clerkUserId)
       .eq('refresh_lease_owner', ownerId);
+
+    if (error) {
+      console.error('[yahoo-storage] Failed to release Yahoo refresh lease:', error);
+      throw new Error('Failed to release Yahoo refresh lease');
+    }
   }
 
   /**

--- a/workers/fantasy-mcp/src/index.ts
+++ b/workers/fantasy-mcp/src/index.ts
@@ -295,6 +295,11 @@ async function handleMcpRequest(c: Context<{ Bindings: Env }>): Promise<Response
 }
 
 async function handleMcpEndpoint(c: Context<{ Bindings: Env }>): Promise<Response> {
+  // Diagnostic probe: fires synchronously at invocation entry, before auth or streaming.
+  // Used to distinguish CF invocation-recording gaps from log-buffering gaps.
+  // Remove once CF partial-capture issue (FLA-86) is resolved.
+  console.log(`[fantasy-mcp] probe method=${c.req.method} path=${c.req.path}`);
+
   if (c.req.method !== 'POST') {
     return buildMethodNotAllowedResponse('POST');
   }

--- a/workers/fantasy-mcp/tests/integration/index.integration.test.ts
+++ b/workers/fantasy-mcp/tests/integration/index.integration.test.ts
@@ -490,4 +490,101 @@ describe('fantasy-mcp gateway integration', () => {
     const response = await app.fetch(buildMcpRequest('/mcp'), env, mockExecutionContext());
     expect(response.status).toBe(200);
   });
+
+  it('routes get_user_session and returns leagues from all platforms', async () => {
+    const espnLeague = {
+      platform: 'espn',
+      sport: 'football',
+      leagueId: '336777',
+      leagueName: 'Test ESPN League',
+      teamId: '1',
+      teamName: 'My Team',
+      seasonYear: 2025,
+    };
+    const yahooLeague = {
+      sport: 'football',
+      leagueKey: '449.l.12345',
+      leagueName: 'Test Yahoo League',
+      teamId: '1',
+      teamName: 'My Yahoo Team',
+      seasonYear: 2025,
+    };
+    const sleeperLeague = {
+      platform: 'sleeper',
+      sport: 'football',
+      leagueId: 'sleeper-league-1',
+      leagueName: 'Test Sleeper League',
+      teamId: 'sl-1',
+      teamName: 'My Sleeper Team',
+      seasonYear: 2025,
+    };
+
+    const authFetch = vi.fn(async (request: Request) => {
+      const url = new URL(request.url);
+      if (url.pathname === '/internal/introspect') {
+        return new Response(
+          JSON.stringify({ valid: true, userId: 'user-123', scope: 'mcp:read mcp:write', authType: 'oauth' }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+      if (url.pathname === '/internal/leagues') {
+        return new Response(
+          JSON.stringify({ success: true, leagues: [espnLeague] }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+      if (url.pathname === '/internal/leagues/yahoo') {
+        return new Response(
+          JSON.stringify({ leagues: [yahooLeague] }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+      if (url.pathname === '/internal/leagues/sleeper') {
+        return new Response(
+          JSON.stringify({ leagues: [sleeperLeague] }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+      return new Response('not found', { status: 404 });
+    });
+
+    const env = buildEnv(authFetch);
+
+    const request = new Request('https://api.flaim.app/mcp', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-token',
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 'session-test-1',
+        method: 'tools/call',
+        params: { name: 'get_user_session', arguments: {} },
+      }),
+    });
+
+    const response = await app.fetch(request, env, mockExecutionContext());
+    expect(response.status).toBe(200);
+
+    const contentType = response.headers.get('Content-Type') || '';
+    let result: { isError?: boolean; content?: Array<{ text?: string }> };
+    if (contentType.includes('text/event-stream')) {
+      const text = await response.text();
+      const data = text.split(/\r?\n/).filter((l) => l.startsWith('data:')).map((l) => l.slice(5).trim()).join('\n').trim();
+      const parsed = JSON.parse(data) as { result?: { isError?: boolean; content?: Array<{ text?: string }> } };
+      result = parsed.result ?? {};
+    } else {
+      const parsed = await response.json() as { result?: { isError?: boolean; content?: Array<{ text?: string }> } };
+      result = parsed.result ?? {};
+    }
+
+    expect(result.isError).not.toBe(true);
+    expect(Array.isArray(result.content)).toBe(true);
+    const payloadText = result.content?.[0]?.text ?? '';
+    expect(payloadText).toContain('Test ESPN League');
+    expect(payloadText).toContain('Test Yahoo League');
+    expect(payloadText).toContain('Test Sleeper League');
+  });
 });


### PR DESCRIPTION
## Summary
- harden Yahoo refresh lease coordination so losers reread current lease state and can safely retry after expiry
- remove the unsafe unguarded credential-write fallback and surface storage lease errors instead of treating them as normal contention
- add regression coverage for loser reacquire, stale pre-race lease reread, owner-guard failure, and storage error paths

## Verification
- npm test -- yahoo-connect-handlers.test.ts
- npm test -- yahoo-storage.test.ts
- npm run type-check