### PR TITLE
Fix prefix stripping to avoid partial segment matches

### DIFF
--- a/workers/shared/src/__tests__/prefix-strip.test.ts
+++ b/workers/shared/src/__tests__/prefix-strip.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { getPathname, stripPrefix } from '../prefix-strip.js';
+
+describe('stripPrefix', () => {
+  it('strips when pathname exactly matches prefix', () => {
+    expect(stripPrefix('/baseball', '/baseball')).toBe('/');
+  });
+
+  it('strips when pathname starts with prefix plus slash', () => {
+    expect(stripPrefix('/baseball/health', '/baseball')).toBe('/health');
+  });
+
+  it('does not strip when pathname only shares a partial prefix', () => {
+    expect(stripPrefix('/baseballish/health', '/baseball')).toBe('/baseballish/health');
+  });
+
+  it('normalizes prefix without leading slash', () => {
+    expect(stripPrefix('/baseball/health', 'baseball')).toBe('/health');
+  });
+});
+
+describe('getPathname', () => {
+  it('returns parsed pathname with prefix stripping applied', () => {
+    const request = new Request('https://example.com/baseball/standings?league=123');
+    expect(getPathname(request, '/baseball')).toBe('/standings');
+  });
+});

--- a/workers/shared/src/__tests__/prefix-strip.test.ts
+++ b/workers/shared/src/__tests__/prefix-strip.test.ts
@@ -17,11 +17,20 @@ describe('stripPrefix', () => {
   it('normalizes prefix without leading slash', () => {
     expect(stripPrefix('/baseball/health', 'baseball')).toBe('/health');
   });
+
+  it('normalizes prefix with trailing slash', () => {
+    expect(stripPrefix('/baseball/health', '/baseball/')).toBe('/health');
+  });
 });
 
 describe('getPathname', () => {
   it('returns parsed pathname with prefix stripping applied', () => {
     const request = new Request('https://example.com/baseball/standings?league=123');
     expect(getPathname(request, '/baseball')).toBe('/standings');
+  });
+
+  it('returns pathname unchanged when no prefix is provided', () => {
+    const request = new Request('https://example.com/baseball/standings?league=123');
+    expect(getPathname(request)).toBe('/baseball/standings');
   });
 });

--- a/workers/shared/src/prefix-strip.ts
+++ b/workers/shared/src/prefix-strip.ts
@@ -21,9 +21,14 @@ export function stripPrefix(pathname: string, prefix: string): string {
   // Normalize prefix to start with /
   const normalizedPrefix = prefix.startsWith('/') ? prefix : `/${prefix}`;
 
-  if (pathname.startsWith(normalizedPrefix)) {
-    const stripped = pathname.slice(normalizedPrefix.length);
-    return stripped || '/';
+  // Strip only exact-prefix or path-segment matches.
+  if (pathname === normalizedPrefix) {
+    return '/';
+  }
+
+  const prefixWithSlash = `${normalizedPrefix}/`;
+  if (pathname.startsWith(prefixWithSlash)) {
+    return pathname.slice(normalizedPrefix.length);
   }
 
   return pathname;

--- a/workers/shared/src/prefix-strip.ts
+++ b/workers/shared/src/prefix-strip.ts
@@ -18,8 +18,8 @@
  * stripPrefix("/health", "/baseball")          // returns "/health" (no match)
  */
 export function stripPrefix(pathname: string, prefix: string): string {
-  // Normalize prefix to start with /
-  const normalizedPrefix = prefix.startsWith('/') ? prefix : `/${prefix}`;
+  // Normalize prefix to start with / and avoid trailing-slash mismatch.
+  const normalizedPrefix = (prefix.startsWith('/') ? prefix : `/${prefix}`).replace(/\/$/, '') || '/';
 
   // Strip only exact-prefix or path-segment matches.
   if (pathname === normalizedPrefix) {


### PR DESCRIPTION
### Motivation

- The previous `stripPrefix` used a naive `startsWith` check which could incorrectly strip paths that only partially matched the configured prefix (e.g., `/baseballish/...` when the prefix is `/baseball`).
- The change ensures internal routing preserves segment boundaries so requests are routed to the correct handlers.

### Description

- Update `stripPrefix` in `workers/shared/src/prefix-strip.ts` to only strip when the pathname exactly equals the normalized prefix or starts with the prefix followed by a `/` (segment boundary).
- Preserve prefix normalization (allowing prefixes without a leading slash) and return `/` when the pathname equals the prefix.
- Add unit tests at `workers/shared/src/__tests__/prefix-strip.test.ts` covering exact match, nested path, partial-prefix non-match, normalized prefix input, and `getPathname` integration.

### Testing

- Ran `corepack pnpm --dir workers/shared test`, and the test suite completed successfully (all tests passed).
- Ran `corepack pnpm --dir workers/shared type-check` (`tsc --noEmit`), and type checking completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6b3f7ad448333980c4b91cb3a83b8)