### PR TITLE
feat(mcp): make scope contract trustworthy across all MCP hosts

### DIFF
--- a/workers/auth-worker/src/__tests__/eval-api-key.test.ts
+++ b/workers/auth-worker/src/__tests__/eval-api-key.test.ts
@@ -63,6 +63,8 @@ vi.mock('../supabase-storage', () => {
       defaultBasketball: null,
       defaultHockey: null,
     }),
+    clearDefaultLeague: vi.fn().mockResolvedValue({ success: true }),
+    clearStaleDefaultForLeague: vi.fn().mockResolvedValue(undefined),
   };
   return {
     EspnSupabaseStorage: {
@@ -421,6 +423,41 @@ describe('eval API key auth', () => {
       })
     );
     expect(res.status).toBe(401);
+  });
+
+  // Test H: DELETE /internal/leagues/default/:sport with no auth → 401/403
+  it('DELETE /auth/internal/leagues/default/football without internal token returns 403', async () => {
+    const res = await appFetch(
+      makeRequest('/auth/internal/leagues/default/football', {
+        method: 'DELETE',
+        headers: bearerHeaders(EVAL_API_KEY), // Bearer only — no X-Flaim-Internal-Token
+      })
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('DELETE /auth/internal/leagues/default/football without any auth returns 4xx', async () => {
+    const res = await appFetch(
+      makeRequest('/auth/internal/leagues/default/football', {
+        method: 'DELETE',
+      })
+    );
+    // Route uses getInternalUserId which checks internal service token first;
+    // missing internal token → 403, missing bearer → 401; either is a rejection.
+    expect([401, 403]).toContain(res.status);
+  });
+
+  // Test I: DELETE /internal/leagues/default/:sport with invalid sport → 400
+  it('DELETE /auth/internal/leagues/default/soccer with valid auth returns 400 for invalid sport', async () => {
+    const res = await appFetch(
+      makeRequest('/auth/internal/leagues/default/soccer', {
+        method: 'DELETE',
+        headers: internalHeaders(EVAL_API_KEY),
+      })
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toContain('Invalid sport');
   });
 
   it('internal helper route rejects requests missing internal token', async () => {

--- a/workers/auth-worker/src/__tests__/eval-api-key.test.ts
+++ b/workers/auth-worker/src/__tests__/eval-api-key.test.ts
@@ -11,6 +11,10 @@ const DEMO_USER_ID = 'user_demo_test_54321';
 const INTERNAL_SERVICE_TOKEN = 'internal-service-secret';
 
 const mockRateLimiter = { limit: async () => ({ success: true }) };
+const { mockClearDefaultLeague, mockClearStaleDefaultForLeague } = vi.hoisted(() => ({
+  mockClearDefaultLeague: vi.fn().mockResolvedValue({ success: true }),
+  mockClearStaleDefaultForLeague: vi.fn().mockResolvedValue(undefined),
+}));
 
 const baseEnv = {
   SUPABASE_URL: 'https://example.supabase.co',
@@ -63,8 +67,8 @@ vi.mock('../supabase-storage', () => {
       defaultBasketball: null,
       defaultHockey: null,
     }),
-    clearDefaultLeague: vi.fn().mockResolvedValue({ success: true }),
-    clearStaleDefaultForLeague: vi.fn().mockResolvedValue(undefined),
+    clearDefaultLeague: mockClearDefaultLeague,
+    clearStaleDefaultForLeague: mockClearStaleDefaultForLeague,
   };
   return {
     EspnSupabaseStorage: {
@@ -122,6 +126,8 @@ vi.mock('../oauth-handlers', () => ({
 describe('eval API key auth', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockClearDefaultLeague.mockResolvedValue({ success: true });
+    mockClearStaleDefaultForLeague.mockResolvedValue(undefined);
   });
 
   // =========================================================================
@@ -458,6 +464,24 @@ describe('eval API key auth', () => {
     expect(res.status).toBe(400);
     const body = await res.json() as { error: string };
     expect(body.error).toContain('Invalid sport');
+  });
+
+  it('DELETE /auth/internal/leagues/default/football with platform, leagueId, and seasonYear clears the exact stale default', async () => {
+    const res = await appFetch(
+      makeRequest('/auth/internal/leagues/default/football?platform=espn&leagueId=123&seasonYear=2024', {
+        method: 'DELETE',
+        headers: internalHeaders(EVAL_API_KEY),
+      })
+    );
+    expect(res.status).toBe(200);
+    expect(mockClearStaleDefaultForLeague).toHaveBeenCalledWith(
+      EVAL_USER_ID,
+      'espn',
+      '123',
+      2024,
+      'football'
+    );
+    expect(mockClearDefaultLeague).not.toHaveBeenCalled();
   });
 
   it('internal helper route rejects requests missing internal token', async () => {

--- a/workers/auth-worker/src/__tests__/preference-defaults.test.ts
+++ b/workers/auth-worker/src/__tests__/preference-defaults.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import { clearDefaultsForLeague, clearDefaultsForPlatform } from '../preference-defaults';
+
+function createSupabaseMock(preferences: Record<string, unknown> | null) {
+  const mockUpsert = vi.fn().mockReturnValue({ error: null });
+  const maybeSingle = vi.fn().mockResolvedValue({ data: preferences, error: null });
+  const eq = vi.fn();
+  eq.mockReturnValue({ maybeSingle });
+
+  const supabase = {
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({ eq }),
+      upsert: mockUpsert,
+    }),
+  };
+
+  return { supabase, mockUpsert };
+}
+
+describe('preference-defaults', () => {
+  it('clearDefaultsForLeague clears only the requested sport column when sport is provided', async () => {
+    const { supabase, mockUpsert } = createSupabaseMock({
+      default_football: { platform: 'espn', leagueId: '123', seasonYear: 2025 },
+      default_baseball: { platform: 'espn', leagueId: '123', seasonYear: 2026 },
+      default_basketball: null,
+      default_hockey: null,
+    });
+
+    const result = await clearDefaultsForLeague(supabase as any, 'user_123', 'espn', '123', undefined, 'football');
+
+    expect(result).toEqual({ skipped: false });
+    expect(mockUpsert).toHaveBeenCalledOnce();
+    const upsertArg = mockUpsert.mock.calls[0][0];
+    expect(upsertArg.default_football).toBeNull();
+    expect(upsertArg).not.toHaveProperty('default_baseball');
+  });
+
+  it('clearDefaultsForPlatform clears every matching platform default and preserves other platforms', async () => {
+    const { supabase, mockUpsert } = createSupabaseMock({
+      default_football: { platform: 'yahoo', leagueId: 'nfl.l.1', seasonYear: 2025 },
+      default_baseball: { platform: 'yahoo', leagueId: 'mlb.l.2', seasonYear: 2025 },
+      default_basketball: { platform: 'espn', leagueId: '999', seasonYear: 2025 },
+      default_hockey: null,
+    });
+
+    const result = await clearDefaultsForPlatform(supabase as any, 'user_123', 'yahoo');
+
+    expect(result).toEqual({ skipped: false });
+    expect(mockUpsert).toHaveBeenCalledOnce();
+    const upsertArg = mockUpsert.mock.calls[0][0];
+    expect(upsertArg.default_football).toBeNull();
+    expect(upsertArg.default_baseball).toBeNull();
+    expect(upsertArg).not.toHaveProperty('default_basketball');
+  });
+});

--- a/workers/auth-worker/src/__tests__/sleeper-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/sleeper-storage.test.ts
@@ -91,14 +91,16 @@ describe('SleeperStorage', () => {
 
     // Test E: clears matching sport default when lookup resolves the league_id
     it('clears matching sport default when lookup resolves the league_id', async () => {
+      const mockPrefsUpsert = vi.fn().mockReturnValue({ error: null });
+
       mockFrom.mockImplementation((table: string) => {
         if (table === 'sleeper_leagues') {
-          const maybySingle = vi.fn().mockResolvedValue({
+          const maybeSingle = vi.fn().mockResolvedValue({
             data: { league_id: 'sleeper-league-abc', season_year: 2025 },
             error: null,
           });
           const eqFn = vi.fn();
-          eqFn.mockReturnValue({ eq: eqFn, maybeSingle: maybySingle, error: null });
+          eqFn.mockReturnValue({ eq: eqFn, maybeSingle, error: null });
           return {
             select: vi.fn().mockReturnValue({ eq: eqFn }),
             delete: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ error: null }) }) }),
@@ -118,7 +120,7 @@ describe('SleeperStorage', () => {
           });
           return {
             select: vi.fn().mockReturnValue({ eq: prefEq }),
-            upsert: vi.fn().mockReturnValue({ error: null }),
+            upsert: mockPrefsUpsert,
           };
         }
         return {};
@@ -126,9 +128,10 @@ describe('SleeperStorage', () => {
 
       await storage.deleteSleeperLeague('user_123', 'league-uuid');
 
-      // user_preferences should have been accessed for cleanup
-      const prefsCalls = mockFrom.mock.calls.filter((c: string[]) => c[0] === 'user_preferences');
-      expect(prefsCalls.length).toBeGreaterThan(0);
+      expect(mockPrefsUpsert).toHaveBeenCalledOnce();
+      const upsertArg = mockPrefsUpsert.mock.calls[0][0];
+      expect(upsertArg.default_football).toBeNull();
+      expect(upsertArg).not.toHaveProperty('default_baseball');
     });
 
     // Test F: does not clear default when season year does not match

--- a/workers/auth-worker/src/__tests__/sleeper-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/sleeper-storage.test.ts
@@ -1,0 +1,247 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SleeperStorage } from '../sleeper-storage';
+
+// Mock Supabase client
+const mockFrom = vi.fn();
+const mockSelect = vi.fn();
+const mockDelete = vi.fn();
+const mockEq = vi.fn();
+const mockMaybeSingle = vi.fn();
+const mockUpsert = vi.fn();
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    from: mockFrom,
+  }),
+}));
+
+describe('SleeperStorage', () => {
+  let storage: SleeperStorage;
+
+  beforeEach(() => {
+    storage = new SleeperStorage('https://example.supabase.co', 'test-key');
+
+    vi.clearAllMocks();
+
+    // Setup chain mocking
+    mockFrom.mockReturnValue({
+      select: mockSelect,
+      delete: mockDelete,
+      upsert: mockUpsert,
+    });
+    mockSelect.mockReturnValue({
+      eq: mockEq,
+      maybeSingle: mockMaybeSingle,
+    });
+    mockMaybeSingle.mockResolvedValue({ data: null, error: null });
+    mockEq.mockReturnValue({
+      eq: mockEq,
+      maybeSingle: mockMaybeSingle,
+      select: mockSelect,
+      delete: mockDelete,
+    });
+    mockDelete.mockReturnValue({
+      eq: mockEq,
+      error: null,
+    });
+    mockUpsert.mockReturnValue({
+      error: null,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ===========================================================================
+  // deleteSleeperLeague Tests
+  // ===========================================================================
+
+  describe('deleteSleeperLeague', () => {
+    // Test D: lookup returns null — delete proceeds, no default cleanup
+    it('deletes a specific league when row lookup returns null (no cleanup needed)', async () => {
+      const mockSleeperEq = vi.fn();
+      const mockPrefsEq = vi.fn();
+
+      mockSleeperEq.mockReturnValue({
+        eq: mockSleeperEq,
+        maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+        error: null,
+      });
+      mockPrefsEq.mockReturnValue({
+        eq: mockPrefsEq,
+        maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+      });
+
+      const mockSleeperDelete = vi.fn().mockReturnValue({ eq: mockSleeperEq, error: null });
+      const mockSleeperSelect = vi.fn().mockReturnValue({ eq: mockSleeperEq });
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'sleeper_leagues') {
+          return { select: mockSleeperSelect, delete: mockSleeperDelete };
+        }
+        return { select: vi.fn().mockReturnValue({ eq: mockPrefsEq }) };
+      });
+
+      await storage.deleteSleeperLeague('user_123', 'league-uuid');
+
+      expect(mockFrom).toHaveBeenCalledWith('sleeper_leagues');
+      expect(mockSleeperDelete).toHaveBeenCalled();
+    });
+
+    // Test E: clears matching sport default when lookup resolves the league_id
+    it('clears matching sport default when lookup resolves the league_id', async () => {
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'sleeper_leagues') {
+          const maybySingle = vi.fn().mockResolvedValue({
+            data: { league_id: 'sleeper-league-abc', season_year: 2025 },
+            error: null,
+          });
+          const eqFn = vi.fn();
+          eqFn.mockReturnValue({ eq: eqFn, maybeSingle: maybySingle, error: null });
+          return {
+            select: vi.fn().mockReturnValue({ eq: eqFn }),
+            delete: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ error: null }) }) }),
+          };
+        }
+        if (table === 'user_preferences') {
+          const prefEq = vi.fn().mockReturnValue({
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: {
+                default_football: { platform: 'sleeper', leagueId: 'sleeper-league-abc', seasonYear: 2025 },
+                default_baseball: null,
+                default_basketball: null,
+                default_hockey: null,
+              },
+              error: null,
+            }),
+          });
+          return {
+            select: vi.fn().mockReturnValue({ eq: prefEq }),
+            upsert: vi.fn().mockReturnValue({ error: null }),
+          };
+        }
+        return {};
+      });
+
+      await storage.deleteSleeperLeague('user_123', 'league-uuid');
+
+      // user_preferences should have been accessed for cleanup
+      const prefsCalls = mockFrom.mock.calls.filter((c: string[]) => c[0] === 'user_preferences');
+      expect(prefsCalls.length).toBeGreaterThan(0);
+    });
+
+    // Test F: does not clear default when season year does not match
+    it('does not clear default when season year does not match', async () => {
+      const mockPrefsUpsert = vi.fn();
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'sleeper_leagues') {
+          const maybeSingleFn = vi.fn().mockResolvedValue({
+            data: { league_id: 'sleeper-league-abc', season_year: 2025 }, // row is 2025
+            error: null,
+          });
+          const eqFn = vi.fn();
+          eqFn.mockReturnValue({ eq: eqFn, maybeSingle: maybeSingleFn, error: null });
+          return {
+            select: vi.fn().mockReturnValue({ eq: eqFn }),
+            delete: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ error: null }) }) }),
+          };
+        }
+        if (table === 'user_preferences') {
+          const prefEq = vi.fn().mockReturnValue({
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: {
+                default_football: { platform: 'sleeper', leagueId: 'sleeper-league-abc', seasonYear: 2024 }, // default is 2024
+                default_baseball: null,
+                default_basketball: null,
+                default_hockey: null,
+              },
+              error: null,
+            }),
+          });
+          return {
+            select: vi.fn().mockReturnValue({ eq: prefEq }),
+            upsert: mockPrefsUpsert,
+          };
+        }
+        return {};
+      });
+
+      await storage.deleteSleeperLeague('user_123', 'league-uuid');
+
+      // upsert should NOT be called — 2025 row deleted but 2024 default is untouched
+      expect(mockPrefsUpsert).not.toHaveBeenCalled();
+    });
+  });
+
+  // ===========================================================================
+  // deleteAllSleeperLeagues Tests
+  // ===========================================================================
+
+  describe('deleteAllSleeperLeagues', () => {
+    // Test G: clears all Sleeper defaults on full disconnect
+    it('clears all Sleeper defaults on full disconnect', async () => {
+      const mockPrefsUpsert = vi.fn().mockReturnValue({ error: null });
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'sleeper_leagues') {
+          return { delete: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ error: null }) }) };
+        }
+        if (table === 'user_preferences') {
+          const prefEq = vi.fn().mockReturnValue({
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: {
+                default_football: { platform: 'sleeper', leagueId: 'sleeper-fb', seasonYear: 2025 },
+                default_baseball: { platform: 'sleeper', leagueId: 'sleeper-bb', seasonYear: 2025 },
+                default_basketball: { platform: 'espn', leagueId: '999', seasonYear: 2024 }, // different platform — should NOT be cleared
+                default_hockey: null,
+              },
+              error: null,
+            }),
+          });
+          return {
+            select: vi.fn().mockReturnValue({ eq: prefEq }),
+            upsert: mockPrefsUpsert,
+          };
+        }
+        return {};
+      });
+
+      await storage.deleteAllSleeperLeagues('user_123');
+
+      expect(mockPrefsUpsert).toHaveBeenCalledOnce();
+      const upsertArg = mockPrefsUpsert.mock.calls[0][0];
+      expect(upsertArg.default_football).toBeNull();
+      expect(upsertArg.default_baseball).toBeNull();
+      // ESPN default should be untouched (not in the upsert payload)
+      expect(upsertArg).not.toHaveProperty('default_basketball');
+    });
+
+    it('deletes all leagues for a user', async () => {
+      mockMaybeSingle.mockResolvedValue({ data: null, error: null });
+      mockEq.mockReturnValue({ eq: mockEq, error: null, maybeSingle: mockMaybeSingle });
+
+      await storage.deleteAllSleeperLeagues('user_123');
+
+      expect(mockFrom).toHaveBeenCalledWith('sleeper_leagues');
+      expect(mockDelete).toHaveBeenCalled();
+      expect(mockEq).toHaveBeenCalledWith('clerk_user_id', 'user_123');
+    });
+  });
+
+  // ===========================================================================
+  // Factory Method Tests
+  // ===========================================================================
+
+  describe('fromEnvironment', () => {
+    it('creates instance from environment variables', () => {
+      const instance = SleeperStorage.fromEnvironment({
+        SUPABASE_URL: 'https://test.supabase.co',
+        SUPABASE_SERVICE_KEY: 'service-key',
+      });
+
+      expect(instance).toBeInstanceOf(SleeperStorage);
+    });
+  });
+});

