### PR TITLE
Harden MCP URL allowlist SSRF checks

### DIFF
--- a/web/lib/mcp-url-allowlist.ts
+++ b/web/lib/mcp-url-allowlist.ts
@@ -24,23 +24,35 @@ export const ALLOWED_WORKER_PREFIXES = [
 export function isAllowedUrl(urlString: string): boolean {
   try {
     const url = new URL(urlString);
+    const hostname = url.hostname.toLowerCase();
+
+    // Never allow embedded credentials in outbound MCP URLs.
+    if (url.username || url.password) {
+      return false;
+    }
 
     // Must be HTTPS in production, allow HTTP for localhost
-    const isLocalhost = url.hostname === 'localhost' || url.hostname === '127.0.0.1';
+    const isLocalhost = hostname === 'localhost' || hostname === '127.0.0.1';
     if (!isLocalhost && url.protocol !== 'https:') {
+      return false;
+    }
+
+    // Keep remote traffic on default TLS port to reduce SSRF surface area.
+    // Localhost can use custom ports for local development workflows.
+    if (!isLocalhost && url.port && url.port !== '443') {
       return false;
     }
 
     // Check against static allowlist patterns
     const matchesStatic = ALLOWED_MCP_HOST_PATTERNS.some(pattern =>
-      url.hostname === pattern || url.hostname.endsWith(`.${pattern}`)
+      hostname === pattern || hostname.endsWith(`.${pattern}`)
     );
     if (matchesStatic) return true;
 
     // Check workers.dev — only allow known Flaim worker prefixes on our account
     // Format: <worker>.<account>.workers.dev (exactly 4 segments)
-    if (url.hostname.endsWith('.workers.dev')) {
-      const parts = url.hostname.split('.');
+    if (hostname.endsWith('.workers.dev')) {
+      const parts = hostname.split('.');
       return parts.length === 4
         && parts[1] === CF_ACCOUNT_SUBDOMAIN
         && ALLOWED_WORKER_PREFIXES.some(prefix => parts[0] === prefix);

--- a/web/lib/mcp-url-allowlist.ts
+++ b/web/lib/mcp-url-allowlist.ts
@@ -6,7 +6,7 @@
 /** Valid MCP server host patterns. */
 export const ALLOWED_MCP_HOST_PATTERNS = [
   'flaim.app',
-  ...(process.env.NODE_ENV === 'development' ? ['localhost', '127.0.0.1'] : []),
+  ...(process.env.NODE_ENV === 'development' ? ['localhost', '127.0.0.1', '[::1]'] : []),
 ];
 
 /** Flaim CF account subdomain. Workers are <name>.gerrygugger.workers.dev. */
@@ -32,7 +32,7 @@ export function isAllowedUrl(urlString: string): boolean {
     }
 
     // Must be HTTPS in production, allow HTTP for localhost
-    const isLocalhost = hostname === 'localhost' || hostname === '127.0.0.1';
+    const isLocalhost = hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]';
     if (!isLocalhost && url.protocol !== 'https:') {
       return false;
     }


### PR DESCRIPTION
### Motivation
- Reduce SSRF and outbound fetch surface area for MCP requests by tightening URL validation and blocking credential-bearing or non-standard remote endpoints.

### Description
- Update `isAllowedUrl` in `web/lib/mcp-url-allowlist.ts` to reject embedded credentials (`url.username`/`url.password`), normalize `hostname` to lowercase before matching, disallow non-localhost remote ports other than `443`, and preserve existing `workers.dev` prefix/account allowlist logic.

### Testing
- Ran `cd web && corepack pnpm run lint` (passed), `cd web && corepack pnpm exec tsc --noEmit` (passed), `cd workers/auth-worker && corepack pnpm test -- --runInBand` (all tests passed), and `cd workers/auth-worker && corepack pnpm exec tsc --noEmit` (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6b3f7ad448333980c4b91cb3a83b8)