--- a/workers/auth-worker/src/__tests__/supabase-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/supabase-storage.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { EspnSupabaseStorage } from '../supabase-storage';
+
+const mockFrom = vi.fn();
+const mockDelete = vi.fn();
+const mockSelect = vi.fn();
+const mockEq = vi.fn();
+const mockMaybeSingle = vi.fn();
+const mockUpsert = vi.fn();
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    from: mockFrom,
+  }),
+}));
+
+describe('EspnSupabaseStorage', () => {
+  let storage: EspnSupabaseStorage;
+
+  beforeEach(() => {
+    storage = new EspnSupabaseStorage({
+      supabaseUrl: 'https://example.supabase.co',
+      supabaseKey: 'test-key',
+    });
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('removeLeague clears only the deleted sport default when league ids collide across sports', async () => {
+    const mockPrefsUpsert = vi.fn().mockReturnValue({ error: null });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'espn_leagues') {
+        const eqFn = vi.fn();
+        const selectFn = vi.fn().mockResolvedValue({
+          data: [{ id: 'row-1', league_id: '123', sport: 'football', season_year: 2025 }],
+          error: null,
+        });
+        eqFn.mockReturnValue({ eq: eqFn, select: selectFn });
+        return { delete: mockDelete.mockReturnValue({ eq: eqFn }) };
+      }
+
+      if (table === 'user_preferences') {
+        const prefEq = vi.fn().mockReturnValue({
+          maybeSingle: vi.fn().mockResolvedValue({
+            data: {
+              default_football: { platform: 'espn', leagueId: '123', seasonYear: 2025 },
+              default_baseball: { platform: 'espn', leagueId: '123', seasonYear: 2026 },
+              default_basketball: null,
+              default_hockey: null,
+            },
+            error: null,
+          }),
+        });
+        return {
+          select: mockSelect.mockReturnValue({ eq: prefEq }),
+          upsert: mockPrefsUpsert,
+        };
+      }
+
+      return {};
+    });
+
+    const result = await storage.removeLeague('user_123', '123', 'football');
+
+    expect(result).toBe(true);
+    expect(mockPrefsUpsert).toHaveBeenCalledOnce();
+    const upsertArg = mockPrefsUpsert.mock.calls[0][0];
+    expect(upsertArg.default_football).toBeNull();
+    expect(upsertArg).not.toHaveProperty('default_baseball');
+  });
+});

--- a/workers/auth-worker/src/__tests__/supabase-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/supabase-storage.test.ts
@@ -8,6 +8,14 @@ const mockEq = vi.fn();
 const mockMaybeSingle = vi.fn();
 const mockUpsert = vi.fn();
 
+function makeMaybeSingleChain(result: { data: unknown; error: unknown }) {
+  const maybeSingle = vi.fn().mockResolvedValue(result);
+  const eq = vi.fn();
+  const chain = { eq, maybeSingle };
+  eq.mockReturnValue(chain);
+  return chain;
+}
+
 vi.mock('@supabase/supabase-js', () => ({
   createClient: () => ({
     from: mockFrom,
@@ -71,5 +79,55 @@ describe('EspnSupabaseStorage', () => {
     const upsertArg = mockPrefsUpsert.mock.calls[0][0];
     expect(upsertArg.default_football).toBeNull();
     expect(upsertArg).not.toHaveProperty('default_baseball');
+  });
+
+  it('setDefaultLeague returns not found when Yahoo league validation misses', async () => {
+    const mockPrefsUpsert = vi.fn();
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'yahoo_leagues') {
+        return {
+          select: vi.fn().mockReturnValue(makeMaybeSingleChain({ data: null, error: null })),
+        };
+      }
+
+      if (table === 'user_preferences') {
+        return {
+          upsert: mockPrefsUpsert,
+        };
+      }
+
+      return {};
+    });
+
+    const result = await storage.setDefaultLeague('user_123', 'yahoo', 'football', 'nfl.l.123', 2025);
+
+    expect(result).toEqual({ success: false, error: 'League not found' });
+    expect(mockPrefsUpsert).not.toHaveBeenCalled();
+  });
+
+  it('setDefaultLeague returns not found when Sleeper league validation misses', async () => {
+    const mockPrefsUpsert = vi.fn();
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'sleeper_leagues') {
+        return {
+          select: vi.fn().mockReturnValue(makeMaybeSingleChain({ data: null, error: null })),
+        };
+      }
+
+      if (table === 'user_preferences') {
+        return {
+          upsert: mockPrefsUpsert,
+        };
+      }
+
+      return {};
+    });
+
+    const result = await storage.setDefaultLeague('user_123', 'sleeper', 'football', 'league-123', 2025);
+
+    expect(result).toEqual({ success: false, error: 'League not found' });
+    expect(mockPrefsUpsert).not.toHaveBeenCalled();
   });
 });

--- a/workers/auth-worker/src/__tests__/yahoo-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-storage.test.ts
@@ -9,6 +9,7 @@ const mockUpdate = vi.fn();
 const mockDelete = vi.fn();
 const mockEq = vi.fn();
 const mockSingle = vi.fn();
+const mockMaybeSingle = vi.fn();
 const mockUpsert = vi.fn();
 const mockIs = vi.fn();
 const mockOr = vi.fn();
@@ -40,11 +41,14 @@ describe('YahooStorage', () => {
     mockSelect.mockReturnValue({
       eq: mockEq,
       single: mockSingle,
+      maybeSingle: mockMaybeSingle,
     });
+    mockMaybeSingle.mockResolvedValue({ data: null, error: null });
     mockEq.mockReturnValue({
       eq: mockEq,
       or: mockOr,
       single: mockSingle,
+      maybeSingle: mockMaybeSingle,
       select: mockSelect,
       delete: mockDelete,
       is: mockIs,
@@ -547,9 +551,17 @@ describe('YahooStorage', () => {
 
   describe('deleteYahooLeague', () => {
     it('deletes a specific league', async () => {
+      // Lookup returns null (no matching row) — cleanup skipped
+      mockMaybeSingle.mockResolvedValue({ data: null, error: null });
       mockEq.mockReturnValue({
-        eq: vi.fn().mockReturnValue({ error: null }),
+        eq: mockEq,
+        single: mockSingle,
+        maybeSingle: mockMaybeSingle,
+        select: mockSelect,
+        delete: mockDelete,
+        error: null,
       });
+      mockDelete.mockReturnValue({ eq: mockEq, error: null });
 
       await storage.deleteYahooLeague('user_123', 'league-uuid');
 
@@ -560,7 +572,9 @@ describe('YahooStorage', () => {
 
   describe('deleteAllYahooLeagues', () => {
     it('deletes all leagues for a user', async () => {
-      mockEq.mockReturnValue({ error: null });
+      // user_preferences lookup returns null — no defaults to clear
+      mockMaybeSingle.mockResolvedValue({ data: null, error: null });
+      mockEq.mockReturnValue({ eq: mockEq, error: null, maybeSingle: mockMaybeSingle });
 
       await storage.deleteAllYahooLeagues('user_123');
 

--- a/workers/auth-worker/src/__tests__/yahoo-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-storage.test.ts
@@ -550,23 +550,119 @@ describe('YahooStorage', () => {
   });
 
   describe('deleteYahooLeague', () => {
-    it('deletes a specific league', async () => {
-      // Lookup returns null (no matching row) — cleanup skipped
-      mockMaybeSingle.mockResolvedValue({ data: null, error: null });
-      mockEq.mockReturnValue({
-        eq: mockEq,
-        single: mockSingle,
-        maybeSingle: mockMaybeSingle,
-        select: mockSelect,
-        delete: mockDelete,
+    it('deletes a specific league when row lookup returns null (no cleanup needed)', async () => {
+      // Separate per-table mocks
+      const mockYahooEq = vi.fn();
+      const mockPrefsEq = vi.fn();
+
+      mockYahooEq.mockReturnValue({
+        eq: mockYahooEq,
+        maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
         error: null,
       });
-      mockDelete.mockReturnValue({ eq: mockEq, error: null });
+      mockPrefsEq.mockReturnValue({ eq: mockPrefsEq, maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }) });
+
+      const mockYahooDelete = vi.fn().mockReturnValue({ eq: mockYahooEq, error: null });
+      const mockYahooSelect = vi.fn().mockReturnValue({ eq: mockYahooEq });
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'yahoo_leagues') {
+          return { select: mockYahooSelect, delete: mockYahooDelete };
+        }
+        return { select: vi.fn().mockReturnValue({ eq: mockPrefsEq }) };
+      });
 
       await storage.deleteYahooLeague('user_123', 'league-uuid');
 
       expect(mockFrom).toHaveBeenCalledWith('yahoo_leagues');
-      expect(mockDelete).toHaveBeenCalled();
+      expect(mockYahooDelete).toHaveBeenCalled();
+    });
+
+    it('clears matching sport default when lookup resolves the league_key', async () => {
+      const mockUpsertResult = vi.fn().mockResolvedValue({ error: null });
+      const mockPrefsUpsert = vi.fn().mockReturnValue({ then: mockUpsertResult, error: null });
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'yahoo_leagues') {
+          const eqChain: Record<string, unknown> = {};
+          const maybySingle = vi.fn().mockResolvedValue({
+            data: { league_key: 'nfl.l.123', season_year: 2025 },
+            error: null,
+          });
+          eqChain.eq = vi.fn().mockReturnValue({ ...eqChain, maybySingle, maybeSingle: maybySingle });
+          (eqChain.eq as ReturnType<typeof vi.fn>).mockReturnValue({ eq: eqChain.eq, maybeSingle: maybySingle, error: null });
+          return {
+            select: vi.fn().mockReturnValue({ eq: eqChain.eq }),
+            delete: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ error: null }) }) }),
+          };
+        }
+        if (table === 'user_preferences') {
+          const prefEq = vi.fn().mockReturnValue({
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: {
+                default_football: { platform: 'yahoo', leagueId: 'nfl.l.123', seasonYear: 2025 },
+                default_baseball: null,
+                default_basketball: null,
+                default_hockey: null,
+              },
+              error: null,
+            }),
+          });
+          return {
+            select: vi.fn().mockReturnValue({ eq: prefEq }),
+            upsert: vi.fn().mockReturnValue({ error: null }),
+          };
+        }
+        return {};
+      });
+
+      await storage.deleteYahooLeague('user_123', 'league-uuid');
+
+      // user_preferences upsert was called (the cleanup ran)
+      const prefsCalls = mockFrom.mock.calls.filter((c) => c[0] === 'user_preferences');
+      expect(prefsCalls.length).toBeGreaterThan(0);
+    });
+
+    it('does not clear default when season year does not match', async () => {
+      const mockPrefsUpsert = vi.fn();
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'yahoo_leagues') {
+          const maybeSingleFn = vi.fn().mockResolvedValue({
+            data: { league_key: 'nfl.l.123', season_year: 2025 }, // row is 2025
+            error: null,
+          });
+          const eqFn = vi.fn();
+          eqFn.mockReturnValue({ eq: eqFn, maybeSingle: maybeSingleFn, error: null });
+          return {
+            select: vi.fn().mockReturnValue({ eq: eqFn }),
+            delete: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ error: null }) }) }),
+          };
+        }
+        if (table === 'user_preferences') {
+          const prefEq = vi.fn().mockReturnValue({
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: {
+                default_football: { platform: 'yahoo', leagueId: 'nfl.l.123', seasonYear: 2024 }, // default is 2024
+                default_baseball: null,
+                default_basketball: null,
+                default_hockey: null,
+              },
+              error: null,
+            }),
+          });
+          return {
+            select: vi.fn().mockReturnValue({ eq: prefEq }),
+            upsert: mockPrefsUpsert,
+          };
+        }
+        return {};
+      });
+
+      await storage.deleteYahooLeague('user_123', 'league-uuid');
+
+      // upsert should NOT be called — 2025 row deleted but 2024 default is untouched
+      expect(mockPrefsUpsert).not.toHaveBeenCalled();
     });
   });
 
@@ -581,6 +677,43 @@ describe('YahooStorage', () => {
       expect(mockFrom).toHaveBeenCalledWith('yahoo_leagues');
       expect(mockDelete).toHaveBeenCalled();
       expect(mockEq).toHaveBeenCalledWith('clerk_user_id', 'user_123');
+    });
+
+    it('clears all Yahoo defaults on full disconnect', async () => {
+      const mockPrefsUpsert = vi.fn().mockReturnValue({ error: null });
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'yahoo_leagues') {
+          return { delete: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ error: null }) }) };
+        }
+        if (table === 'user_preferences') {
+          const prefEq = vi.fn().mockReturnValue({
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: {
+                default_football: { platform: 'yahoo', leagueId: 'nfl.l.123', seasonYear: 2025 },
+                default_baseball: { platform: 'yahoo', leagueId: 'mlb.l.456', seasonYear: 2025 },
+                default_basketball: { platform: 'espn', leagueId: '999', seasonYear: 2024 }, // different platform — should NOT be cleared
+                default_hockey: null,
+              },
+              error: null,
+            }),
+          });
+          return {
+            select: vi.fn().mockReturnValue({ eq: prefEq }),
+            upsert: mockPrefsUpsert,
+          };
+        }
+        return {};
+      });
+
+      await storage.deleteAllYahooLeagues('user_123');
+
+      expect(mockPrefsUpsert).toHaveBeenCalledOnce();
+      const upsertArg = mockPrefsUpsert.mock.calls[0][0];
+      expect(upsertArg.default_football).toBeNull();
+      expect(upsertArg.default_baseball).toBeNull();
+      // ESPN default should be untouched (not in the upsert payload)
+      expect(upsertArg).not.toHaveProperty('default_basketball');
     });
   });
 

--- a/workers/auth-worker/src/__tests__/yahoo-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-storage.test.ts
@@ -579,20 +579,18 @@ describe('YahooStorage', () => {
     });
 
     it('clears matching sport default when lookup resolves the league_key', async () => {
-      const mockUpsertResult = vi.fn().mockResolvedValue({ error: null });
-      const mockPrefsUpsert = vi.fn().mockReturnValue({ then: mockUpsertResult, error: null });
+      const mockPrefsUpsert = vi.fn().mockReturnValue({ error: null });
 
       mockFrom.mockImplementation((table: string) => {
         if (table === 'yahoo_leagues') {
-          const eqChain: Record<string, unknown> = {};
-          const maybySingle = vi.fn().mockResolvedValue({
+          const maybeSingle = vi.fn().mockResolvedValue({
             data: { league_key: 'nfl.l.123', season_year: 2025 },
             error: null,
           });
-          eqChain.eq = vi.fn().mockReturnValue({ ...eqChain, maybySingle, maybeSingle: maybySingle });
-          (eqChain.eq as ReturnType<typeof vi.fn>).mockReturnValue({ eq: eqChain.eq, maybeSingle: maybySingle, error: null });
+          const eqFn = vi.fn();
+          eqFn.mockReturnValue({ eq: eqFn, maybeSingle, error: null });
           return {
-            select: vi.fn().mockReturnValue({ eq: eqChain.eq }),
+            select: vi.fn().mockReturnValue({ eq: eqFn }),
             delete: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ error: null }) }) }),
           };
         }
@@ -610,7 +608,7 @@ describe('YahooStorage', () => {
           });
           return {
             select: vi.fn().mockReturnValue({ eq: prefEq }),
-            upsert: vi.fn().mockReturnValue({ error: null }),
+            upsert: mockPrefsUpsert,
           };
         }
         return {};
@@ -618,9 +616,10 @@ describe('YahooStorage', () => {
 
       await storage.deleteYahooLeague('user_123', 'league-uuid');
 
-      // user_preferences upsert was called (the cleanup ran)
-      const prefsCalls = mockFrom.mock.calls.filter((c) => c[0] === 'user_preferences');
-      expect(prefsCalls.length).toBeGreaterThan(0);
+      expect(mockPrefsUpsert).toHaveBeenCalledOnce();
+      const upsertArg = mockPrefsUpsert.mock.calls[0][0];
+      expect(upsertArg.default_football).toBeNull();
+      expect(upsertArg).not.toHaveProperty('default_baseball');
     });
 
     it('does not clear default when season year does not match', async () => {

--- a/workers/auth-worker/src/index-hono.ts
+++ b/workers/auth-worker/src/index-hono.ts
@@ -1147,17 +1147,23 @@ api.delete('/internal/leagues/default/:sport', async (c) => {
 
   const platform = c.req.query('platform');
   const leagueId = c.req.query('leagueId');
+  const seasonYearParam = c.req.query('seasonYear');
+  const seasonYear =
+    seasonYearParam === undefined ? undefined : Number.parseInt(seasonYearParam, 10);
+  if (seasonYearParam !== undefined && Number.isNaN(seasonYear)) {
+    return c.json({ error: 'Invalid seasonYear' }, 400);
+  }
 
   const storage = EspnSupabaseStorage.fromEnvironment(c.env);
 
-  // If platform + leagueId are provided, do a conditional (TOCTOU-safe) clear —
-  // only removes the default if it still points to this specific league.
+  // If platform + leagueId are provided, do an exact conditional clear — only
+  // removes the default if it still points to this specific league + season.
   if (platform && leagueId) {
     await storage.clearStaleDefaultForLeague(
       userId,
       platform as 'espn' | 'yahoo' | 'sleeper',
       leagueId,
-      undefined,
+      seasonYear,
       sport
     );
     return c.json({ success: true });

--- a/workers/auth-worker/src/index-hono.ts
+++ b/workers/auth-worker/src/index-hono.ts
@@ -1156,7 +1156,9 @@ api.delete('/internal/leagues/default/:sport', async (c) => {
     await storage.clearStaleDefaultForLeague(
       userId,
       platform as 'espn' | 'yahoo' | 'sleeper',
-      leagueId
+      leagueId,
+      undefined,
+      sport
     );
     return c.json({ success: true });
   }

--- a/workers/auth-worker/src/index-hono.ts
+++ b/workers/auth-worker/src/index-hono.ts
@@ -1131,6 +1131,33 @@ api.get('/internal/user/preferences', async (c) => {
   });
 });
 
+// Internal: clear a default league for a sport (called by fantasy-mcp read-time self-heal)
+api.delete('/internal/leagues/default/:sport', async (c) => {
+  const { userId, error: authError } = await getInternalUserId(c.req.raw, c.env, undefined, { allowStaticApiKey: true });
+  if (!userId) {
+    const status = authError?.includes(INTERNAL_SERVICE_TOKEN_HEADER) || authError?.includes('Internal service authentication') ? 403 : 401;
+    return c.json({ error: 'unauthorized', error_description: authError || 'Authentication required' }, status);
+  }
+
+  const sport = c.req.param('sport');
+  const validSports = ['football', 'baseball', 'basketball', 'hockey'];
+  if (!validSports.includes(sport)) {
+    return c.json({ error: 'Invalid sport' }, 400);
+  }
+
+  const storage = EspnSupabaseStorage.fromEnvironment(c.env);
+  const result = await storage.clearDefaultLeague(
+    userId,
+    sport as 'football' | 'baseball' | 'basketball' | 'hockey'
+  );
+
+  if (!result.success) {
+    return c.json({ error: result.error || 'Failed to clear default' }, 500);
+  }
+
+  return c.json({ success: true });
+});
+
 // Set default sport
 api.post('/user/preferences/default-sport', async (c) => {
   const { userId, error: authError } = await getClerkUserId(c.req.raw, c.env);

--- a/workers/auth-worker/src/index-hono.ts
+++ b/workers/auth-worker/src/index-hono.ts
@@ -1145,7 +1145,22 @@ api.delete('/internal/leagues/default/:sport', async (c) => {
     return c.json({ error: 'Invalid sport' }, 400);
   }
 
+  const platform = c.req.query('platform');
+  const leagueId = c.req.query('leagueId');
+
   const storage = EspnSupabaseStorage.fromEnvironment(c.env);
+
+  // If platform + leagueId are provided, do a conditional (TOCTOU-safe) clear —
+  // only removes the default if it still points to this specific league.
+  if (platform && leagueId) {
+    await storage.clearStaleDefaultForLeague(
+      userId,
+      platform as 'espn' | 'yahoo' | 'sleeper',
+      leagueId
+    );
+    return c.json({ success: true });
+  }
+
   const result = await storage.clearDefaultLeague(
     userId,
     sport as 'football' | 'baseball' | 'basketball' | 'hockey'

--- a/workers/auth-worker/src/preference-defaults.ts
+++ b/workers/auth-worker/src/preference-defaults.ts
@@ -1,0 +1,116 @@
+/**
+ * Shared helpers for clearing stale sport defaults in user_preferences.
+ * Used by SupabaseStorage, YahooStorage, and SleeperStorage after league deletion
+ * to keep user_preferences.default_<sport> in sync with the leagues tables.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+type Platform = 'espn' | 'yahoo' | 'sleeper';
+type StoredDefault = { platform: string; leagueId: string; seasonYear: number } | null;
+
+const SPORT_COLUMNS = ['football', 'baseball', 'basketball', 'hockey'] as const;
+
+function maskUserId(userId: string): string {
+  if (!userId || userId.length <= 8) return '***';
+  return `${userId.substring(0, 8)}...`;
+}
+
+/**
+ * Clear any sport default that matches the given platform + leagueId.
+ * When seasonYear is provided, only clears an exact {platform, leagueId, seasonYear} match.
+ * When omitted (ESPN all-seasons delete), clears any matching {platform, leagueId}.
+ */
+export async function clearDefaultsForLeague(
+  supabase: SupabaseClient,
+  clerkUserId: string,
+  platform: Platform,
+  leagueId: string,
+  seasonYear?: number
+): Promise<void> {
+  const { data, error } = await supabase
+    .from('user_preferences')
+    .select('default_football, default_baseball, default_basketball, default_hockey')
+    .eq('clerk_user_id', clerkUserId)
+    .maybeSingle();
+
+  if (error) {
+    console.error('[preference-defaults] clearDefaultsForLeague: failed to read preferences:', error);
+    return;
+  }
+  if (!data) return;
+
+  const updates: Record<string, null> = {};
+  for (const sport of SPORT_COLUMNS) {
+    const col = `default_${sport}` as keyof typeof data;
+    const stored = data[col] as StoredDefault;
+    if (
+      stored &&
+      stored.platform === platform &&
+      stored.leagueId === leagueId &&
+      (seasonYear === undefined || stored.seasonYear === seasonYear)
+    ) {
+      updates[col] = null;
+    }
+  }
+
+  if (Object.keys(updates).length === 0) return;
+
+  const { error: upsertError } = await supabase
+    .from('user_preferences')
+    .upsert(
+      { clerk_user_id: clerkUserId, ...updates, updated_at: new Date().toISOString() },
+      { onConflict: 'clerk_user_id' }
+    );
+
+  if (upsertError) {
+    console.error('[preference-defaults] clearDefaultsForLeague: failed to clear stale defaults:', upsertError);
+  } else {
+    console.log(`[preference-defaults] clearDefaultsForLeague: cleared stale ${platform}:${leagueId} default for user ${maskUserId(clerkUserId)}`);
+  }
+}
+
+/**
+ * Clear all sport defaults for a given platform (used on full-platform disconnect).
+ */
+export async function clearDefaultsForPlatform(
+  supabase: SupabaseClient,
+  clerkUserId: string,
+  platform: Platform
+): Promise<void> {
+  const { data, error } = await supabase
+    .from('user_preferences')
+    .select('default_football, default_baseball, default_basketball, default_hockey')
+    .eq('clerk_user_id', clerkUserId)
+    .maybeSingle();
+
+  if (error) {
+    console.error('[preference-defaults] clearDefaultsForPlatform: failed to read preferences:', error);
+    return;
+  }
+  if (!data) return;
+
+  const updates: Record<string, null> = {};
+  for (const sport of SPORT_COLUMNS) {
+    const col = `default_${sport}` as keyof typeof data;
+    const stored = data[col] as { platform: string } | null;
+    if (stored && stored.platform === platform) {
+      updates[col] = null;
+    }
+  }
+
+  if (Object.keys(updates).length === 0) return;
+
+  const { error: upsertError } = await supabase
+    .from('user_preferences')
+    .upsert(
+      { clerk_user_id: clerkUserId, ...updates, updated_at: new Date().toISOString() },
+      { onConflict: 'clerk_user_id' }
+    );
+
+  if (upsertError) {
+    console.error('[preference-defaults] clearDefaultsForPlatform: failed to clear platform defaults:', upsertError);
+  } else {
+    console.log(`[preference-defaults] clearDefaultsForPlatform: cleared ${platform} defaults for user ${maskUserId(clerkUserId)}`);
+  }
+}

--- a/workers/auth-worker/src/preference-defaults.ts
+++ b/workers/auth-worker/src/preference-defaults.ts
@@ -20,6 +20,9 @@ function maskUserId(userId: string): string {
  * Clear any sport default that matches the given platform + leagueId.
  * When seasonYear is provided, only clears an exact {platform, leagueId, seasonYear} match.
  * When omitted (ESPN all-seasons delete), clears any matching {platform, leagueId}.
+ *
+ * Returns { skipped: true, error } if a database error prevented the clear,
+ * or { skipped: false } if the operation completed (even if no columns matched).
  */
 export async function clearDefaultsForLeague(
   supabase: SupabaseClient,
@@ -27,7 +30,7 @@ export async function clearDefaultsForLeague(
   platform: Platform,
   leagueId: string,
   seasonYear?: number
-): Promise<void> {
+): Promise<{ skipped: boolean; error?: string }> {
   const { data, error } = await supabase
     .from('user_preferences')
     .select('default_football, default_baseball, default_basketball, default_hockey')
@@ -36,9 +39,9 @@ export async function clearDefaultsForLeague(
 
   if (error) {
     console.error('[preference-defaults] clearDefaultsForLeague: failed to read preferences:', error);
-    return;
+    return { skipped: true, error: error.message };
   }
-  if (!data) return;
+  if (!data) return { skipped: false };
 
   const updates: Record<string, null> = {};
   for (const sport of SPORT_COLUMNS) {
@@ -54,7 +57,7 @@ export async function clearDefaultsForLeague(
     }
   }
 
-  if (Object.keys(updates).length === 0) return;
+  if (Object.keys(updates).length === 0) return { skipped: false };
 
   const { error: upsertError } = await supabase
     .from('user_preferences')
@@ -65,19 +68,24 @@ export async function clearDefaultsForLeague(
 
   if (upsertError) {
     console.error('[preference-defaults] clearDefaultsForLeague: failed to clear stale defaults:', upsertError);
-  } else {
-    console.log(`[preference-defaults] clearDefaultsForLeague: cleared stale ${platform}:${leagueId} default for user ${maskUserId(clerkUserId)}`);
+    return { skipped: true, error: upsertError.message };
   }
+
+  console.log(`[preference-defaults] clearDefaultsForLeague: cleared stale ${platform}:${leagueId} default for user ${maskUserId(clerkUserId)}`);
+  return { skipped: false };
 }
 
 /**
  * Clear all sport defaults for a given platform (used on full-platform disconnect).
+ *
+ * Returns { skipped: true, error } if a database error prevented the clear,
+ * or { skipped: false } if the operation completed (even if no columns matched).
  */
 export async function clearDefaultsForPlatform(
   supabase: SupabaseClient,
   clerkUserId: string,
   platform: Platform
-): Promise<void> {
+): Promise<{ skipped: boolean; error?: string }> {
   const { data, error } = await supabase
     .from('user_preferences')
     .select('default_football, default_baseball, default_basketball, default_hockey')
@@ -86,9 +94,9 @@ export async function clearDefaultsForPlatform(
 
   if (error) {
     console.error('[preference-defaults] clearDefaultsForPlatform: failed to read preferences:', error);
-    return;
+    return { skipped: true, error: error.message };
   }
-  if (!data) return;
+  if (!data) return { skipped: false };
 
   const updates: Record<string, null> = {};
   for (const sport of SPORT_COLUMNS) {
@@ -99,7 +107,7 @@ export async function clearDefaultsForPlatform(
     }
   }
 
-  if (Object.keys(updates).length === 0) return;
+  if (Object.keys(updates).length === 0) return { skipped: false };
 
   const { error: upsertError } = await supabase
     .from('user_preferences')
@@ -110,7 +118,9 @@ export async function clearDefaultsForPlatform(
 
   if (upsertError) {
     console.error('[preference-defaults] clearDefaultsForPlatform: failed to clear platform defaults:', upsertError);
-  } else {
-    console.log(`[preference-defaults] clearDefaultsForPlatform: cleared ${platform} defaults for user ${maskUserId(clerkUserId)}`);
+    return { skipped: true, error: upsertError.message };
   }
+
+  console.log(`[preference-defaults] clearDefaultsForPlatform: cleared ${platform} defaults for user ${maskUserId(clerkUserId)}`);
+  return { skipped: false };
 }

--- a/workers/auth-worker/src/preference-defaults.ts
+++ b/workers/auth-worker/src/preference-defaults.ts
@@ -20,6 +20,8 @@ function maskUserId(userId: string): string {
  * Clear any sport default that matches the given platform + leagueId.
  * When seasonYear is provided, only clears an exact {platform, leagueId, seasonYear} match.
  * When omitted (ESPN all-seasons delete), clears any matching {platform, leagueId}.
+ * When sport is provided, scopes the clear to only that column — prevents a shared leagueId
+ * from accidentally clearing an unrelated sport's default.
  *
  * Returns { skipped: true, error } if a database error prevented the clear,
  * or { skipped: false } if the operation completed (even if no columns matched).
@@ -29,7 +31,8 @@ export async function clearDefaultsForLeague(
   clerkUserId: string,
   platform: Platform,
   leagueId: string,
-  seasonYear?: number
+  seasonYear?: number,
+  sport?: string
 ): Promise<{ skipped: boolean; error?: string }> {
   const { data, error } = await supabase
     .from('user_preferences')
@@ -43,9 +46,13 @@ export async function clearDefaultsForLeague(
   }
   if (!data) return { skipped: false };
 
+  const columnsToCheck = sport
+    ? SPORT_COLUMNS.filter(s => s === sport)
+    : SPORT_COLUMNS;
+
   const updates: Record<string, null> = {};
-  for (const sport of SPORT_COLUMNS) {
-    const col = `default_${sport}` as keyof typeof data;
+  for (const s of columnsToCheck) {
+    const col = `default_${s}` as keyof typeof data;
     const stored = data[col] as StoredDefault;
     if (
       stored &&

--- a/workers/auth-worker/src/sleeper-storage.ts
+++ b/workers/auth-worker/src/sleeper-storage.ts
@@ -1,6 +1,11 @@
 import { createClient } from '@supabase/supabase-js';
 import { clearDefaultsForLeague as _clearDefaultsForLeague, clearDefaultsForPlatform as _clearDefaultsForPlatform } from './preference-defaults';
 
+function maskUserId(userId: string): string {
+  if (!userId || userId.length <= 8) return '***';
+  return `${userId.substring(0, 8)}...`;
+}
+
 interface SleeperStorageEnv {
   SUPABASE_URL: string;
   SUPABASE_SERVICE_KEY: string;
@@ -137,12 +142,16 @@ export class SleeperStorage {
 
   async deleteSleeperLeague(clerkUserId: string, leagueId: string): Promise<void> {
     // Resolve platform identifiers before deleting (route arg is DB row UUID)
-    const { data: row } = await this.supabase
+    const { data: row, error: lookupError } = await this.supabase
       .from('sleeper_leagues')
       .select('league_id, season_year')
       .eq('clerk_user_id', clerkUserId)
       .eq('id', leagueId)
       .maybeSingle();
+
+    if (lookupError) {
+      console.warn(`[sleeper-storage] Failed to look up Sleeper league ${leagueId} before delete:`, lookupError);
+    }
 
     const { error } = await this.supabase
       .from('sleeper_leagues')
@@ -171,10 +180,16 @@ export class SleeperStorage {
   }
 
   private async _clearDefaultsForLeague(clerkUserId: string, platform: 'sleeper', leagueId: string, seasonYear: number): Promise<void> {
-    return _clearDefaultsForLeague(this.supabase, clerkUserId, platform, leagueId, seasonYear);
+    const result = await _clearDefaultsForLeague(this.supabase, clerkUserId, platform, leagueId, seasonYear);
+    if (result.skipped) {
+      console.warn(`[sleeper-storage] clearDefaultsForLeague skipped for user ${maskUserId(clerkUserId)}: ${result.error ?? 'unknown reason'}`);
+    }
   }
 
   private async _clearDefaultsForPlatform(clerkUserId: string, platform: 'sleeper'): Promise<void> {
-    return _clearDefaultsForPlatform(this.supabase, clerkUserId, platform);
+    const result = await _clearDefaultsForPlatform(this.supabase, clerkUserId, platform);
+    if (result.skipped) {
+      console.warn(`[sleeper-storage] clearDefaultsForPlatform skipped for user ${maskUserId(clerkUserId)}: ${result.error ?? 'unknown reason'}`);
+    }
   }
 }

--- a/workers/auth-worker/src/sleeper-storage.ts
+++ b/workers/auth-worker/src/sleeper-storage.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
+import { clearDefaultsForLeague as _clearDefaultsForLeague, clearDefaultsForPlatform as _clearDefaultsForPlatform } from './preference-defaults';
 
 interface SleeperStorageEnv {
   SUPABASE_URL: string;
@@ -169,69 +170,11 @@ export class SleeperStorage {
     await this._clearDefaultsForPlatform(clerkUserId, 'sleeper');
   }
 
-  private async _clearDefaultsForLeague(
-    clerkUserId: string,
-    platform: 'sleeper',
-    leagueId: string,
-    seasonYear: number
-  ): Promise<void> {
-    const sportColumns = ['football', 'baseball', 'basketball', 'hockey'] as const;
-    const { data, error } = await this.supabase
-      .from('user_preferences')
-      .select('default_football, default_baseball, default_basketball, default_hockey')
-      .eq('clerk_user_id', clerkUserId)
-      .maybeSingle();
-
-    if (error || !data) return;
-
-    const updates: Record<string, null> = {};
-    for (const sport of sportColumns) {
-      const col = `default_${sport}` as keyof typeof data;
-      const stored = data[col] as { platform: string; leagueId: string; seasonYear: number } | null;
-      if (stored && stored.platform === platform && stored.leagueId === leagueId && stored.seasonYear === seasonYear) {
-        updates[col] = null;
-      }
-    }
-
-    if (Object.keys(updates).length === 0) return;
-
-    await this.supabase
-      .from('user_preferences')
-      .upsert(
-        { clerk_user_id: clerkUserId, ...updates, updated_at: new Date().toISOString() },
-        { onConflict: 'clerk_user_id' }
-      );
+  private async _clearDefaultsForLeague(clerkUserId: string, platform: 'sleeper', leagueId: string, seasonYear: number): Promise<void> {
+    return _clearDefaultsForLeague(this.supabase, clerkUserId, platform, leagueId, seasonYear);
   }
 
-  private async _clearDefaultsForPlatform(
-    clerkUserId: string,
-    platform: 'sleeper'
-  ): Promise<void> {
-    const sportColumns = ['football', 'baseball', 'basketball', 'hockey'] as const;
-    const { data, error } = await this.supabase
-      .from('user_preferences')
-      .select('default_football, default_baseball, default_basketball, default_hockey')
-      .eq('clerk_user_id', clerkUserId)
-      .maybeSingle();
-
-    if (error || !data) return;
-
-    const updates: Record<string, null> = {};
-    for (const sport of sportColumns) {
-      const col = `default_${sport}` as keyof typeof data;
-      const stored = data[col] as { platform: string } | null;
-      if (stored && stored.platform === platform) {
-        updates[col] = null;
-      }
-    }
-
-    if (Object.keys(updates).length === 0) return;
-
-    await this.supabase
-      .from('user_preferences')
-      .upsert(
-        { clerk_user_id: clerkUserId, ...updates, updated_at: new Date().toISOString() },
-        { onConflict: 'clerk_user_id' }
-      );
+  private async _clearDefaultsForPlatform(clerkUserId: string, platform: 'sleeper'): Promise<void> {
+    return _clearDefaultsForPlatform(this.supabase, clerkUserId, platform);
   }
 }

--- a/workers/auth-worker/src/sleeper-storage.ts
+++ b/workers/auth-worker/src/sleeper-storage.ts
@@ -135,6 +135,14 @@ export class SleeperStorage {
   }
 
   async deleteSleeperLeague(clerkUserId: string, leagueId: string): Promise<void> {
+    // Resolve platform identifiers before deleting (route arg is DB row UUID)
+    const { data: row } = await this.supabase
+      .from('sleeper_leagues')
+      .select('league_id, season_year')
+      .eq('clerk_user_id', clerkUserId)
+      .eq('id', leagueId)
+      .maybeSingle();
+
     const { error } = await this.supabase
       .from('sleeper_leagues')
       .delete()
@@ -142,6 +150,11 @@ export class SleeperStorage {
       .eq('id', leagueId);
 
     if (error) throw new Error(`Failed to delete Sleeper league: ${error.message}`);
+
+    // Clear any sport default pointing to this league (keyed by platform league_id + season)
+    if (row) {
+      await this._clearDefaultsForLeague(clerkUserId, 'sleeper', row.league_id, row.season_year);
+    }
   }
 
   async deleteAllSleeperLeagues(clerkUserId: string): Promise<void> {
@@ -151,5 +164,74 @@ export class SleeperStorage {
       .eq('clerk_user_id', clerkUserId);
 
     if (error) throw new Error(`Failed to delete Sleeper leagues: ${error.message}`);
+
+    // Clear all Sleeper sport defaults for this user
+    await this._clearDefaultsForPlatform(clerkUserId, 'sleeper');
+  }
+
+  private async _clearDefaultsForLeague(
+    clerkUserId: string,
+    platform: 'sleeper',
+    leagueId: string,
+    seasonYear: number
+  ): Promise<void> {
+    const sportColumns = ['football', 'baseball', 'basketball', 'hockey'] as const;
+    const { data, error } = await this.supabase
+      .from('user_preferences')
+      .select('default_football, default_baseball, default_basketball, default_hockey')
+      .eq('clerk_user_id', clerkUserId)
+      .maybeSingle();
+
+    if (error || !data) return;
+
+    const updates: Record<string, null> = {};
+    for (const sport of sportColumns) {
+      const col = `default_${sport}` as keyof typeof data;
+      const stored = data[col] as { platform: string; leagueId: string; seasonYear: number } | null;
+      if (stored && stored.platform === platform && stored.leagueId === leagueId && stored.seasonYear === seasonYear) {
+        updates[col] = null;
+      }
+    }
+
+    if (Object.keys(updates).length === 0) return;
+
+    await this.supabase
+      .from('user_preferences')
+      .upsert(
+        { clerk_user_id: clerkUserId, ...updates, updated_at: new Date().toISOString() },
+        { onConflict: 'clerk_user_id' }
+      );
+  }
+
+  private async _clearDefaultsForPlatform(
+    clerkUserId: string,
+    platform: 'sleeper'
+  ): Promise<void> {
+    const sportColumns = ['football', 'baseball', 'basketball', 'hockey'] as const;
+    const { data, error } = await this.supabase
+      .from('user_preferences')
+      .select('default_football, default_baseball, default_basketball, default_hockey')
+      .eq('clerk_user_id', clerkUserId)
+      .maybeSingle();
+
+    if (error || !data) return;
+
+    const updates: Record<string, null> = {};
+    for (const sport of sportColumns) {
+      const col = `default_${sport}` as keyof typeof data;
+      const stored = data[col] as { platform: string } | null;
+      if (stored && stored.platform === platform) {
+        updates[col] = null;
+      }
+    }
+
+    if (Object.keys(updates).length === 0) return;
+
+    await this.supabase
+      .from('user_preferences')
+      .upsert(
+        { clerk_user_id: clerkUserId, ...updates, updated_at: new Date().toISOString() },
+        { onConflict: 'clerk_user_id' }
+      );
   }
 }

--- a/workers/auth-worker/src/supabase-storage.ts
+++ b/workers/auth-worker/src/supabase-storage.ts
@@ -490,8 +490,8 @@ export class EspnSupabaseStorage {
         return false;
       }
 
-      // Clear any stale defaults pointing to this ESPN league (all seasons deleted at once)
-      await this.clearStaleDefaultForLeague(clerkUserId, 'espn', leagueId);
+      // Clear any stale defaults pointing to this ESPN league for the deleted sport only
+      await this.clearStaleDefaultForLeague(clerkUserId, 'espn', leagueId, undefined, sport);
 
       return true;
     } catch (error) {

--- a/workers/auth-worker/src/supabase-storage.ts
+++ b/workers/auth-worker/src/supabase-storage.ts
@@ -673,14 +673,16 @@ export class EspnSupabaseStorage {
    * Clear any sport default that matches the given platform + leagueId.
    * When seasonYear is provided, only clears an exact match (platform, leagueId, seasonYear).
    * When omitted (ESPN all-seasons delete), clears any matching (platform, leagueId) regardless of year.
+   * When sport is provided, scopes the clear to only that column.
    */
   async clearStaleDefaultForLeague(
     clerkUserId: string,
     platform: 'espn' | 'yahoo' | 'sleeper',
     leagueId: string,
-    seasonYear?: number
+    seasonYear?: number,
+    sport?: string
   ): Promise<void> {
-    const result = await _clearDefaultsForLeague(this.supabase, clerkUserId, platform, leagueId, seasonYear);
+    const result = await _clearDefaultsForLeague(this.supabase, clerkUserId, platform, leagueId, seasonYear, sport);
     if (result.skipped) {
       console.warn(`[supabase-storage] clearStaleDefaultForLeague skipped for user ${maskUserId(clerkUserId)}: ${result.error ?? 'unknown reason'}`);
     }

--- a/workers/auth-worker/src/supabase-storage.ts
+++ b/workers/auth-worker/src/supabase-storage.ts
@@ -489,6 +489,9 @@ export class EspnSupabaseStorage {
         return false;
       }
 
+      // Clear any stale defaults pointing to this ESPN league (all seasons deleted at once)
+      await this.clearDefaultsForLeague(clerkUserId, 'espn', leagueId);
+
       return true;
     } catch (error) {
       console.error('[removeLeague] Failed to remove ESPN league:', error);
@@ -555,7 +558,7 @@ export class EspnSupabaseStorage {
     seasonYear: number
   ): Promise<{ success: boolean; error?: string }> {
     try {
-      // Validate the league exists and has a team_id (ESPN only for now)
+      // Validate the league exists before writing the default
       if (platform === 'espn') {
         const { data: targetLeague, error: checkError } = await this.supabase
           .from('espn_leagues')
@@ -574,8 +577,33 @@ export class EspnSupabaseStorage {
         if (!targetLeague.team_id) {
           return { success: false, error: 'Cannot set default: no team selected for this league' };
         }
+      } else if (platform === 'yahoo') {
+        const { data: targetLeague, error: checkError } = await this.supabase
+          .from('yahoo_leagues')
+          .select('league_key')
+          .eq('clerk_user_id', clerkUserId)
+          .eq('league_key', leagueId)
+          .eq('season_year', seasonYear)
+          .single();
+
+        if (checkError || !targetLeague) {
+          console.error('Yahoo league not found for default:', checkError);
+          return { success: false, error: 'League not found' };
+        }
+      } else if (platform === 'sleeper') {
+        const { data: targetLeague, error: checkError } = await this.supabase
+          .from('sleeper_leagues')
+          .select('league_id')
+          .eq('clerk_user_id', clerkUserId)
+          .eq('league_id', leagueId)
+          .eq('season_year', seasonYear)
+          .single();
+
+        if (checkError || !targetLeague) {
+          console.error('Sleeper league not found for default:', checkError);
+          return { success: false, error: 'League not found' };
+        }
       }
-      // Note: Yahoo validation could be added here if needed
 
       // Build the default object
       const defaultValue: LeagueDefault = { platform, leagueId, seasonYear };
@@ -637,6 +665,105 @@ export class EspnSupabaseStorage {
     } catch (error) {
       console.error('Failed to clear default league:', error);
       return { success: false, error: 'Internal error' };
+    }
+  }
+
+  /**
+   * Clear any sport default that matches the given platform + leagueId.
+   * When seasonYear is provided, only clears an exact match (platform, leagueId, seasonYear).
+   * When omitted (ESPN all-seasons delete), clears any matching (platform, leagueId) regardless of year.
+   */
+  async clearDefaultsForLeague(
+    clerkUserId: string,
+    platform: 'espn' | 'yahoo' | 'sleeper',
+    leagueId: string,
+    seasonYear?: number
+  ): Promise<void> {
+    const sportColumns = ['football', 'baseball', 'basketball', 'hockey'] as const;
+    const { data, error } = await this.supabase
+      .from('user_preferences')
+      .select('default_football, default_baseball, default_basketball, default_hockey')
+      .eq('clerk_user_id', clerkUserId)
+      .maybeSingle();
+
+    if (error) {
+      console.error('[supabase-storage] clearDefaultsForLeague: failed to read preferences:', error);
+      return;
+    }
+    if (!data) return;
+
+    const updates: Record<string, LeagueDefault | null> = {};
+    for (const sport of sportColumns) {
+      const col = `default_${sport}` as keyof typeof data;
+      const stored = data[col] as LeagueDefault | null;
+      if (
+        stored &&
+        stored.platform === platform &&
+        stored.leagueId === leagueId &&
+        (seasonYear === undefined || stored.seasonYear === seasonYear)
+      ) {
+        updates[col] = null;
+      }
+    }
+
+    if (Object.keys(updates).length === 0) return;
+
+    const { error: upsertError } = await this.supabase
+      .from('user_preferences')
+      .upsert(
+        { clerk_user_id: clerkUserId, ...updates, updated_at: new Date().toISOString() },
+        { onConflict: 'clerk_user_id' }
+      );
+
+    if (upsertError) {
+      console.error('[supabase-storage] clearDefaultsForLeague: failed to clear stale defaults:', upsertError);
+    } else {
+      console.log(`[supabase-storage] clearDefaultsForLeague: cleared stale ${platform}:${leagueId} defaults for user ${maskUserId(clerkUserId)}`);
+    }
+  }
+
+  /**
+   * Clear all sport defaults for a given platform (used on full-platform disconnect).
+   */
+  async clearDefaultsForPlatform(
+    clerkUserId: string,
+    platform: 'espn' | 'yahoo' | 'sleeper'
+  ): Promise<void> {
+    const sportColumns = ['football', 'baseball', 'basketball', 'hockey'] as const;
+    const { data, error } = await this.supabase
+      .from('user_preferences')
+      .select('default_football, default_baseball, default_basketball, default_hockey')
+      .eq('clerk_user_id', clerkUserId)
+      .maybeSingle();
+
+    if (error) {
+      console.error('[supabase-storage] clearDefaultsForPlatform: failed to read preferences:', error);
+      return;
+    }
+    if (!data) return;
+
+    const updates: Record<string, LeagueDefault | null> = {};
+    for (const sport of sportColumns) {
+      const col = `default_${sport}` as keyof typeof data;
+      const stored = data[col] as LeagueDefault | null;
+      if (stored && stored.platform === platform) {
+        updates[col] = null;
+      }
+    }
+
+    if (Object.keys(updates).length === 0) return;
+
+    const { error: upsertError } = await this.supabase
+      .from('user_preferences')
+      .upsert(
+        { clerk_user_id: clerkUserId, ...updates, updated_at: new Date().toISOString() },
+        { onConflict: 'clerk_user_id' }
+      );
+
+    if (upsertError) {
+      console.error('[supabase-storage] clearDefaultsForPlatform: failed to clear platform defaults:', upsertError);
+    } else {
+      console.log(`[supabase-storage] clearDefaultsForPlatform: cleared ${platform} defaults for user ${maskUserId(clerkUserId)}`);
     }
   }
 

--- a/workers/auth-worker/src/supabase-storage.ts
+++ b/workers/auth-worker/src/supabase-storage.ts
@@ -585,7 +585,7 @@ export class EspnSupabaseStorage {
           .eq('clerk_user_id', clerkUserId)
           .eq('league_key', leagueId)
           .eq('season_year', seasonYear)
-          .single();
+          .maybeSingle();
 
         if (checkError || !targetLeague) {
           console.error('Yahoo league not found for default:', checkError);
@@ -598,7 +598,7 @@ export class EspnSupabaseStorage {
           .eq('clerk_user_id', clerkUserId)
           .eq('league_id', leagueId)
           .eq('season_year', seasonYear)
-          .single();
+          .maybeSingle();
 
         if (checkError || !targetLeague) {
           console.error('Sleeper league not found for default:', checkError);

--- a/workers/auth-worker/src/supabase-storage.ts
+++ b/workers/auth-worker/src/supabase-storage.ts
@@ -15,6 +15,7 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { EspnCredentials, EspnCredentialsWithMetadata, EspnLeague, EspnUserData } from './espn-types';
 import { isCurrentSeason, type SeasonSport } from './season-utils';
+import { clearDefaultsForLeague as _clearDefaultsForLeague, clearDefaultsForPlatform as _clearDefaultsForPlatform } from './preference-defaults';
 
 /**
  * Mask user ID for logging to avoid PII exposure
@@ -679,47 +680,7 @@ export class EspnSupabaseStorage {
     leagueId: string,
     seasonYear?: number
   ): Promise<void> {
-    const sportColumns = ['football', 'baseball', 'basketball', 'hockey'] as const;
-    const { data, error } = await this.supabase
-      .from('user_preferences')
-      .select('default_football, default_baseball, default_basketball, default_hockey')
-      .eq('clerk_user_id', clerkUserId)
-      .maybeSingle();
-
-    if (error) {
-      console.error('[supabase-storage] clearDefaultsForLeague: failed to read preferences:', error);
-      return;
-    }
-    if (!data) return;
-
-    const updates: Record<string, LeagueDefault | null> = {};
-    for (const sport of sportColumns) {
-      const col = `default_${sport}` as keyof typeof data;
-      const stored = data[col] as LeagueDefault | null;
-      if (
-        stored &&
-        stored.platform === platform &&
-        stored.leagueId === leagueId &&
-        (seasonYear === undefined || stored.seasonYear === seasonYear)
-      ) {
-        updates[col] = null;
-      }
-    }
-
-    if (Object.keys(updates).length === 0) return;
-
-    const { error: upsertError } = await this.supabase
-      .from('user_preferences')
-      .upsert(
-        { clerk_user_id: clerkUserId, ...updates, updated_at: new Date().toISOString() },
-        { onConflict: 'clerk_user_id' }
-      );
-
-    if (upsertError) {
-      console.error('[supabase-storage] clearDefaultsForLeague: failed to clear stale defaults:', upsertError);
-    } else {
-      console.log(`[supabase-storage] clearDefaultsForLeague: cleared stale ${platform}:${leagueId} defaults for user ${maskUserId(clerkUserId)}`);
-    }
+    return _clearDefaultsForLeague(this.supabase, clerkUserId, platform, leagueId, seasonYear);
   }
 
   /**
@@ -729,42 +690,7 @@ export class EspnSupabaseStorage {
     clerkUserId: string,
     platform: 'espn' | 'yahoo' | 'sleeper'
   ): Promise<void> {
-    const sportColumns = ['football', 'baseball', 'basketball', 'hockey'] as const;
-    const { data, error } = await this.supabase
-      .from('user_preferences')
-      .select('default_football, default_baseball, default_basketball, default_hockey')
-      .eq('clerk_user_id', clerkUserId)
-      .maybeSingle();
-
-    if (error) {
-      console.error('[supabase-storage] clearDefaultsForPlatform: failed to read preferences:', error);
-      return;
-    }
-    if (!data) return;
-
-    const updates: Record<string, LeagueDefault | null> = {};
-    for (const sport of sportColumns) {
-      const col = `default_${sport}` as keyof typeof data;
-      const stored = data[col] as LeagueDefault | null;
-      if (stored && stored.platform === platform) {
-        updates[col] = null;
-      }
-    }
-
-    if (Object.keys(updates).length === 0) return;
-
-    const { error: upsertError } = await this.supabase
-      .from('user_preferences')
-      .upsert(
-        { clerk_user_id: clerkUserId, ...updates, updated_at: new Date().toISOString() },
-        { onConflict: 'clerk_user_id' }
-      );
-
-    if (upsertError) {
-      console.error('[supabase-storage] clearDefaultsForPlatform: failed to clear platform defaults:', upsertError);
-    } else {
-      console.log(`[supabase-storage] clearDefaultsForPlatform: cleared ${platform} defaults for user ${maskUserId(clerkUserId)}`);
-    }
+    return _clearDefaultsForPlatform(this.supabase, clerkUserId, platform);
   }
 
   /**

--- a/workers/auth-worker/src/supabase-storage.ts
+++ b/workers/auth-worker/src/supabase-storage.ts
@@ -491,7 +491,7 @@ export class EspnSupabaseStorage {
       }
 
       // Clear any stale defaults pointing to this ESPN league (all seasons deleted at once)
-      await this.clearDefaultsForLeague(clerkUserId, 'espn', leagueId);
+      await this.clearStaleDefaultForLeague(clerkUserId, 'espn', leagueId);
 
       return true;
     } catch (error) {
@@ -674,23 +674,29 @@ export class EspnSupabaseStorage {
    * When seasonYear is provided, only clears an exact match (platform, leagueId, seasonYear).
    * When omitted (ESPN all-seasons delete), clears any matching (platform, leagueId) regardless of year.
    */
-  async clearDefaultsForLeague(
+  async clearStaleDefaultForLeague(
     clerkUserId: string,
     platform: 'espn' | 'yahoo' | 'sleeper',
     leagueId: string,
     seasonYear?: number
   ): Promise<void> {
-    return _clearDefaultsForLeague(this.supabase, clerkUserId, platform, leagueId, seasonYear);
+    const result = await _clearDefaultsForLeague(this.supabase, clerkUserId, platform, leagueId, seasonYear);
+    if (result.skipped) {
+      console.warn(`[supabase-storage] clearStaleDefaultForLeague skipped for user ${maskUserId(clerkUserId)}: ${result.error ?? 'unknown reason'}`);
+    }
   }
 
   /**
    * Clear all sport defaults for a given platform (used on full-platform disconnect).
    */
-  async clearDefaultsForPlatform(
+  async clearStaleDefaultsForPlatform(
     clerkUserId: string,
     platform: 'espn' | 'yahoo' | 'sleeper'
   ): Promise<void> {
-    return _clearDefaultsForPlatform(this.supabase, clerkUserId, platform);
+    const result = await _clearDefaultsForPlatform(this.supabase, clerkUserId, platform);
+    if (result.skipped) {
+      console.warn(`[supabase-storage] clearStaleDefaultsForPlatform skipped for user ${maskUserId(clerkUserId)}: ${result.error ?? 'unknown reason'}`);
+    }
   }
 
   /**

--- a/workers/auth-worker/src/yahoo-storage.ts
+++ b/workers/auth-worker/src/yahoo-storage.ts
@@ -434,12 +434,16 @@ export class YahooStorage {
    */
   async deleteYahooLeague(clerkUserId: string, leagueId: string): Promise<void> {
     // Resolve platform identifiers before deleting (route arg is DB row UUID)
-    const { data: row } = await this.supabase
+    const { data: row, error: lookupError } = await this.supabase
       .from('yahoo_leagues')
       .select('league_key, season_year')
       .eq('clerk_user_id', clerkUserId)
       .eq('id', leagueId)
       .maybeSingle();
+
+    if (lookupError) {
+      console.warn(`[yahoo-storage] Failed to look up Yahoo league ${leagueId} before delete:`, lookupError);
+    }
 
     const { error } = await this.supabase
       .from('yahoo_leagues')
@@ -485,11 +489,17 @@ export class YahooStorage {
   // ---------------------------------------------------------------------------
 
   private async _clearDefaultsForLeague(clerkUserId: string, platform: 'yahoo', leagueId: string, seasonYear: number): Promise<void> {
-    return _clearDefaultsForLeague(this.supabase, clerkUserId, platform, leagueId, seasonYear);
+    const result = await _clearDefaultsForLeague(this.supabase, clerkUserId, platform, leagueId, seasonYear);
+    if (result.skipped) {
+      console.warn(`[yahoo-storage] clearDefaultsForLeague skipped for user ${maskUserId(clerkUserId)}: ${result.error ?? 'unknown reason'}`);
+    }
   }
 
   private async _clearDefaultsForPlatform(clerkUserId: string, platform: 'yahoo'): Promise<void> {
-    return _clearDefaultsForPlatform(this.supabase, clerkUserId, platform);
+    const result = await _clearDefaultsForPlatform(this.supabase, clerkUserId, platform);
+    if (result.skipped) {
+      console.warn(`[yahoo-storage] clearDefaultsForPlatform skipped for user ${maskUserId(clerkUserId)}: ${result.error ?? 'unknown reason'}`);
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/workers/auth-worker/src/yahoo-storage.ts
+++ b/workers/auth-worker/src/yahoo-storage.ts
@@ -14,6 +14,7 @@
  */
 
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { clearDefaultsForLeague as _clearDefaultsForLeague, clearDefaultsForPlatform as _clearDefaultsForPlatform } from './preference-defaults';
 
 // =============================================================================
 // TYPES
@@ -483,70 +484,12 @@ export class YahooStorage {
   // INTERNAL DEFAULT CLEANUP HELPERS
   // ---------------------------------------------------------------------------
 
-  private async _clearDefaultsForLeague(
-    clerkUserId: string,
-    platform: 'yahoo',
-    leagueId: string,
-    seasonYear: number
-  ): Promise<void> {
-    const sportColumns = ['football', 'baseball', 'basketball', 'hockey'] as const;
-    const { data, error } = await this.supabase
-      .from('user_preferences')
-      .select('default_football, default_baseball, default_basketball, default_hockey')
-      .eq('clerk_user_id', clerkUserId)
-      .maybeSingle();
-
-    if (error || !data) return;
-
-    const updates: Record<string, null> = {};
-    for (const sport of sportColumns) {
-      const col = `default_${sport}` as keyof typeof data;
-      const stored = data[col] as { platform: string; leagueId: string; seasonYear: number } | null;
-      if (stored && stored.platform === platform && stored.leagueId === leagueId && stored.seasonYear === seasonYear) {
-        updates[col] = null;
-      }
-    }
-
-    if (Object.keys(updates).length === 0) return;
-
-    await this.supabase
-      .from('user_preferences')
-      .upsert(
-        { clerk_user_id: clerkUserId, ...updates, updated_at: new Date().toISOString() },
-        { onConflict: 'clerk_user_id' }
-      );
+  private async _clearDefaultsForLeague(clerkUserId: string, platform: 'yahoo', leagueId: string, seasonYear: number): Promise<void> {
+    return _clearDefaultsForLeague(this.supabase, clerkUserId, platform, leagueId, seasonYear);
   }
 
-  private async _clearDefaultsForPlatform(
-    clerkUserId: string,
-    platform: 'yahoo'
-  ): Promise<void> {
-    const sportColumns = ['football', 'baseball', 'basketball', 'hockey'] as const;
-    const { data, error } = await this.supabase
-      .from('user_preferences')
-      .select('default_football, default_baseball, default_basketball, default_hockey')
-      .eq('clerk_user_id', clerkUserId)
-      .maybeSingle();
-
-    if (error || !data) return;
-
-    const updates: Record<string, null> = {};
-    for (const sport of sportColumns) {
-      const col = `default_${sport}` as keyof typeof data;
-      const stored = data[col] as { platform: string } | null;
-      if (stored && stored.platform === platform) {
-        updates[col] = null;
-      }
-    }
-
-    if (Object.keys(updates).length === 0) return;
-
-    await this.supabase
-      .from('user_preferences')
-      .upsert(
-        { clerk_user_id: clerkUserId, ...updates, updated_at: new Date().toISOString() },
-        { onConflict: 'clerk_user_id' }
-      );
+  private async _clearDefaultsForPlatform(clerkUserId: string, platform: 'yahoo'): Promise<void> {
+    return _clearDefaultsForPlatform(this.supabase, clerkUserId, platform);
   }
 
   // ---------------------------------------------------------------------------

--- a/workers/auth-worker/src/yahoo-storage.ts
+++ b/workers/auth-worker/src/yahoo-storage.ts
@@ -427,9 +427,19 @@ export class YahooStorage {
   }
 
   /**
-   * Delete a specific Yahoo league
+   * Delete a specific Yahoo league.
+   * Resolves the platform league_key and season_year before deleting so that any
+   * matching sport default in user_preferences can be cleared correctly.
    */
   async deleteYahooLeague(clerkUserId: string, leagueId: string): Promise<void> {
+    // Resolve platform identifiers before deleting (route arg is DB row UUID)
+    const { data: row } = await this.supabase
+      .from('yahoo_leagues')
+      .select('league_key, season_year')
+      .eq('clerk_user_id', clerkUserId)
+      .eq('id', leagueId)
+      .maybeSingle();
+
     const { error } = await this.supabase
       .from('yahoo_leagues')
       .delete()
@@ -442,6 +452,11 @@ export class YahooStorage {
     }
 
     console.log(`[yahoo-storage] Deleted Yahoo league ${leagueId} for user ${maskUserId(clerkUserId)}`);
+
+    // Clear any sport default pointing to this league (keyed by platform league_key + season)
+    if (row) {
+      await this._clearDefaultsForLeague(clerkUserId, 'yahoo', row.league_key, row.season_year);
+    }
   }
 
   /**
@@ -459,6 +474,79 @@ export class YahooStorage {
     }
 
     console.log(`[yahoo-storage] Deleted all Yahoo leagues for user ${maskUserId(clerkUserId)}`);
+
+    // Clear all Yahoo sport defaults for this user
+    await this._clearDefaultsForPlatform(clerkUserId, 'yahoo');
+  }
+
+  // ---------------------------------------------------------------------------
+  // INTERNAL DEFAULT CLEANUP HELPERS
+  // ---------------------------------------------------------------------------
+
+  private async _clearDefaultsForLeague(
+    clerkUserId: string,
+    platform: 'yahoo',
+    leagueId: string,
+    seasonYear: number
+  ): Promise<void> {
+    const sportColumns = ['football', 'baseball', 'basketball', 'hockey'] as const;
+    const { data, error } = await this.supabase
+      .from('user_preferences')
+      .select('default_football, default_baseball, default_basketball, default_hockey')
+      .eq('clerk_user_id', clerkUserId)
+      .maybeSingle();
+
+    if (error || !data) return;
+
+    const updates: Record<string, null> = {};
+    for (const sport of sportColumns) {
+      const col = `default_${sport}` as keyof typeof data;
+      const stored = data[col] as { platform: string; leagueId: string; seasonYear: number } | null;
+      if (stored && stored.platform === platform && stored.leagueId === leagueId && stored.seasonYear === seasonYear) {
+        updates[col] = null;
+      }
+    }
+
+    if (Object.keys(updates).length === 0) return;
+
+    await this.supabase
+      .from('user_preferences')
+      .upsert(
+        { clerk_user_id: clerkUserId, ...updates, updated_at: new Date().toISOString() },
+        { onConflict: 'clerk_user_id' }
+      );
+  }
+
+  private async _clearDefaultsForPlatform(
+    clerkUserId: string,
+    platform: 'yahoo'
+  ): Promise<void> {
+    const sportColumns = ['football', 'baseball', 'basketball', 'hockey'] as const;
+    const { data, error } = await this.supabase
+      .from('user_preferences')
+      .select('default_football, default_baseball, default_basketball, default_hockey')
+      .eq('clerk_user_id', clerkUserId)
+      .maybeSingle();
+
+    if (error || !data) return;
+
+    const updates: Record<string, null> = {};
+    for (const sport of sportColumns) {
+      const col = `default_${sport}` as keyof typeof data;
+      const stored = data[col] as { platform: string } | null;
+      if (stored && stored.platform === platform) {
+        updates[col] = null;
+      }
+    }
+
+    if (Object.keys(updates).length === 0) return;
+
+    await this.supabase
+      .from('user_preferences')
+      .upsert(
+        { clerk_user_id: clerkUserId, ...updates, updated_at: new Date().toISOString() },
+        { onConflict: 'clerk_user_id' }
+      );
   }
 
   // ---------------------------------------------------------------------------

--- a/workers/fantasy-mcp/src/__tests__/tools.test.ts
+++ b/workers/fantasy-mcp/src/__tests__/tools.test.ts
@@ -381,6 +381,161 @@ describe('fantasy-mcp tools', () => {
     expect(tool!.description).toContain('get_roster');
   });
 
+  // Test A: multi-league, no defaultSport pref → defaultLeague should be null
+  it('get_user_session: multiple leagues with no defaultSport → defaultLeague is null', async () => {
+    const tool = getUnifiedTools().find((t) => t.name === 'get_user_session');
+    expect(tool).toBeTruthy();
+
+    const twoLeagues = [
+      { platform: 'espn', sport: 'football', leagueId: 'fb1', leagueName: 'Gridiron', teamId: 't1', seasonYear: 2025 },
+      { platform: 'espn', sport: 'baseball', leagueId: 'bb1', leagueName: 'Diamond', teamId: 't2', seasonYear: 2026 },
+    ];
+
+    const env = {
+      INTERNAL_SERVICE_TOKEN: 'internal-secret',
+      AUTH_WORKER: {
+        fetch: async (req: Request) => {
+          const url = new URL(req.url);
+          if (url.pathname === '/internal/leagues') {
+            return new Response(JSON.stringify({ leagues: twoLeagues }), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          }
+          if (url.pathname === '/internal/user/preferences') {
+            return new Response(JSON.stringify({ defaultSport: null }), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          }
+          return new Response(JSON.stringify({ leagues: [] }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        },
+      },
+    } as unknown as Env;
+
+    const result = await tool!.handler({}, env, 'Bearer test-token');
+    const payload = JSON.parse(result.content[0].text) as {
+      defaultLeague: unknown;
+      totalLeaguesFound: number;
+    };
+    expect(payload.totalLeaguesFound).toBe(2);
+    expect(payload.defaultLeague).toBeNull();
+  });
+
+  // Test B: single league, no prefs → defaultLeague auto-populated
+  it('get_user_session: single league with no prefs → defaultLeague is auto-populated', async () => {
+    const tool = getUnifiedTools().find((t) => t.name === 'get_user_session');
+    expect(tool).toBeTruthy();
+
+    // Yahoo leagues API uses leagueKey (not leagueId) — fetchYahooLeagues maps leagueKey → leagueId
+    const oneYahooLeague = [
+      { sport: 'football', leagueKey: '449.l.123', leagueName: 'My Yahoo League', teamId: 't5', seasonYear: 2025 },
+    ];
+
+    const env = {
+      INTERNAL_SERVICE_TOKEN: 'internal-secret',
+      AUTH_WORKER: {
+        fetch: async (req: Request) => {
+          const url = new URL(req.url);
+          if (url.pathname === '/internal/leagues') {
+            return new Response(JSON.stringify({ leagues: [] }), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          }
+          if (url.pathname === '/internal/leagues/yahoo') {
+            return new Response(JSON.stringify({ leagues: oneYahooLeague }), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          }
+          return new Response(JSON.stringify({ leagues: [] }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        },
+      },
+    } as unknown as Env;
+
+    const result = await tool!.handler({}, env, 'Bearer test-token');
+    const payload = JSON.parse(result.content[0].text) as {
+      defaultLeague: { leagueId: string; platform: string; sport: string } | null;
+      totalLeaguesFound: number;
+    };
+    expect(payload.totalLeaguesFound).toBe(1);
+    expect(payload.defaultLeague).not.toBeNull();
+    expect(payload.defaultLeague?.leagueId).toBe('449.l.123');
+    expect(payload.defaultLeague?.platform).toBe('yahoo');
+    expect(payload.defaultLeague?.sport).toBe('football');
+  });
+
+  // Test C: stale default → DELETE fires with platform+leagueId params, warning appended
+  it('get_user_session: stale default fires conditional DELETE and appends warning', async () => {
+    const tool = getUnifiedTools().find((t) => t.name === 'get_user_session');
+    expect(tool).toBeTruthy();
+
+    const activeLeague = { platform: 'espn', sport: 'baseball', leagueId: 'bb1', leagueName: 'Diamond', teamId: 't2', seasonYear: 2026 };
+    // Football default points to a league that is no longer active
+    const stalePrefs = {
+      defaultSport: 'football',
+      defaultFootball: { platform: 'espn', leagueId: 'old-fb', seasonYear: 2024 },
+    };
+
+    let deleteCalled = false;
+    let deleteUrl: URL | null = null;
+
+    const env = {
+      INTERNAL_SERVICE_TOKEN: 'internal-secret',
+      AUTH_WORKER: {
+        fetch: async (req: Request) => {
+          const url = new URL(req.url);
+          if (url.pathname === '/internal/leagues') {
+            return new Response(JSON.stringify({ leagues: [activeLeague] }), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          }
+          if (url.pathname === '/internal/user/preferences') {
+            return new Response(JSON.stringify(stalePrefs), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          }
+          if (req.method === 'DELETE' && url.pathname.startsWith('/internal/leagues/default/')) {
+            deleteCalled = true;
+            deleteUrl = url;
+            return new Response(JSON.stringify({ success: true }), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          }
+          return new Response(JSON.stringify({ leagues: [] }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        },
+      },
+    } as unknown as Env;
+
+    const result = await tool!.handler({}, env, 'Bearer test-token');
+    const payload = JSON.parse(result.content[0].text) as {
+      warnings?: string[];
+    };
+
+    // DELETE should have been called with platform + leagueId query params
+    expect(deleteCalled).toBe(true);
+    expect(deleteUrl!.searchParams.get('platform')).toBe('espn');
+    expect(deleteUrl!.searchParams.get('leagueId')).toBe('old-fb');
+
+    // Warning should mention the stale league
+    expect(payload.warnings).toBeDefined();
+    expect(payload.warnings!.length).toBeGreaterThan(0);
+    expect(payload.warnings![0]).toContain('old-fb');
+  });
+
   it('get_players routes unchanged to client', async () => {
     const tool = getUnifiedTools().find((t) => t.name === 'get_players');
     expect(tool).toBeTruthy();

--- a/workers/fantasy-mcp/src/__tests__/tools.test.ts
+++ b/workers/fantasy-mcp/src/__tests__/tools.test.ts
@@ -172,6 +172,53 @@ describe('fantasy-mcp tools', () => {
     expect(bbOld?.seasonYear).toBe(2025);
   });
 
+  it('get_ancient_history keeps recurring Yahoo seasons under active leagues', async () => {
+    const tool = getUnifiedTools().find((t) => t.name === 'get_ancient_history');
+    expect(tool).toBeTruthy();
+
+    const yahooLeagues = [
+      { sport: 'football', leagueKey: '449.l.1000', leagueName: 'Touchdown League', teamId: 't1', seasonYear: 2024 },
+      { sport: 'football', leagueKey: '461.l.1000', leagueName: 'Touchdown League', teamId: 't2', seasonYear: 2025 },
+    ];
+
+    const env = {
+      INTERNAL_SERVICE_TOKEN: 'internal-secret',
+      AUTH_WORKER: {
+        fetch: async (req: Request) => {
+          const url = new URL(req.url);
+          if (url.pathname === '/internal/leagues/yahoo') {
+            return new Response(JSON.stringify({ leagues: yahooLeagues }), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          }
+          return new Response(JSON.stringify({ leagues: [] }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        },
+      },
+    } as unknown as Env;
+
+    const result = await tool!.handler({}, env, 'Bearer test-token');
+    const payload = JSON.parse(result.content[0].text) as {
+      oldLeagues: Array<{ platform: string; leagueId: string; seasonYear: number }>;
+      oldSeasonsFromActiveLeagues: Record<string, Array<{ platform: string; leagueId: string; seasonYear: number }>>;
+      totalOldLeagues: number;
+      totalOldSeasons: number;
+    };
+
+    expect(payload.totalOldLeagues).toBe(0);
+    expect(payload.totalOldSeasons).toBe(1);
+    const allOldSeasons = Object.values(payload.oldSeasonsFromActiveLeagues).flat();
+    expect(allOldSeasons).toHaveLength(1);
+    expect(allOldSeasons[0]).toMatchObject({
+      platform: 'yahoo',
+      leagueId: '449.l.1000',
+      seasonYear: 2024,
+    });
+  });
+
   it('get_league_info routes to client and formats a success payload', async () => {
     const tool = getUnifiedTools().find((t) => t.name === 'get_league_info');
     expect(tool).toBeTruthy();
@@ -525,10 +572,11 @@ describe('fantasy-mcp tools', () => {
       warnings?: string[];
     };
 
-    // DELETE should have been called with platform + leagueId query params
+    // DELETE should have been called with platform + leagueId + seasonYear query params
     expect(deleteCalled).toBe(true);
     expect(deleteUrl!.searchParams.get('platform')).toBe('espn');
     expect(deleteUrl!.searchParams.get('leagueId')).toBe('old-fb');
+    expect(deleteUrl!.searchParams.get('seasonYear')).toBe('2024');
 
     // Warning should mention the stale league
     expect(payload.warnings).toBeDefined();
@@ -596,10 +644,10 @@ describe('fantasy-mcp tools', () => {
     const tool = getUnifiedTools().find((t) => t.name === 'get_user_session');
     expect(tool).toBeTruthy();
 
-    // Same Yahoo league renewed across two seasons — should surface only 2025
+    // Same Yahoo league renewed across two seasons — game_key changes, stable league_id does not.
     const yahooLeagues = [
-      { sport: 'football', leagueKey: 'nfl.l.1000', leagueName: 'Touchdown League', teamId: 't1', seasonYear: 2024 },
-      { sport: 'football', leagueKey: 'nfl.l.2000', leagueName: 'Touchdown League', teamId: 't2', seasonYear: 2025 },
+      { sport: 'football', leagueKey: '449.l.1000', leagueName: 'Touchdown League', teamId: 't1', seasonYear: 2024 },
+      { sport: 'football', leagueKey: '461.l.1000', leagueName: 'Touchdown League', teamId: 't2', seasonYear: 2025 },
     ];
 
     const env = {
@@ -633,6 +681,49 @@ describe('fantasy-mcp tools', () => {
     );
     expect(yahooFootball).toHaveLength(1);
     expect(yahooFootball[0].seasonYear).toBe(2025);
+    expect(yahooFootball[0].leagueId).toBe('461.l.1000');
+  });
+
+  it('get_user_session: distinct Yahoo leagues with the same name remain separate', async () => {
+    const tool = getUnifiedTools().find((t) => t.name === 'get_user_session');
+    expect(tool).toBeTruthy();
+
+    const yahooLeagues = [
+      { sport: 'football', leagueKey: '461.l.1000', leagueName: 'Touchdown League', teamId: 't1', seasonYear: 2025 },
+      { sport: 'football', leagueKey: '461.l.2000', leagueName: 'Touchdown League', teamId: 't2', seasonYear: 2025 },
+    ];
+
+    const env = {
+      INTERNAL_SERVICE_TOKEN: 'internal-secret',
+      AUTH_WORKER: {
+        fetch: async (req: Request) => {
+          const url = new URL(req.url);
+          if (url.pathname === '/internal/leagues/yahoo') {
+            return new Response(JSON.stringify({ leagues: yahooLeagues }), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          }
+          return new Response(JSON.stringify({ leagues: [] }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        },
+      },
+    } as unknown as Env;
+
+    const result = await tool!.handler({}, env, 'Bearer test-token');
+    const payload = JSON.parse(result.content[0].text) as {
+      allLeagues: Array<{ platform: string; sport: string; leagueId: string; leagueName: string }>;
+      totalLeaguesFound: number;
+    };
+
+    const yahooFootball = payload.allLeagues.filter(
+      (l) => l.platform === 'yahoo' && l.sport === 'football'
+    );
+    expect(payload.totalLeaguesFound).toBe(2);
+    expect(yahooFootball).toHaveLength(2);
+    expect(yahooFootball.map((l) => l.leagueId).sort()).toEqual(['461.l.1000', '461.l.2000']);
   });
 
   it('get_players routes unchanged to client', async () => {

--- a/workers/fantasy-mcp/src/__tests__/tools.test.ts
+++ b/workers/fantasy-mcp/src/__tests__/tools.test.ts
@@ -536,6 +536,105 @@ describe('fantasy-mcp tools', () => {
     expect(payload.warnings![0]).toContain('old-fb');
   });
 
+  it('get_user_session: stale default skips DELETE when platform fetch failed', async () => {
+    const tool = getUnifiedTools().find((t) => t.name === 'get_user_session');
+    expect(tool).toBeTruthy();
+
+    const stalePrefs = {
+      defaultSport: 'football',
+      defaultFootball: { platform: 'yahoo', leagueId: 'nfl.l.123', seasonYear: 2025 },
+    };
+
+    let deleteCalled = false;
+
+    const env = {
+      INTERNAL_SERVICE_TOKEN: 'internal-secret',
+      AUTH_WORKER: {
+        fetch: async (req: Request) => {
+          const url = new URL(req.url);
+          if (url.pathname === '/internal/leagues') {
+            return new Response(JSON.stringify({ leagues: [] }), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          }
+          if (url.pathname === '/internal/leagues/yahoo') {
+            // Simulate Yahoo fetch failure
+            return new Response(JSON.stringify({ error: 'Yahoo API unavailable' }), {
+              status: 502,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          }
+          if (url.pathname === '/internal/user/preferences') {
+            return new Response(JSON.stringify(stalePrefs), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          }
+          if (req.method === 'DELETE' && url.pathname.startsWith('/internal/leagues/default/')) {
+            deleteCalled = true;
+            return new Response(JSON.stringify({ success: true }), { status: 200 });
+          }
+          return new Response(JSON.stringify({ leagues: [] }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        },
+      },
+    } as unknown as Env;
+
+    const result = await tool!.handler({}, env, 'Bearer test-token');
+    const payload = JSON.parse(result.content[0].text) as { warnings?: string[] };
+
+    // DELETE must NOT fire when the platform fetch failed
+    expect(deleteCalled).toBe(false);
+    // A warning should appear mentioning the unavailability (not clearing)
+    expect(payload.warnings?.some((w) => w.includes('temporarily unavailable'))).toBe(true);
+  });
+
+  it('get_user_session: recurring Yahoo leagues dedup to current season only', async () => {
+    const tool = getUnifiedTools().find((t) => t.name === 'get_user_session');
+    expect(tool).toBeTruthy();
+
+    // Same Yahoo league renewed across two seasons — should surface only 2025
+    const yahooLeagues = [
+      { sport: 'football', leagueKey: 'nfl.l.1000', leagueName: 'Touchdown League', teamId: 't1', seasonYear: 2024 },
+      { sport: 'football', leagueKey: 'nfl.l.2000', leagueName: 'Touchdown League', teamId: 't2', seasonYear: 2025 },
+    ];
+
+    const env = {
+      INTERNAL_SERVICE_TOKEN: 'internal-secret',
+      AUTH_WORKER: {
+        fetch: async (req: Request) => {
+          const url = new URL(req.url);
+          if (url.pathname === '/internal/leagues/yahoo') {
+            return new Response(JSON.stringify({ leagues: yahooLeagues }), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          }
+          return new Response(JSON.stringify({ leagues: [] }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        },
+      },
+    } as unknown as Env;
+
+    const result = await tool!.handler({}, env, 'Bearer test-token');
+    const payload = JSON.parse(result.content[0].text) as {
+      allLeagues: Array<{ platform: string; sport: string; leagueId: string; seasonYear: number }>;
+      totalLeaguesFound: number;
+    };
+
+    // Only the 2025 season should appear — 2024 is superseded
+    const yahooFootball = payload.allLeagues.filter(
+      (l) => l.platform === 'yahoo' && l.sport === 'football'
+    );
+    expect(yahooFootball).toHaveLength(1);
+    expect(yahooFootball[0].seasonYear).toBe(2025);
+  });
+
   it('get_players routes unchanged to client', async () => {
     const tool = getUnifiedTools().find((t) => t.name === 'get_players');
     expect(tool).toBeTruthy();

--- a/workers/fantasy-mcp/src/mcp/instructions.ts
+++ b/workers/fantasy-mcp/src/mcp/instructions.ts
@@ -1,0 +1,17 @@
+// workers/fantasy-mcp/src/mcp/instructions.ts
+
+/**
+ * Short operational rulebook injected into the MCP initialize response.
+ * Delivery is best-effort — MCP spec says host handling is implementation-defined.
+ * Keep this concise (~500 tokens). No persona, no setup URLs, no tool re-documentation.
+ */
+export const FLAIM_MCP_INSTRUCTIONS = `Flaim provides read-only fantasy league data across ESPN, Yahoo, and Sleeper.
+
+Scope resolution rules:
+1. Call get_user_session once at the start of the chat, before any data tool.
+2. For vague singular prompts ("how's my team?", "what's my matchup?"), use preferences.defaultSport and that sport's league from defaultLeagues. No fan-out, no asking.
+3. For explicit plural or comparative prompts ("each of my leagues", "compare my ESPN and Yahoo", "all my teams", "across my leagues"), enumerate every matching league in allLeagues and call the target tool once per league before synthesizing.
+4. For ambiguous prompts with no applicable default, ask which league.
+5. Call get_league_info early for any league-specific tool chain so team names, scoring, and roster slots are resolved before downstream calls. When fanning out, call it once per league.
+6. Never infer league ownership from a player's market_percent_owned or ownership_scope. For "who owns X in my league", enumerate teams via get_league_info and call get_roster per team.
+7. Do not retry the same tool with the same parameters on error. season_year is always the start year of the season.`;

--- a/workers/fantasy-mcp/src/mcp/server.ts
+++ b/workers/fantasy-mcp/src/mcp/server.ts
@@ -3,6 +3,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { Env } from '../types';
 import { getUnifiedTools, hasRequiredScope, mcpAuthError } from './tools';
 import { USER_SESSION_WIDGET_HTML } from '../widgets/user-session-widget';
+import { FLAIM_MCP_INSTRUCTIONS } from './instructions';
 
 export interface McpContext {
   env: Env;
@@ -20,16 +21,19 @@ export interface McpContext {
 export function createFantasyMcpServer(ctx: McpContext): McpServer {
   const { env, authHeader, tokenScope, correlationId, evalRunId, evalTraceId } = ctx;
 
-  const server = new McpServer({
-    name: 'fantasy-mcp',
-    version: '1.0.0',
-    icons: [
-      {
-        src: 'https://flaim.app/icon-light.png',
-        mimeType: 'image/png',
-      },
-    ],
-  });
+  const server = new McpServer(
+    {
+      name: 'fantasy-mcp',
+      version: '1.0.0',
+      icons: [
+        {
+          src: 'https://flaim.app/icon-light.png',
+          mimeType: 'image/png',
+        },
+      ],
+    },
+    { instructions: FLAIM_MCP_INSTRUCTIONS }
+  );
 
   // Register widget resources
   server.registerResource(

--- a/workers/fantasy-mcp/src/mcp/tools.ts
+++ b/workers/fantasy-mcp/src/mcp/tools.ts
@@ -591,6 +591,7 @@ export function getUnifiedTools(): UnifiedTool[] {
               } else {
                 // Stale default — no matching active league. Fire a best-effort clear
                 // so future reads don't repeat this lookup, then surface a warning.
+                let cleared = false;
                 try {
                   const staleHeaders: Record<string, string> = {
                     'Content-Type': 'application/json',
@@ -599,13 +600,21 @@ export function getUnifiedTools(): UnifiedTool[] {
                   const withStaleCorrelation = correlationId ? withCorrelationId(staleHeaders, correlationId) : new Headers(staleHeaders);
                   const withStaleInternal = withInternalServiceToken(withStaleCorrelation, env, `auth-worker /internal/leagues/default/${sport}`);
                   const staleHeaders2 = withEvalHeaders(withStaleInternal, evalRunId, evalTraceId);
-                  await env.AUTH_WORKER.fetch(
+                  const clearResp = await env.AUTH_WORKER.fetch(
                     new Request(`https://internal/internal/leagues/default/${sport}`, { method: 'DELETE', headers: staleHeaders2 })
                   );
+                  cleared = clearResp.ok;
+                  if (!clearResp.ok) {
+                    console.error(`[get_user_session] Stale ${sport} default DELETE returned ${clearResp.status}`);
+                  }
                 } catch (e) {
                   console.error(`[get_user_session] Failed to clear stale ${sport} default:`, e);
                 }
-                warnings.push(`Cleared stale ${sport} default: league ${defaultInfo.leagueId} is no longer in your active leagues.`);
+                warnings.push(
+                  cleared
+                    ? `Cleared stale ${sport} default: league ${defaultInfo.leagueId} is no longer in your active leagues.`
+                    : `Stale ${sport} default detected (league ${defaultInfo.leagueId} is no longer active) — automatic cleanup failed, will retry next session.`
+                );
               }
             }
           }

--- a/workers/fantasy-mcp/src/mcp/tools.ts
+++ b/workers/fantasy-mcp/src/mcp/tools.ts
@@ -591,24 +591,27 @@ export function getUnifiedTools(): UnifiedTool[] {
               } else {
                 // Stale default — no matching active league. Fire a best-effort clear
                 // so future reads don't repeat this lookup, then surface a warning.
+                const staleBaseHeaders: Record<string, string> = {
+                  'Content-Type': 'application/json',
+                  ...(authHeader ? { Authorization: authHeader } : {}),
+                };
+                const withStaleCorrelation = correlationId ? withCorrelationId(staleBaseHeaders, correlationId) : new Headers(staleBaseHeaders);
+                const withStaleInternal = withInternalServiceToken(withStaleCorrelation, env, `auth-worker /internal/leagues/default/${sport}`);
+                const staleHeaders = withEvalHeaders(withStaleInternal, evalRunId, evalTraceId);
+                const staleUrl = new URL(`https://internal/internal/leagues/default/${sport}`);
+                staleUrl.searchParams.set('platform', defaultInfo.platform);
+                staleUrl.searchParams.set('leagueId', defaultInfo.leagueId);
                 let cleared = false;
                 try {
-                  const staleHeaders: Record<string, string> = {
-                    'Content-Type': 'application/json',
-                    ...(authHeader ? { Authorization: authHeader } : {}),
-                  };
-                  const withStaleCorrelation = correlationId ? withCorrelationId(staleHeaders, correlationId) : new Headers(staleHeaders);
-                  const withStaleInternal = withInternalServiceToken(withStaleCorrelation, env, `auth-worker /internal/leagues/default/${sport}`);
-                  const staleHeaders2 = withEvalHeaders(withStaleInternal, evalRunId, evalTraceId);
                   const clearResp = await env.AUTH_WORKER.fetch(
-                    new Request(`https://internal/internal/leagues/default/${sport}`, { method: 'DELETE', headers: staleHeaders2 })
+                    new Request(staleUrl.toString(), { method: 'DELETE', headers: staleHeaders })
                   );
                   cleared = clearResp.ok;
                   if (!clearResp.ok) {
                     console.error(`[get_user_session] Stale ${sport} default DELETE returned ${clearResp.status}`);
                   }
                 } catch (e) {
-                  console.error(`[get_user_session] Failed to clear stale ${sport} default:`, e);
+                  console.error(`[get_user_session] Network error clearing stale ${sport} default:`, e);
                 }
                 warnings.push(
                   cleared

--- a/workers/fantasy-mcp/src/mcp/tools.ts
+++ b/workers/fantasy-mcp/src/mcp/tools.ts
@@ -446,7 +446,7 @@ export function getUnifiedTools(): UnifiedTool[] {
       openaiMeta: { invoking: 'Loading your leagues\u2026', invoked: 'Leagues loaded' },
       widgetUri: 'ui://widget/user-session.html',
       description:
-        "Call this exactly once at the start of each chat before any other Flaim tool. It establishes the chat's working league context by discovering the user's available leagues and defaults, and returns the platform, sport, leagueId, teamId, and seasonYear values needed for subsequent tool calls. In normal chat flows, do not skip this first step. After this, strongly consider calling get_league_info as the second call for the selected league. season_year always represents the start year of the season. Read-only and safe to retry.",
+        "Call this exactly once at the start of each chat before any other Flaim tool. Returns the user's full league landscape: allLeagues (all active leagues), defaultLeagues (per-sport defaults), and defaultLeague (populated only when a single league exists or defaultSport matches). Use defaultLeague for vague singular prompts. For explicit plural or comparative prompts (each, all, compare, across leagues/platforms), enumerate every matching league in allLeagues and call the target tool once per league. In normal chat flows, do not skip this first step. After this, strongly consider calling get_league_info for the target league. season_year always represents the start year of the season. Read-only and safe to retry.",
       inputSchema: {},
       handler: async (_args, env, authHeader, correlationId, evalRunId, evalTraceId) => {
         return withToolLogging(correlationId, 'get_user_session', 'session', async () => {
@@ -483,9 +483,7 @@ export function getUnifiedTools(): UnifiedTool[] {
           // Group leagues by unique league identifier
           const leagueGroups = new Map<string, typeof allLeagues>();
           for (const league of allLeagues) {
-            const key = league.platform === 'yahoo'
-              ? `${league.platform}:${league.leagueName}`
-              : `${league.platform}:${league.leagueId}`;
+            const key = `${league.platform}:${league.leagueId}`;
             if (!leagueGroups.has(key)) {
               leagueGroups.set(key, []);
             }
@@ -533,9 +531,10 @@ export function getUnifiedTools(): UnifiedTool[] {
             const league = leagues[0];
             sessionMessage = `Use platform="${league.platform}", sport="${league.sport}", leagueId="${league.leagueId}", teamId="${league.teamId || 'none'}", seasonYear=${league.seasonYear} for all tool calls.`;
           } else {
-            sessionMessage = `User has ${leagues.length} leagues configured across: ${Object.entries(sportCounts)
+            const sportSummary = Object.entries(sportCounts)
               .map(([sport, count]) => `${count} ${sport}`)
-              .join(', ')}. Only current-season leagues are shown. For past seasons or historical data, use get_ancient_history. Infer sport from context (e.g., "tight ends" → football) and use that sport's default league. If sport is unclear, use the default sport and its default league. Only ask when no default applies.`;
+              .join(', ');
+            sessionMessage = `User has ${leagues.length} active leagues across ${sportSummary}. Scope rules: (1) For vague singular prompts ("how's my team?", "what's my matchup?"), use preferences.defaultSport and that sport's defaultLeagues entry — no fan-out, no asking. (2) For explicit plural or comparative prompts ("each of my leagues", "compare my ESPN and Yahoo", "all my teams"), enumerate every matching league in allLeagues and call the target tool once per league before synthesizing. (3) For ambiguous prompts with no applicable default, ask which league. For past seasons or historical data, use get_ancient_history.`;
           }
 
           // Fetch user preferences for defaults
@@ -589,16 +588,36 @@ export function getUnifiedTools(): UnifiedTool[] {
               );
               if (matchingLeague) {
                 defaultLeagues[sport] = matchingLeague;
+              } else {
+                // Stale default — no matching active league. Fire a best-effort clear
+                // so future reads don't repeat this lookup, then surface a warning.
+                try {
+                  const staleHeaders: Record<string, string> = {
+                    'Content-Type': 'application/json',
+                    ...(authHeader ? { Authorization: authHeader } : {}),
+                  };
+                  const withStaleCorrelation = correlationId ? withCorrelationId(staleHeaders, correlationId) : new Headers(staleHeaders);
+                  const withStaleInternal = withInternalServiceToken(withStaleCorrelation, env, `auth-worker /internal/leagues/default/${sport}`);
+                  const staleHeaders2 = withEvalHeaders(withStaleInternal, evalRunId, evalTraceId);
+                  await env.AUTH_WORKER.fetch(
+                    new Request(`https://internal/internal/leagues/default/${sport}`, { method: 'DELETE', headers: staleHeaders2 })
+                  );
+                } catch (e) {
+                  console.error(`[get_user_session] Failed to clear stale ${sport} default:`, e);
+                }
+                warnings.push(`Cleared stale ${sport} default: league ${defaultInfo.leagueId} is no longer in your active leagues.`);
               }
             }
           }
 
-          // Compute primary default from preferences
+          // Compute primary default — three deterministic branches only:
+          // 1. defaultSport is set AND that sport has a validated default in defaultLeagues
+          // 2. Exactly one active league (single-user shortcut, no prefs needed)
+          // 3. null — no arbitrary fallback; model should fan out or ask
           const primarySport = preferences.defaultSport as string | undefined;
           const defaultLeague =
             (primarySport && defaultLeagues[primarySport]) ||
-            Object.values(defaultLeagues)[0] ||
-            leagues[0];
+            (leagues.length === 1 ? leagues[0] : null);
 
           const sessionData = {
             success: true,
@@ -706,9 +725,7 @@ export function getUnifiedTools(): UnifiedTool[] {
           // Group by league
           const leagueGroups = new Map<string, typeof allLeagues>();
           for (const league of allLeagues) {
-            const key = league.platform === 'yahoo'
-              ? `${league.platform}:${league.leagueName}`
-              : `${league.platform}:${league.leagueId}`;
+            const key = `${league.platform}:${league.leagueId}`;
             if (!leagueGroups.has(key)) {
               leagueGroups.set(key, []);
             }
@@ -763,7 +780,7 @@ export function getUnifiedTools(): UnifiedTool[] {
       requiredScope: 'mcp:read',
       securitySchemes: buildSecuritySchemes('mcp:read'),
       openaiMeta: { invoking: 'Fetching league info\u2026', invoked: 'League info ready' },
-      description: `Strongly encouraged as the second call after get_user_session for the selected league. This provides the baseline league context for analysis: league name, settings, scoring type, roster configuration, and team/owner context, plus schedule or season-window metadata when the platform provides it. Use it liberally before standings, matchups, roster, free-agent, player, or transaction analysis so team names are resolved and the model has league-type, scoring, and roster context. The exact team fields vary by platform but all include ownerName. Use values from get_user_session. Read-only and safe to retry. Current date is ${currentDate}.`,
+      description: `Strongly encouraged as the second call after get_user_session for the specified league. This provides the baseline league context for analysis: league name, settings, scoring type, roster configuration, and team/owner context, plus schedule or season-window metadata when the platform provides it. Use it liberally before standings, matchups, roster, free-agent, player, or transaction analysis so team names are resolved and the model has league-type, scoring, and roster context. When fanning out across multiple leagues, call this once per league. The exact team fields vary by platform but all include ownerName. Use values from get_user_session. Read-only and safe to retry. Current date is ${currentDate}.`,
       inputSchema: {
         platform: z
           .enum(['espn', 'yahoo', 'sleeper'])
@@ -798,7 +815,7 @@ export function getUnifiedTools(): UnifiedTool[] {
       requiredScope: 'mcp:read',
       securitySchemes: buildSecuritySchemes('mcp:read'),
       openaiMeta: { invoking: 'Fetching standings\u2026', invoked: 'Standings ready' },
-      description: `Get season standings and outcome snapshot; includes verified season-outcome fields when available. Returns team records, rankings, and points summaries. The rank field is a standings sort position (1 = best): on ESPN and Sleeper it is computed by Flaim from win percentage; on Yahoo it is passed through from Yahoo's own standings API. It is NOT a verified postseason finish. For verified postseason outcome, use finalRank and championshipWon instead. Also returns seasonPhase (regular_season/playoffs_in_progress/season_complete), seasonComplete, and per-team outcome fields: finalRank, championshipWon, playoffOutcome, outcomeConfidence, madePlayoffs, playoffSeed. Outcome fields are null when not verifiable — do not infer championship from rank or team name. Note: playoffOutcome returns 'in_progress' on Sleeper for teams in active playoffs; ESPN and Yahoo return null for that state. ESPN may also include projected-rank fields. Best used after get_user_session and, in most league-specific chats, after get_league_info so team names and league context are already established. For historical finish questions, call get_ancient_history first to discover seasons, then call this tool per season for verified outcomes. Read-only and safe to retry. Current date is ${currentDate}.`,
+      description: `Get season standings and outcome snapshot; includes verified season-outcome fields when available. Returns team records, rankings, and points summaries. The rank field is a standings sort position (1 = best): on ESPN and Sleeper it is computed by Flaim from win percentage; on Yahoo it is passed through from Yahoo's own standings API. It is NOT a verified postseason finish. For verified postseason outcome, use finalRank and championshipWon instead. Also returns seasonPhase (regular_season/playoffs_in_progress/season_complete), seasonComplete, and per-team outcome fields: finalRank, championshipWon, playoffOutcome, outcomeConfidence, madePlayoffs, playoffSeed. Outcome fields are null when not verifiable — do not infer championship from rank or team name. Note: playoffOutcome returns 'in_progress' on Sleeper for teams in active playoffs; ESPN and Yahoo return null for that state. ESPN may also include projected-rank fields. Best used after get_user_session and after get_league_info for the specified league so team names and league context are already established. For multi-league comparisons, call once per league. For historical finish questions, call get_ancient_history first to discover seasons, then call this tool per season for verified outcomes. Read-only and safe to retry. Current date is ${currentDate}.`,
       inputSchema: {
         platform: z
           .enum(['espn', 'yahoo', 'sleeper'])
@@ -833,7 +850,7 @@ export function getUnifiedTools(): UnifiedTool[] {
       requiredScope: 'mcp:read',
       securitySchemes: buildSecuritySchemes('mcp:read'),
       openaiMeta: { invoking: 'Fetching matchups\u2026', invoked: 'Matchups ready' },
-      description: `Get matchups/scoreboard for a specific week or the current week. Best used after get_user_session and, in most league-specific chats, after get_league_info so the model already knows the league's team names, owner/team mapping, and league context before interpreting the matchup. Read-only and safe to retry. Current date is ${currentDate}.`,
+      description: `Get matchups/scoreboard for a specific week or the current week. Best used after get_user_session and after get_league_info for the specified league so the model already knows the league's team names, owner/team mapping, and league context before interpreting the matchup. For multi-league comparisons, call once per league. Read-only and safe to retry. Current date is ${currentDate}.`,
       inputSchema: {
         platform: z
           .enum(['espn', 'yahoo', 'sleeper'])
@@ -870,7 +887,7 @@ export function getUnifiedTools(): UnifiedTool[] {
       requiredScope: 'mcp:read',
       securitySchemes: buildSecuritySchemes('mcp:read'),
       openaiMeta: { invoking: 'Fetching roster\u2026', invoked: 'Roster ready' },
-      description: `Get roster details for a specific team. Exact payload varies by platform: ESPN and Yahoo return player entries with lineup/position context, while Sleeper returns starters, bench, reserve, and record metadata for the selected roster. Best used after get_user_session and, in most league-specific chats, after get_league_info so the model already knows the league's team names, owner/team mapping, league settings, and roster context before interpreting this roster. Requires authentication except on Sleeper's public API. Read-only and safe to retry. Current date is ${currentDate}.`,
+      description: `Get roster details for a specific team. Exact payload varies by platform: ESPN and Yahoo return player entries with lineup/position context, while Sleeper returns starters, bench, reserve, and record metadata for the selected roster. Best used after get_user_session and after get_league_info for the specified league so the model already knows the league's team names, owner/team mapping, league settings, and roster context before interpreting this roster. Requires authentication except on Sleeper's public API. Read-only and safe to retry. Current date is ${currentDate}.`,
       inputSchema: {
         platform: z
           .enum(['espn', 'yahoo', 'sleeper'])
@@ -909,7 +926,7 @@ export function getUnifiedTools(): UnifiedTool[] {
       requiredScope: 'mcp:read',
       securitySchemes: buildSecuritySchemes('mcp:read'),
       openaiMeta: { invoking: 'Searching free agents\u2026', invoked: 'Free agents ready' },
-      description: `Get currently available players for the selected league, optionally filtered by position. Exact payload varies by platform: ESPN and Yahoo include ownership percentages and sort by ownership, while Sleeper returns available-player identities from the public player index without ownership percentages. Best used after get_user_session and usually after get_league_info so team names, owner/team mapping, scoring context, and roster-slot context are already established before giving pickup advice. Use this for player availability only. Do not use percentOwned or market ownership to infer who owns a player in the user's league; for ownership questions, use get_league_info (returns teams with ownerName) and get_roster. Requires authentication on ESPN and Yahoo; Sleeper uses the public API. Use values from get_user_session. Read-only and safe to retry. Current date is ${currentDate}.`,
+      description: `Get currently available players for the specified league, optionally filtered by position. Exact payload varies by platform: ESPN and Yahoo include ownership percentages and sort by ownership, while Sleeper returns available-player identities from the public player index without ownership percentages. Best used after get_user_session and usually after get_league_info for the specified league so team names, owner/team mapping, scoring context, and roster-slot context are already established before giving pickup advice. For multi-league comparisons, call once per league. Use this for player availability only. Do not use percentOwned or market ownership to infer who owns a player in the user's league; for ownership questions, use get_league_info (returns teams with ownerName) and get_roster. Requires authentication on ESPN and Yahoo; Sleeper uses the public API. Use values from get_user_session. Read-only and safe to retry. Current date is ${currentDate}.`,
       inputSchema: {
         platform: z
           .enum(['espn', 'yahoo', 'sleeper'])

--- a/workers/fantasy-mcp/src/mcp/tools.ts
+++ b/workers/fantasy-mcp/src/mcp/tools.ts
@@ -480,10 +480,23 @@ export function getUnifiedTools(): UnifiedTool[] {
           // Filter to active leagues (have a season within 2 years) and limit to 2 most recent seasons
           const thresholdYear = getActiveThresholdYear();
 
-          // Group leagues by unique league identifier
+          // Track which platforms failed to fetch — used to avoid clearing valid defaults
+          // when a platform was temporarily unavailable.
+          const failedPlatforms = new Set<string>();
+          if (espnData.error) failedPlatforms.add('espn');
+          if (yahooData.error) failedPlatforms.add('yahoo');
+          if (sleeperData.error) failedPlatforms.add('sleeper');
+
+          // Group leagues by unique league identifier.
+          // Yahoo: group by sport+name because Yahoo assigns a new leagueKey each season;
+          // without name-based grouping, recurring leagues surface every past season
+          // as a separate active entry. ESPN/Sleeper reuse the same leagueId across
+          // seasons, so platform:leagueId is the correct stable key for those.
           const leagueGroups = new Map<string, typeof allLeagues>();
           for (const league of allLeagues) {
-            const key = `${league.platform}:${league.leagueId}`;
+            const key = league.platform === 'yahoo'
+              ? `${league.platform}:${(league.sport || '').toLowerCase()}:${league.leagueName}`
+              : `${league.platform}:${league.leagueId}`;
             if (!leagueGroups.has(key)) {
               leagueGroups.set(key, []);
             }
@@ -589,8 +602,14 @@ export function getUnifiedTools(): UnifiedTool[] {
               if (matchingLeague) {
                 defaultLeagues[sport] = matchingLeague;
               } else {
-                // Stale default — no matching active league. Fire a best-effort clear
-                // so future reads don't repeat this lookup, then surface a warning.
+                // Default doesn't match any active league.
+                if (failedPlatforms.has(defaultInfo.platform)) {
+                  // Platform fetch failed — the league may still be valid. Preserve
+                  // the default and surface a transient warning instead of clearing.
+                  warnings.push(`Could not verify ${sport} default: ${defaultInfo.platform} data is temporarily unavailable. Default preserved.`);
+                } else {
+                // Platform fetch succeeded but league is missing — it's genuinely stale.
+                // Fire a best-effort clear so future reads don't repeat this lookup.
                 const staleBaseHeaders: Record<string, string> = {
                   'Content-Type': 'application/json',
                   ...(authHeader ? { Authorization: authHeader } : {}),
@@ -618,6 +637,7 @@ export function getUnifiedTools(): UnifiedTool[] {
                     ? `Cleared stale ${sport} default: league ${defaultInfo.leagueId} is no longer in your active leagues.`
                     : `Stale ${sport} default detected (league ${defaultInfo.leagueId} is no longer active) — automatic cleanup failed, will retry next session.`
                 );
+                } // end: platform fetch succeeded (stale default)
               }
             }
           }

--- a/workers/fantasy-mcp/src/mcp/tools.ts
+++ b/workers/fantasy-mcp/src/mcp/tools.ts
@@ -86,6 +86,18 @@ interface UserLeague {
   teamName?: string;
 }
 
+function getYahooStableLeagueId(leagueId: string): string {
+  const stableId = leagueId.match(/^[^.]+\.l\.(.+)$/)?.[1];
+  return stableId || leagueId;
+}
+
+function getActiveLeagueGroupKey(league: UserLeague): string {
+  if (league.platform === 'yahoo') {
+    return `${league.platform}:${(league.sport || '').toLowerCase()}:${getYahooStableLeagueId(league.leagueId)}`;
+  }
+  return `${league.platform}:${league.leagueId}`;
+}
+
 async function fetchUserLeagues(
   env: Env,
   authHeader?: string,
@@ -487,16 +499,13 @@ export function getUnifiedTools(): UnifiedTool[] {
           if (yahooData.error) failedPlatforms.add('yahoo');
           if (sleeperData.error) failedPlatforms.add('sleeper');
 
-          // Group leagues by unique league identifier.
-          // Yahoo: group by sport+name because Yahoo assigns a new leagueKey each season;
-          // without name-based grouping, recurring leagues surface every past season
-          // as a separate active entry. ESPN/Sleeper reuse the same leagueId across
-          // seasons, so platform:leagueId is the correct stable key for those.
+          // Group leagues by stable identity.
+          // Yahoo league_key is season-scoped (`<game_key>.l.<league_id>`), so strip the
+          // changing game prefix and group on the stable league_id portion instead.
+          // That keeps recurring seasons together without collapsing two same-name leagues.
           const leagueGroups = new Map<string, typeof allLeagues>();
           for (const league of allLeagues) {
-            const key = league.platform === 'yahoo'
-              ? `${league.platform}:${(league.sport || '').toLowerCase()}:${league.leagueName}`
-              : `${league.platform}:${league.leagueId}`;
+            const key = getActiveLeagueGroupKey(league);
             if (!leagueGroups.has(key)) {
               leagueGroups.set(key, []);
             }
@@ -620,6 +629,7 @@ export function getUnifiedTools(): UnifiedTool[] {
                 const staleUrl = new URL(`https://internal/internal/leagues/default/${sport}`);
                 staleUrl.searchParams.set('platform', defaultInfo.platform);
                 staleUrl.searchParams.set('leagueId', defaultInfo.leagueId);
+                staleUrl.searchParams.set('seasonYear', String(defaultInfo.seasonYear));
                 let cleared = false;
                 try {
                   const clearResp = await env.AUTH_WORKER.fetch(
@@ -754,10 +764,12 @@ export function getUnifiedTools(): UnifiedTool[] {
 
           const thresholdYear = getActiveThresholdYear();
 
-          // Group by league
+          // Group by stable league identity.
+          // For Yahoo, collapse recurring seasons by stripping the season-specific
+          // game prefix from league_key, while still keeping distinct active leagues separate.
           const leagueGroups = new Map<string, typeof allLeagues>();
           for (const league of allLeagues) {
-            const key = `${league.platform}:${league.leagueId}`;
+            const key = getActiveLeagueGroupKey(league);
             if (!leagueGroups.has(key)) {
               leagueGroups.set(key, []);
             }


### PR DESCRIPTION
## Summary

- **Fix Yahoo dedup bug** — `get_user_session` and `get_ancient_history` were grouping Yahoo leagues by `leagueName` instead of `leagueId`, silently collapsing distinct Yahoo leagues with the same display name
- **Rewrite scope contract** — `sessionMessage` and `defaultLeague` now encode the singular-vs-plural model explicitly: vague singular prompts → use `defaultLeagues`; explicit plural/comparative prompts → enumerate `allLeagues` and fan-out; `defaultLeague` is `null` when no deterministic resolution exists (removes the arbitrary `Object.values()[0] || leagues[0]` fallback)
- **Delete-time default cleanup** — all five league removal paths (ESPN `removeLeague`, Yahoo `deleteYahooLeague`/`deleteAllYahooLeagues`, Sleeper `deleteSleeperLeague`/`deleteAllSleeperLeagues`) now clear stale `user_preferences.default_<sport>` entries on delete; Yahoo/Sleeper use a lookup-before-delete to resolve platform `league_key`/`league_id` from the DB row UUID
- **Read-time self-heal** — stale defaults detected in `get_user_session` fire a best-effort `DELETE /internal/leagues/default/:sport` and surface a warning in `sessionData.warnings`
- **New internal route** — `DELETE /internal/leagues/default/:sport` using `getInternalUserId` auth (mirrors user-facing route, separate auth path)
- **Write-time validation** — `setDefaultLeague` now validates Yahoo and Sleeper leagues exist before writing (ESPN was already validated)
- **Shared cleanup module** — `preference-defaults.ts` is the single source of truth for default-clearing logic; `supabase-storage`, `yahoo-storage`, and `sleeper-storage` all delegate to it
- **Tool description audit** — stripped singular-league bias from `get_user_session`, `get_league_info`, `get_standings`, `get_matchups`, `get_roster`, `get_free_agents`
- **MCP server instructions** — new `instructions.ts` with ~500-token operational rulebook wired into `McpServer` constructor for all MCP hosts

## Motivation

Perplexity's Nemotron 3 Super called Flaim's ESPN tools and stopped — never querying Yahoo even with both platforms connected. Root cause: `get_user_session` was encoding a singular-league mental model (one `defaultLeague` via arbitrary fallback, session message telling the model to "use that sport's default league"), and defaults were untrustworthy (stale rows persisted after league removal, Yahoo leagues with identical names collapsed into one entry).

## Test plan

- [ ] TypeScript compiles clean on both workers (`npx tsc --noEmit`)
- [ ] All tests pass: auth-worker (218), fantasy-mcp (63)
- [ ] Reconnect Flaim in Perplexity and run: *"Please review the best streaming starting options for fantasy baseball for today. Then compare those to who is available in my ESPN and Yahoo leagues."* — expect both platforms queried before synthesis
- [ ] Verify `get_user_session` `defaultLeague` is `null` for a multi-league user with no `defaultSport` set
- [ ] Verify removing a Yahoo league clears the sport default in the web UI at flaim.app/leagues

🤖 Generated with [Claude Code](https://claude.com/claude-code)