### PR TITLE
Normalize ESPN season-year handling across workers and web onboarding

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -90,7 +90,7 @@ Season year defaults are deterministic and use America/New_York time. The canoni
 | Basketball | Aug 1 | ~10 weeks before NBA opening night (late October) |
 | Hockey | Aug 1 | ~10 weeks before NHL opening night (early October) |
 
-**ESPN normalization:** ESPN uses the END year for NBA/NHL seasons (e.g., `2025` for the 2024-25 season). Flaim normalizes this to the start year internally via `toCanonicalYear()`/`toPlatformYear()` in `workers/auth-worker/src/season-utils.ts`.
+**ESPN normalization:** ESPN uses the END year for NBA/NHL seasons (e.g., `2025` for the 2024-25 season). Flaim normalizes this to the start year internally via the shared `toCanonicalYear()`/`toPlatformYear()` helpers in `@flaim/worker-shared` (`workers/shared/src/season.ts`).
 
 ## User Defaults
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -5,19 +5,21 @@ Keep testing light and focused. Flaim is a solo hobby project; prioritize critic
 ## What We Test Today
 
 Automated tests currently focus on the Workers layer:
+- **web**: targeted server-side ESPN onboarding regression coverage
 - **auth-worker**: OAuth handler behavior, league discovery helpers, ESPN type utilities
 - **fantasy-mcp**: tool routing, schema constraints, and core tool contract behavior
 - **espn-client**: type utilities plus cross-sport handler behavior (transactions and search)
 - **yahoo-client**: response normalizers plus cross-sport handler behavior (transactions and search)
 - **sleeper-client**: sport handlers, KV player cache, free-agent computation, transactions enrichment, routing
 
-The **web app** and **extension** do not have automated tests right now. Manual testing is acceptable until usage grows.
+The **extension** does not have automated tests right now. Most web UI flows are still manually tested; only the ESPN onboarding server helpers have automated coverage so far.
 
 ## Run Tests
 
 Workers use Vitest.
 
 ```bash
+cd web && npm test
 cd workers/auth-worker && npm test
 cd workers/fantasy-mcp && npm test
 cd workers/espn-client && npm test

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       typescript:
         specifier: ^5.6.2
         version: 5.9.3
+      vitest:
+        specifier: ~3.0.0
+        version: 3.0.9(@types/debug@4.1.13)(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)
 
   workers/auth-worker:
     dependencies:

--- a/web/README.md
+++ b/web/README.md
@@ -68,6 +68,7 @@ Leagues are stored per season year. The `/leagues` UI defaults the season year b
 
 - **Baseball (flb)**: Defaults to the previous year until Feb 1, then switches to the current year
 - **Football (ffl)**: Defaults to the previous year until Jul 1, then switches to the current year
+- **Basketball (fba)** / **Hockey (fhl)**: Manual ESPN onboarding still stores the canonical start year (for example `2024` for the 2024-25 season) even though ESPN's upstream API uses the end year
 
 Deleting a league removes all seasons for that league.
 

--- a/web/app/(site)/leagues/page.tsx
+++ b/web/app/(site)/leagues/page.tsx
@@ -45,7 +45,7 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog';
 import { useEspnCredentials } from '@/lib/use-espn-credentials';
-import { getDefaultSeasonYear } from '@/lib/season-utils';
+import { getDefaultSeasonYear, getPreviousSeasonYear, getSeasonYearOptions } from '@/lib/season-utils';
 import { CHROME_EXTENSION_URL } from '@/config/constants';
 import { StepConnectAI } from '@/components/site/StepConnectAI';
 
@@ -113,7 +113,7 @@ interface UnifiedLeague {
   platform: 'espn' | 'yahoo' | 'sleeper';
   // Common fields
   sport: string;
-  seasonYear: number;
+  seasonYear?: number;
   leagueName: string;
   teamName?: string;
   isDefault: boolean;
@@ -143,13 +143,8 @@ const SPORT_OPTIONS: { value: Sport; label: string; emoji: string }[] = [
   { value: 'hockey', label: 'Hockey', emoji: '\u{1F3D2}' },
 ];
 
-// Generate season options (current year down to 2000)
+// Generate season options (current season year down to 2000)
 const MIN_YEAR = 2000;
-const currentYear = new Date().getFullYear();
-const SEASON_OPTIONS = Array.from(
-  { length: currentYear - MIN_YEAR + 1 },
-  (_, i) => currentYear - i
-);
 
 function capitalize(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1);
@@ -166,7 +161,7 @@ function espnToUnified(leagues: League[], preferences: UserPreferencesState): Un
     return {
       platform: 'espn' as const,
       sport: l.sport,
-      seasonYear: l.seasonYear || new Date().getFullYear(),
+      seasonYear: l.seasonYear,
       leagueName: l.leagueName || `League ${l.leagueId}`,
       teamName: l.teamName,
       isDefault,
@@ -302,11 +297,22 @@ function LeaguesPageContent() {
   const [selectedTeamId, setSelectedTeamId] = useState<string>('');
   const [isAddingLeague, setIsAddingLeague] = useState(false);
   const [discoverLeagueKey, setDiscoverLeagueKey] = useState<string>('');
+  const manualSeasonOptions = useMemo(
+    () => getSeasonYearOptions(newLeagueSport, MIN_YEAR),
+    [newLeagueSport]
+  );
 
   // Helper to determine if a league is "old" (no seasons in last 2 years)
-  const isOldLeague = (seasons: { seasonYear: number }[]): boolean => {
-    const thresholdYear = new Date().getFullYear() - 2;
-    const mostRecentYear = Math.max(...seasons.map(s => s.seasonYear), 0);
+  const isOldLeague = (sport: Sport, seasons: Array<{ seasonYear?: number }>): boolean => {
+    const knownSeasonYears = seasons
+      .map((season) => season.seasonYear)
+      .filter((seasonYear): seasonYear is number => typeof seasonYear === 'number');
+    if (knownSeasonYears.length === 0) {
+      return false;
+    }
+
+    const thresholdYear = getDefaultSeasonYear(sport) - 1;
+    const mostRecentYear = Math.max(...knownSeasonYears);
     return mostRecentYear < thresholdYear;
   };
 
@@ -346,7 +352,7 @@ function LeaguesPageContent() {
 
     // Sort seasons desc within each group
     for (const group of grouped.values()) {
-      group.seasons.sort((a, b) => b.seasonYear - a.seasonYear);
+      group.seasons.sort((a, b) => (b.seasonYear ?? 0) - (a.seasonYear ?? 0));
       // Use most recent season's league name
       group.leagueName = group.seasons[0]?.leagueName || group.leagueName;
       group.teamId = group.seasons.find((s) => s.teamId)?.teamId;
@@ -357,7 +363,7 @@ function LeaguesPageContent() {
     const oldLeagueGroups: UnifiedLeagueGroup[] = [];
 
     for (const group of grouped.values()) {
-      if (isOldLeague(group.seasons)) {
+      if (isOldLeague(group.sport as Sport, group.seasons)) {
         oldLeagueGroups.push(group);
       } else {
         activeLeagues.push(group);
@@ -639,7 +645,10 @@ function LeaguesPageContent() {
 
     // Check for duplicates (including season year for multi-season support)
     const exists = leagues.some(
-      (l) => l.leagueId === newLeagueId.trim() && l.sport === newLeagueSport && l.seasonYear === newLeagueSeason
+      (l) =>
+        l.leagueId === newLeagueId.trim() &&
+        l.sport === newLeagueSport &&
+        l.seasonYear === newLeagueSeason
     );
     if (exists) {
       setLeagueError('This league and season is already added');
@@ -1231,7 +1240,9 @@ function LeaguesPageContent() {
                                 <div className="flex items-center gap-1 text-xs text-muted-foreground">
                                   {(() => {
                                     const mostRecentSeason = group.seasons[0];
+                                    const mostRecentSeasonYear = mostRecentSeason?.seasonYear;
                                     const isLeagueDefault = mostRecentSeason?.isDefault;
+                                    const canSetDefault = !!mostRecentSeason?.teamId && typeof mostRecentSeasonYear === 'number';
                                     const leagueKey = group.platform === 'yahoo'
                                       ? `yahoo:${mostRecentSeason?.yahooId}`
                                       : group.platform === 'sleeper'
@@ -1246,17 +1257,24 @@ function LeaguesPageContent() {
                                             ? 'text-warning'
                                             : 'text-muted-foreground hover:text-warning'
                                         }`}
-                                        onClick={() => handleSetDefault(
-                                          group.platform,
-                                          mostRecentSeason.leagueId,
-                                          mostRecentSeason.sport,
-                                          mostRecentSeason.seasonYear,
-                                          mostRecentSeason.yahooId
-                                        )}
-                                        disabled={isSettingThis || isLeagueDefault || !mostRecentSeason?.teamId}
+                                        onClick={() => {
+                                          if (!canSetDefault) {
+                                            return;
+                                          }
+                                          handleSetDefault(
+                                            group.platform,
+                                            mostRecentSeason.leagueId,
+                                            mostRecentSeason.sport,
+                                            mostRecentSeasonYear,
+                                            mostRecentSeason.yahooId
+                                          );
+                                        }}
+                                        disabled={isSettingThis || isLeagueDefault || !canSetDefault}
                                         title={
                                           !mostRecentSeason?.teamId
                                             ? 'No team selected'
+                                            : mostRecentSeasonYear === undefined
+                                            ? 'Legacy league row is missing a season year'
                                             : isLeagueDefault
                                             ? 'Default league for this sport'
                                             : 'Set as default for this sport'
@@ -1662,10 +1680,10 @@ function LeaguesPageContent() {
                                 This season
                               </Button>
                               <Button
-                                variant={newLeagueSeason === new Date().getFullYear() - 1 ? 'default' : 'outline'}
+                                variant={newLeagueSeason === getPreviousSeasonYear(newLeagueSport) ? 'default' : 'outline'}
                                 size="sm"
                                 onClick={() => {
-                                  setNewLeagueSeason(new Date().getFullYear() - 1);
+                                  setNewLeagueSeason(getPreviousSeasonYear(newLeagueSport));
                                   setSeasonManuallySet(true);
                                 }}
                                 disabled={isVerifying}
@@ -1692,8 +1710,16 @@ function LeaguesPageContent() {
                                   onValueChange={(v) => {
                                     const sport = v as Sport;
                                     setNewLeagueSport(sport);
+                                    const defaultSeasonYear = getDefaultSeasonYear(sport);
                                     if (!seasonManuallySet) {
-                                      setNewLeagueSeason(getDefaultSeasonYear(sport));
+                                      setNewLeagueSeason(defaultSeasonYear);
+                                      return;
+                                    }
+
+                                    const seasonOptions = getSeasonYearOptions(sport, MIN_YEAR);
+                                    if (!seasonOptions.includes(newLeagueSeason)) {
+                                      setNewLeagueSeason(defaultSeasonYear);
+                                      setSeasonManuallySet(false);
                                     }
                                   }}
                                   disabled={isVerifying}
@@ -1724,7 +1750,7 @@ function LeaguesPageContent() {
                                     <SelectValue />
                                   </SelectTrigger>
                                   <SelectContent>
-                                    {SEASON_OPTIONS.map((year) => (
+                                    {manualSeasonOptions.map((year) => (
                                       <SelectItem key={year} value={String(year)}>
                                         {year}
                                       </SelectItem>

--- a/web/lib/season-utils.ts
+++ b/web/lib/season-utils.ts
@@ -5,3 +5,20 @@ export {
   toCanonicalYear,
   toPlatformYear,
 } from '@flaim/worker-shared';
+export type { SeasonSport } from '@flaim/worker-shared';
+
+import { getDefaultSeasonYear } from '@flaim/worker-shared';
+import type { SeasonSport } from '@flaim/worker-shared';
+
+export function getPreviousSeasonYear(sport: SeasonSport, now = new Date()): number {
+  return getDefaultSeasonYear(sport, now) - 1;
+}
+
+export function getSeasonYearOptions(
+  sport: SeasonSport,
+  minYear = 2000,
+  now = new Date()
+): number[] {
+  const currentSeasonYear = getDefaultSeasonYear(sport, now);
+  return Array.from({ length: currentSeasonYear - minYear + 1 }, (_, index) => currentSeasonYear - index);
+}

--- a/web/lib/season-utils.ts
+++ b/web/lib/season-utils.ts
@@ -1,27 +1,7 @@
-type SeasonSport = 'baseball' | 'football' | 'basketball' | 'hockey';
-
-const ROLLOVER_MONTHS: Record<SeasonSport, number> = {
-  baseball: 2,    // Feb 1
-  football: 7,    // Jul 1
-  basketball: 8,  // Aug 1
-  hockey: 8,      // Aug 1
-};
-
-/**
- * Returns the current season year for a sport using America/New_York time.
- * Mirrors the canonical logic in workers/auth-worker/src/season-utils.ts.
- * Always returns the START year of the season.
- */
-export function getDefaultSeasonYear(sport: SeasonSport, now = new Date()): number {
-  const ny = new Intl.DateTimeFormat('en-US', {
-    timeZone: 'America/New_York',
-    year: 'numeric',
-    month: '2-digit',
-  }).formatToParts(now);
-
-  const year = Number(ny.find((p) => p.type === 'year')?.value);
-  const month = Number(ny.find((p) => p.type === 'month')?.value);
-
-  const rolloverMonth = ROLLOVER_MONTHS[sport] ?? 1;
-  return month < rolloverMonth ? year - 1 : year;
-}
+export {
+  getDefaultSeasonYear,
+  getSeasonLabel,
+  isCurrentSeason,
+  toCanonicalYear,
+  toPlatformYear,
+} from '@flaim/worker-shared';

--- a/web/lib/server/__tests__/espn-onboarding.test.ts
+++ b/web/lib/server/__tests__/espn-onboarding.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { runEspnAutoPull, runEspnDiscoverSeasons } from '../espn-onboarding';
+
+const ORIGINAL_ENV = {
+  NEXT_PUBLIC_AUTH_WORKER_URL: process.env.NEXT_PUBLIC_AUTH_WORKER_URL,
+  INTERNAL_SERVICE_TOKEN: process.env.INTERNAL_SERVICE_TOKEN,
+};
+
+function setTestEnv() {
+  process.env.NEXT_PUBLIC_AUTH_WORKER_URL = 'https://auth.example';
+  process.env.INTERNAL_SERVICE_TOKEN = 'test-internal-token';
+}
+
+function restoreTestEnv() {
+  process.env.NEXT_PUBLIC_AUTH_WORKER_URL = ORIGINAL_ENV.NEXT_PUBLIC_AUTH_WORKER_URL;
+  process.env.INTERNAL_SERVICE_TOKEN = ORIGINAL_ENV.INTERNAL_SERVICE_TOKEN;
+}
+
+function createFetchMock(options: {
+  seasonId?: number;
+  teamCount?: number;
+  onEspnUrl?: (url: string) => void;
+}) {
+  const { seasonId, teamCount = 1, onEspnUrl } = options;
+
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+
+    if (url === 'https://auth.example/internal/credentials/espn/raw') {
+      return new Response(
+        JSON.stringify({
+          success: true,
+          credentials: {
+            swid: '{swid}',
+            s2: 'cookie',
+          },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      );
+    }
+
+    if (url.includes('lm-api-reads.fantasy.espn.com/apis/v3')) {
+      onEspnUrl?.(url);
+      return new Response(
+        JSON.stringify({
+          seasonId,
+          settings: { name: 'ESPN Test League' },
+          teams: Array.from({ length: teamCount }, (_, index) => ({
+            id: index + 1,
+            location: `Team ${index + 1}`,
+            nickname: 'Testers',
+          })),
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      );
+    }
+
+    throw new Error(`Unexpected fetch call: ${url}`);
+  });
+}
+
+beforeEach(() => {
+  setTestEnv();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  restoreTestEnv();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('runEspnAutoPull', () => {
+  it.each(['basketball', 'hockey'] as const)(
+    'returns canonical start-year season info for explicit ESPN %s seasons',
+    async (sport) => {
+      let espnUrl = '';
+      vi.stubGlobal('fetch', createFetchMock({
+        seasonId: 2025,
+        onEspnUrl: (url) => {
+          espnUrl = url;
+        },
+      }));
+
+      const result = await runEspnAutoPull({
+        sport,
+        leagueId: '12345',
+        seasonYear: 2024,
+        authHeader: 'Bearer test-token',
+      });
+
+      expect(result.status).toBe(200);
+      if (!('success' in result.body) || !result.body.success || !result.body.leagueInfo) {
+        throw new Error('Expected a successful ESPN auto-pull response');
+      }
+
+      expect(result.body.leagueInfo.seasonYear).toBe(2024);
+      expect(espnUrl).toContain('/seasons/2025/segments/0/leagues/12345');
+    }
+  );
+
+  it.each(['football', 'baseball'] as const)(
+    'uses the canonical current season in January for %s',
+    async (sport) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-01-15T12:00:00-05:00'));
+
+      let espnUrl = '';
+      vi.stubGlobal('fetch', createFetchMock({
+        onEspnUrl: (url) => {
+          espnUrl = url;
+        },
+      }));
+
+      const result = await runEspnAutoPull({
+        sport,
+        leagueId: '12345',
+        authHeader: 'Bearer test-token',
+      });
+
+      expect(result.status).toBe(200);
+      if (!('success' in result.body) || !result.body.success || !result.body.leagueInfo) {
+        throw new Error('Expected a successful ESPN auto-pull response');
+      }
+
+      expect(result.body.leagueInfo.seasonYear).toBe(2025);
+      expect(espnUrl).toContain('/seasons/2025/segments/0/leagues/12345');
+    }
+  );
+});
+
+describe('runEspnDiscoverSeasons', () => {
+  it('keeps January football discovery anchored to the canonical current season', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-15T12:00:00-05:00'));
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+
+      if (url === 'https://auth.example/internal/credentials/espn/raw') {
+        return new Response(
+          JSON.stringify({
+            success: true,
+            credentials: {
+              swid: '{swid}',
+              s2: 'cookie',
+            },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        );
+      }
+
+      if (url === 'https://auth.example/leagues') {
+        return new Response(
+          JSON.stringify({
+            success: true,
+            leagues: [
+              {
+                leagueId: '12345',
+                sport: 'football',
+                teamId: '1',
+                seasonYear: 2025,
+              },
+            ],
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        );
+      }
+
+      if (url.includes('lm-api-reads.fantasy.espn.com/apis/v3')) {
+        return new Response('', { status: 404, statusText: 'Not Found' });
+      }
+
+      throw new Error(`Unexpected fetch call: ${url}`);
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const resultPromise = runEspnDiscoverSeasons({
+      sport: 'football',
+      leagueId: '12345',
+      authHeader: 'Bearer test-token',
+    });
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(result.status).toBe(200);
+    expect((result.body as { startYear?: number }).startYear).toBe(2025);
+    expect(String(fetchMock.mock.calls[2]?.[0])).toContain('/games/ffl/seasons/2024/segments/0/leagues/12345');
+  });
+});

--- a/web/lib/server/espn-onboarding.ts
+++ b/web/lib/server/espn-onboarding.ts
@@ -1,5 +1,9 @@
 import type { AutoPullResponse, EspnLeagueInfo, SportName } from '@/lib/espn-types';
-import { getDefaultSeasonYear } from '@/lib/season-utils';
+import {
+  getDefaultSeasonYear,
+  toCanonicalYear,
+  toPlatformYear,
+} from '@/lib/season-utils';
 
 interface EspnCredentials {
   swid: string;
@@ -124,20 +128,6 @@ function normalizeSport(input?: string): SportName | null {
   return null;
 }
 
-function toEspnSeasonYear(canonicalYear: number, sport: string): number {
-  if (sport === 'basketball' || sport === 'hockey') {
-    return canonicalYear + 1;
-  }
-  return canonicalYear;
-}
-
-function fromEspnSeasonYear(espnYear: number, sport: string): number {
-  if (sport === 'basketball' || sport === 'hockey') {
-    return espnYear - 1;
-  }
-  return espnYear;
-}
-
 async function fetchEspnCredentials(
   authHeader: string,
   correlationId?: string
@@ -259,8 +249,8 @@ async function getBasicLeagueInfo(
   seasonYear?: number
 ): Promise<BasicLeagueInfoResponse> {
   try {
-    const requestedSeasonYear = seasonYear || getDefaultSeasonYear(sport);
-    const espnSeasonYear = toEspnSeasonYear(requestedSeasonYear, sport);
+    const requestedSeasonYear = seasonYear ?? getDefaultSeasonYear(sport);
+    const espnSeasonYear = toPlatformYear(requestedSeasonYear, sport, 'espn');
     const gameId = ESPN_GAME_IDS[sport];
     const apiPath = `/seasons/${espnSeasonYear}/segments/0/leagues/${leagueId}?view=mStandings&view=mTeam&view=mSettings`;
 
@@ -327,7 +317,7 @@ async function getBasicLeagueInfo(
 
     const leagueName = data.settings?.name || `${sport.charAt(0).toUpperCase()}${sport.slice(1)} League ${leagueId}`;
     const returnedSeasonYear = data.seasonId
-      ? fromEspnSeasonYear(data.seasonId, sport)
+      ? toCanonicalYear(data.seasonId, sport, 'espn')
       : requestedSeasonYear;
 
     const teams = (data.teams || []).map((team) => ({
@@ -425,7 +415,7 @@ export async function runEspnAutoPull(params: {
     leagueId,
     leagueName: leagueInfo.leagueName || `${targetSport} League ${leagueId}`,
     sport: targetSport,
-    seasonYear: leagueInfo.seasonYear || seasonYear || currentSeasonYear,
+    seasonYear: leagueInfo.seasonYear ?? seasonYear ?? currentSeasonYear,
     gameId: ESPN_GAME_IDS[targetSport],
     standings: leagueInfo.standings || [],
     teams: leagueInfo.teams || [],

--- a/web/lib/server/espn-onboarding.ts
+++ b/web/lib/server/espn-onboarding.ts
@@ -131,6 +131,13 @@ function toEspnSeasonYear(canonicalYear: number, sport: string): number {
   return canonicalYear;
 }
 
+function fromEspnSeasonYear(espnYear: number, sport: string): number {
+  if (sport === 'basketball' || sport === 'hockey') {
+    return espnYear - 1;
+  }
+  return espnYear;
+}
+
 async function fetchEspnCredentials(
   authHeader: string,
   correlationId?: string
@@ -319,7 +326,9 @@ async function getBasicLeagueInfo(
     }
 
     const leagueName = data.settings?.name || `${sport.charAt(0).toUpperCase()}${sport.slice(1)} League ${leagueId}`;
-    const returnedSeasonYear = data.seasonId || requestedSeasonYear;
+    const returnedSeasonYear = data.seasonId
+      ? fromEspnSeasonYear(data.seasonId, sport)
+      : requestedSeasonYear;
 
     const teams = (data.teams || []).map((team) => ({
       teamId: team.id?.toString() || '',
@@ -411,18 +420,19 @@ export async function runEspnAutoPull(params: {
     };
   }
 
+  const currentSeasonYear = getDefaultSeasonYear(targetSport);
   const responseLeagueInfo: EspnLeagueInfo = {
     leagueId,
     leagueName: leagueInfo.leagueName || `${targetSport} League ${leagueId}`,
     sport: targetSport,
-    seasonYear: leagueInfo.seasonYear || seasonYear || new Date().getFullYear(),
+    seasonYear: leagueInfo.seasonYear || seasonYear || currentSeasonYear,
     gameId: ESPN_GAME_IDS[targetSport],
     standings: leagueInfo.standings || [],
     teams: leagueInfo.teams || [],
   };
 
   if (!responseLeagueInfo.teams.length) {
-    const suggestedYear = responseLeagueInfo.seasonYear === new Date().getFullYear()
+    const suggestedYear = responseLeagueInfo.seasonYear === currentSeasonYear
       ? responseLeagueInfo.seasonYear - 1
       : responseLeagueInfo.seasonYear;
     return {
@@ -481,7 +491,7 @@ export async function runEspnDiscoverSeasons(params: {
   const MIN_YEAR = 2000;
   const MAX_CONSECUTIVE_MISSES = 2;
   const PROBE_DELAY_MS = 200;
-  const currentYear = new Date().getFullYear();
+  const currentSeasonYear = getDefaultSeasonYear(targetSport);
   const discovered: DiscoveredSeason[] = [];
   let consecutiveMisses = 0;
   let skippedCount = 0;
@@ -489,7 +499,7 @@ export async function runEspnDiscoverSeasons(params: {
   let limitExceeded = false;
   let minYearReached = false;
 
-  for (let year = currentYear; year >= MIN_YEAR; year -= 1) {
+  for (let year = currentSeasonYear; year >= MIN_YEAR; year -= 1) {
     if (year === MIN_YEAR) {
       minYearReached = true;
     }
@@ -499,7 +509,7 @@ export async function runEspnDiscoverSeasons(params: {
       continue;
     }
 
-    const mustProbe = year >= currentYear - 1;
+    const mustProbe = year >= currentSeasonYear - 1;
     if (!mustProbe && consecutiveMisses >= MAX_CONSECUTIVE_MISSES) {
       break;
     }
@@ -656,7 +666,7 @@ export async function runEspnDiscoverSeasons(params: {
       success: true,
       leagueId,
       sport: targetSport,
-      startYear: currentYear,
+      startYear: currentSeasonYear,
       minYearReached,
       rateLimited,
       limitExceeded,

--- a/web/package.json
+++ b/web/package.json
@@ -9,12 +9,13 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "vitest run -c vitest.config.ts"
   },
   "dependencies": {
-    "@flaim/worker-shared": "workspace:*",
     "@clerk/nextjs": "^6.39.2",
     "@clerk/themes": "^2.4.51",
+    "@flaim/worker-shared": "workspace:*",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-popover": "^1.1.8",
@@ -46,6 +47,7 @@
     "postcss": "^8",
     "tailwindcss": "^4.1.18",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^5.6.2"
+    "typescript": "^5.6.2",
+    "vitest": "~3.0.0"
   }
 }

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./', import.meta.url)),
+      '@flaim/worker-shared': fileURLToPath(new URL('../workers/shared/src/browser.ts', import.meta.url)),
+    },
+  },
+  test: {
+    environment: 'node',
+    include: ['lib/server/__tests__/**/*.test.ts'],
+  },
+});

--- a/workers/auth-worker/README.md
+++ b/workers/auth-worker/README.md
@@ -180,3 +180,4 @@ npm run deploy       # Deploy
 
 - Leagues are stored per season year; `(user, sport, leagueId, seasonYear)` is unique.
 - Deleting a league removes all seasons for that league.
+- `src/v3/get-league-info.ts` returns canonical start years in `seasonYear`, `settings.season`, and `status.previousSeasons`; ESPN-native end years are only used for upstream ESPN requests.

--- a/workers/auth-worker/README.md
+++ b/workers/auth-worker/README.md
@@ -180,4 +180,5 @@ npm run deploy       # Deploy
 
 - Leagues are stored per season year; `(user, sport, leagueId, seasonYear)` is unique.
 - Deleting a league removes all seasons for that league.
+- Shared season helper logic now lives in `@flaim/worker-shared` (`src/season.ts`); `src/season-utils.ts` stays as a backward-compatible wrapper for local imports.
 - `src/v3/get-league-info.ts` returns canonical start years in `seasonYear`, `settings.season`, and `status.previousSeasons`; ESPN-native end years are only used for upstream ESPN requests.

--- a/workers/auth-worker/src/__tests__/get-league-info.test.ts
+++ b/workers/auth-worker/src/__tests__/get-league-info.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type MockedFunction } from 'vitest';
+
+import { getLeagueInfo } from '../v3/get-league-info';
+
+const mockFetch = vi.fn() as MockedFunction<typeof fetch>;
+global.fetch = mockFetch;
+
+describe('getLeagueInfo', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('uses the sport default season translated to ESPN-native year when no season is provided', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-09-15T12:00:00Z'));
+
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          id: '123',
+          name: 'Dynasty League',
+          seasonId: 2027,
+          scoringPeriodId: 1,
+          firstScoringPeriod: 1,
+          finalScoringPeriod: 22,
+          status: {
+            currentMatchupPeriod: 1,
+            isActive: true,
+            previousSeasons: [2026],
+            statusType: { type: 'ACTIVE' },
+          },
+          settings: {
+            name: 'Dynasty League',
+            size: 12,
+          },
+          gameId: 2,
+          gameName: 'Fantasy Basketball',
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      )
+    );
+
+    await getLeagueInfo('{swid}', 's2token', '123', undefined, 'fba');
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://lm-api-reads.fantasy.espn.com/apis/v3/games/fba/seasons/2027/segments/0/leagues/123?view=mSettings',
+      expect.objectContaining({
+        method: 'GET',
+      })
+    );
+  });
+
+  it('normalizes ESPN-native season fields to canonical years for cross-calendar sports', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          id: '123',
+          name: 'Dynasty League',
+          seasonId: 2027,
+          scoringPeriodId: 3,
+          firstScoringPeriod: 1,
+          finalScoringPeriod: 22,
+          status: {
+            currentMatchupPeriod: 7,
+            isActive: true,
+            previousSeasons: [2026, 2025],
+            statusType: { type: 'ACTIVE' },
+          },
+          settings: {
+            name: 'Dynasty League',
+            size: 12,
+          },
+          gameId: 2,
+          gameName: 'Fantasy Basketball',
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      )
+    );
+
+    const leagueInfo = await getLeagueInfo('{swid}', 's2token', '123', 2027, 'fba');
+
+    expect(leagueInfo.seasonYear).toBe(2026);
+    expect(leagueInfo.settings?.season).toBe(2026);
+    expect(leagueInfo.status?.previousSeasons).toEqual([2025, 2024]);
+  });
+});

--- a/workers/auth-worker/src/__tests__/league-discovery.test.ts
+++ b/workers/auth-worker/src/__tests__/league-discovery.test.ts
@@ -220,4 +220,59 @@ describe('discoverAndSaveLeagues', () => {
       })
     );
   });
+
+  it('converts canonical historical basketball seasons back to ESPN-native years for ESPN calls', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({
+        preferences: [
+          {
+            id: 'pref-1',
+            type: { code: 'fantasy' },
+            metaData: {
+              entry: {
+                entryId: 8,
+                gameId: 3,
+                seasonId: 2026,
+                entryMetadata: { teamName: 'Buckets' },
+                groups: [{ groupId: 54321, groupName: 'Dynasty Hoops' }],
+              },
+            },
+          },
+        ],
+      }),
+    } as Response);
+
+    mockGetLeagueInfo
+      .mockResolvedValueOnce({
+        status: { previousSeasons: [2024] },
+      } as any)
+      .mockResolvedValueOnce({ leagueName: 'Dynasty Hoops 2024-25' } as any);
+
+    mockGetLeagueTeams.mockResolvedValueOnce([
+      { teamId: '8', teamName: 'Buckets 2024-25' },
+    ]);
+
+    const storage = {
+      leagueExists: vi.fn()
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(false),
+      addLeague: vi.fn().mockResolvedValue({ success: true }),
+      updateLeague: vi.fn().mockResolvedValue(true),
+    } as any;
+
+    await discoverAndSaveLeagues('user_123', '{swid}', 's2token', storage);
+
+    expect(mockGetLeagueTeams).toHaveBeenCalledWith('{swid}', 's2token', '54321', 2025, 'fba');
+    expect(mockGetLeagueInfo).toHaveBeenNthCalledWith(2, '{swid}', 's2token', '54321', 2025, 'fba');
+    expect(storage.addLeague).toHaveBeenCalledWith('user_123', expect.objectContaining({
+      leagueId: '54321',
+      sport: 'basketball',
+      seasonYear: 2024,
+      teamId: '8',
+      teamName: 'Buckets 2024-25',
+    }));
+  });
 });

--- a/workers/auth-worker/src/__tests__/season-utils.test.ts
+++ b/workers/auth-worker/src/__tests__/season-utils.test.ts
@@ -1,185 +1,32 @@
 import { describe, expect, it } from 'vitest';
 import {
   getDefaultSeasonYear,
+  getSeasonLabel,
   isCurrentSeason,
   toCanonicalYear,
   toPlatformYear,
-  getSeasonLabel,
-  SeasonSport,
 } from '../season-utils';
+import {
+  getDefaultSeasonYear as sharedGetDefaultSeasonYear,
+  getSeasonLabel as sharedGetSeasonLabel,
+  isCurrentSeason as sharedIsCurrentSeason,
+  toCanonicalYear as sharedToCanonicalYear,
+  toPlatformYear as sharedToPlatformYear,
+} from '@flaim/worker-shared';
 
-describe('season-utils', () => {
-  describe('getDefaultSeasonYear', () => {
-    // Baseball: rolls over Feb 1
-    describe('baseball', () => {
-      it('returns previous year before Feb 1', () => {
-        const jan15 = new Date('2026-01-15T12:00:00-05:00');
-        expect(getDefaultSeasonYear('baseball', jan15)).toBe(2025);
-      });
-
-      it('returns current year on Feb 1', () => {
-        const feb1 = new Date('2026-02-01T00:00:00-05:00');
-        expect(getDefaultSeasonYear('baseball', feb1)).toBe(2026);
-      });
-
-      it('returns current year after Feb 1', () => {
-        const mar15 = new Date('2026-03-15T12:00:00-04:00');
-        expect(getDefaultSeasonYear('baseball', mar15)).toBe(2026);
-      });
-    });
-
-    // Football: rolls over Jul 1
-    describe('football', () => {
-      it('returns previous year before Jul 1', () => {
-        const jun15 = new Date('2026-06-15T12:00:00-04:00');
-        expect(getDefaultSeasonYear('football', jun15)).toBe(2025);
-      });
-
-      it('returns current year on Jul 1', () => {
-        const jul1 = new Date('2026-07-01T00:00:00-04:00');
-        expect(getDefaultSeasonYear('football', jul1)).toBe(2026);
-      });
-
-      it('returns current year in January (post-playoffs)', () => {
-        const jan15 = new Date('2026-01-15T12:00:00-05:00');
-        expect(getDefaultSeasonYear('football', jan15)).toBe(2025);
-      });
-    });
-
-    // Basketball: rolls over Aug 1
-    describe('basketball', () => {
-      it('returns previous year before Aug 1', () => {
-        const jul15 = new Date('2026-07-15T12:00:00-04:00');
-        expect(getDefaultSeasonYear('basketball', jul15)).toBe(2025);
-      });
-
-      it('returns current year on Aug 1', () => {
-        const aug1 = new Date('2026-08-01T00:00:00-04:00');
-        expect(getDefaultSeasonYear('basketball', aug1)).toBe(2026);
-      });
-
-      it('returns previous year in January (mid-season)', () => {
-        const jan15 = new Date('2026-01-15T12:00:00-05:00');
-        expect(getDefaultSeasonYear('basketball', jan15)).toBe(2025);
-      });
-    });
-
-    // Hockey: rolls over Aug 1
-    describe('hockey', () => {
-      it('returns previous year before Aug 1', () => {
-        const jul15 = new Date('2026-07-15T12:00:00-04:00');
-        expect(getDefaultSeasonYear('hockey', jul15)).toBe(2025);
-      });
-
-      it('returns current year on Aug 1', () => {
-        const aug1 = new Date('2026-08-01T00:00:00-04:00');
-        expect(getDefaultSeasonYear('hockey', aug1)).toBe(2026);
-      });
-    });
-
-    // Edge cases
-    describe('edge cases', () => {
-      it('uses current date when no date provided', () => {
-        const result = getDefaultSeasonYear('baseball');
-        expect(typeof result).toBe('number');
-        expect(result).toBeGreaterThanOrEqual(2024);
-        expect(result).toBeLessThanOrEqual(2030);
-      });
-    });
+describe('season-utils wrapper', () => {
+  it('re-exports the shared implementation for current-season rollover', () => {
+    const now = new Date('2026-07-01T00:00:00-04:00');
+    expect(getDefaultSeasonYear('football', now)).toBe(sharedGetDefaultSeasonYear('football', now));
+    expect(isCurrentSeason('football', 2026, now)).toBe(sharedIsCurrentSeason('football', 2026, now));
   });
 
-  describe('isCurrentSeason', () => {
-    it('returns true when season matches current', () => {
-      const feb15 = new Date('2026-02-15T12:00:00-05:00');
-      expect(isCurrentSeason('baseball', 2026, feb15)).toBe(true);
-    });
-
-    it('returns false when season does not match current', () => {
-      const feb15 = new Date('2026-02-15T12:00:00-05:00');
-      expect(isCurrentSeason('baseball', 2025, feb15)).toBe(false);
-    });
-
-    it('handles football season spanning calendar years', () => {
-      const jan15 = new Date('2026-01-15T12:00:00-05:00');
-      expect(isCurrentSeason('football', 2025, jan15)).toBe(true);
-      expect(isCurrentSeason('football', 2026, jan15)).toBe(false);
-    });
+  it('re-exports canonical year translation helpers', () => {
+    expect(toCanonicalYear(2025, 'basketball', 'espn')).toBe(sharedToCanonicalYear(2025, 'basketball', 'espn'));
+    expect(toPlatformYear(2024, 'basketball', 'espn')).toBe(sharedToPlatformYear(2024, 'basketball', 'espn'));
   });
 
-  describe('toCanonicalYear', () => {
-    it('subtracts 1 for ESPN basketball', () => {
-      expect(toCanonicalYear(2025, 'basketball', 'espn')).toBe(2024);
-    });
-
-    it('subtracts 1 for ESPN hockey', () => {
-      expect(toCanonicalYear(2025, 'hockey', 'espn')).toBe(2024);
-    });
-
-    it('passes through ESPN baseball', () => {
-      expect(toCanonicalYear(2025, 'baseball', 'espn')).toBe(2025);
-    });
-
-    it('passes through ESPN football', () => {
-      expect(toCanonicalYear(2025, 'football', 'espn')).toBe(2025);
-    });
-
-    it('passes through Yahoo basketball', () => {
-      expect(toCanonicalYear(2024, 'basketball', 'yahoo')).toBe(2024);
-    });
-
-    it('passes through Yahoo hockey', () => {
-      expect(toCanonicalYear(2024, 'hockey', 'yahoo')).toBe(2024);
-    });
-  });
-
-  describe('toPlatformYear', () => {
-    it('adds 1 for ESPN basketball', () => {
-      expect(toPlatformYear(2024, 'basketball', 'espn')).toBe(2025);
-    });
-
-    it('adds 1 for ESPN hockey', () => {
-      expect(toPlatformYear(2024, 'hockey', 'espn')).toBe(2025);
-    });
-
-    it('passes through ESPN baseball', () => {
-      expect(toPlatformYear(2025, 'baseball', 'espn')).toBe(2025);
-    });
-
-    it('passes through ESPN football', () => {
-      expect(toPlatformYear(2025, 'football', 'espn')).toBe(2025);
-    });
-
-    it('passes through Yahoo basketball', () => {
-      expect(toPlatformYear(2024, 'basketball', 'yahoo')).toBe(2024);
-    });
-
-    it('round-trips correctly for ESPN basketball', () => {
-      const espnYear = 2025;
-      const canonical = toCanonicalYear(espnYear, 'basketball', 'espn');
-      const backToEspn = toPlatformYear(canonical, 'basketball', 'espn');
-      expect(backToEspn).toBe(espnYear);
-    });
-  });
-
-  describe('getSeasonLabel', () => {
-    it('returns hyphenated label for basketball', () => {
-      expect(getSeasonLabel(2024, 'basketball')).toBe('2024-25');
-    });
-
-    it('returns hyphenated label for hockey', () => {
-      expect(getSeasonLabel(2025, 'hockey')).toBe('2025-26');
-    });
-
-    it('returns plain year for baseball', () => {
-      expect(getSeasonLabel(2025, 'baseball')).toBe('2025');
-    });
-
-    it('returns plain year for football', () => {
-      expect(getSeasonLabel(2025, 'football')).toBe('2025');
-    });
-
-    it('handles century boundary', () => {
-      expect(getSeasonLabel(2099, 'basketball')).toBe('2099-00');
-    });
+  it('re-exports season labeling', () => {
+    expect(getSeasonLabel(2024, 'basketball')).toBe(sharedGetSeasonLabel(2024, 'basketball'));
   });
 });

--- a/workers/auth-worker/src/season-utils.ts
+++ b/workers/auth-worker/src/season-utils.ts
@@ -1,114 +1,14 @@
 /**
- * Season Year Utilities for Auth Worker
+ * Backward-compatible auth-worker wrapper for shared season helpers.
  *
- * Provides deterministic season year calculation based on sport and date.
- * Uses America/New_York timezone for consistency with ESPN fantasy seasons.
- *
- * Canonical form: season_year always stores the START year of the season.
- * Historical rationale pointer: docs/archive/README.md.
- *
- * Rollover rules (when the "current season" flips to next year):
- * - Baseball: Feb 1 (~10 weeks before Opening Day late March)
- * - Football: Jul 1 (~10 weeks before NFL kickoff early September)
- * - Basketball: Aug 1 (~10 weeks before NBA opening night late October)
- * - Hockey: Aug 1 (~10 weeks before NHL opening night early October)
+ * The actual implementation lives in `@flaim/worker-shared` so browser-safe
+ * and worker-safe consumers share the same source of truth.
  */
-
-export type SeasonSport = 'baseball' | 'football' | 'basketball' | 'hockey';
-
-/**
- * Month when each sport's season year rolls over (1-indexed).
- * Before this month: use previous year. On/after: use current year.
- */
-const ROLLOVER_MONTHS: Record<SeasonSport, number> = {
-  baseball: 2,    // Feb 1
-  football: 7,    // Jul 1
-  basketball: 8,  // Aug 1
-  hockey: 8,      // Aug 1
-};
-
-/**
- * Calculate the default season year for a sport based on the current date.
- *
- * @param sport - The sport type
- * @param now - Optional date to use (defaults to current time)
- * @returns The season year (e.g., 2025)
- *
- * @example
- * // On Jan 4, 2026:
- * getDefaultSeasonYear('baseball') // => 2025 (before Feb 1)
- * getDefaultSeasonYear('football') // => 2025 (before Jul 1)
- *
- * // On Feb 1, 2026:
- * getDefaultSeasonYear('baseball') // => 2026
- *
- * // On Jul 1, 2026:
- * getDefaultSeasonYear('football') // => 2026
- */
-export function getDefaultSeasonYear(sport: SeasonSport, now = new Date()): number {
-  // Use Intl.DateTimeFormat to get date parts in America/New_York timezone
-  const ny = new Intl.DateTimeFormat('en-US', {
-    timeZone: 'America/New_York',
-    year: 'numeric',
-    month: '2-digit',
-  }).formatToParts(now);
-
-  const year = Number(ny.find((p) => p.type === 'year')?.value);
-  const month = Number(ny.find((p) => p.type === 'month')?.value);
-
-  const rolloverMonth = ROLLOVER_MONTHS[sport] || 1;
-  return month < rolloverMonth ? year - 1 : year;
-}
-
-/**
- * Check if a given season year is the "current" season for a sport.
- * Used to filter leagues for the default dropdown.
- *
- * @param sport - The sport type
- * @param seasonYear - The season year to check
- * @param now - Optional date to use (defaults to current time)
- * @returns True if this is the current season for the sport
- */
-export function isCurrentSeason(sport: SeasonSport, seasonYear: number, now = new Date()): boolean {
-  const currentSeason = getDefaultSeasonYear(sport, now);
-  return seasonYear === currentSeason;
-}
-
-/**
- * Normalize a platform-specific season year to Flaim's canonical form (start year).
- *
- * ESPN uses the END year for NBA/NHL (e.g., 2025 for the 2024-25 season).
- * All other platform/sport combinations already use the start year.
- */
-export function toCanonicalYear(platformYear: number, sport: string, platform: string): number {
-  if ((sport === 'basketball' || sport === 'hockey') && platform === 'espn') {
-    return platformYear - 1;
-  }
-  return platformYear;
-}
-
-/**
- * Convert Flaim's canonical season year (start year) to a platform-native value.
- *
- * ESPN expects the END year for NBA/NHL (e.g., 2025 for the 2024-25 season).
- * All other platform/sport combinations expect the start year as-is.
- */
-export function toPlatformYear(canonicalYear: number, sport: string, platform: string): number {
-  if ((sport === 'basketball' || sport === 'hockey') && platform === 'espn') {
-    return canonicalYear + 1;
-  }
-  return canonicalYear;
-}
-
-/**
- * Get a human-readable season label from a canonical start year.
- *
- * Cross-year sports (basketball, hockey) return "2024-25" format.
- * Single-year sports (baseball) and football return "2025" format.
- */
-export function getSeasonLabel(canonicalYear: number, sport: string): string {
-  if (sport === 'basketball' || sport === 'hockey') {
-    return `${canonicalYear}-${String(canonicalYear + 1).slice(2)}`;
-  }
-  return String(canonicalYear);
-}
+export {
+  getDefaultSeasonYear,
+  isCurrentSeason,
+  toCanonicalYear,
+  toPlatformYear,
+  getSeasonLabel,
+} from '@flaim/worker-shared';
+export type { SeasonSport } from '@flaim/worker-shared';

--- a/workers/auth-worker/src/v3/get-league-info.ts
+++ b/workers/auth-worker/src/v3/get-league-info.ts
@@ -13,6 +13,7 @@ import {
   gameIdToSport,
   type EspnLeagueInfo
 } from '../espn-types';
+import { getDefaultSeasonYear, toCanonicalYear, toPlatformYear } from '../season-utils';
 
 interface EspnApiLeagueResponse {
   id: string;
@@ -45,7 +46,8 @@ export type { EspnLeagueInfo };
  * @param swid - ESPN SWID cookie value
  * @param s2 - ESPN espn_s2 cookie value
  * @param leagueId - ESPN league ID
- * @param season - Season year (defaults to current year)
+ * @param season - ESPN-native request year. When omitted, defaults from the
+ * sport's canonical current season and is translated to ESPN's native year.
  * @param gameId - ESPN game ID (ffl, flb, fba, fhl) - defaults to 'ffl' for backwards compatibility
  * @returns Promise with league information
  * @throws {EspnAuthenticationFailed} If authentication fails
@@ -56,7 +58,7 @@ export async function getLeagueInfo(
   swid: string,
   s2: string,
   leagueId: string,
-  season: number = new Date().getFullYear(),
+  season?: number,
   gameId: string = 'ffl'
 ): Promise<EspnLeagueInfo> {
   if (!swid || !s2) {
@@ -66,8 +68,12 @@ export async function getLeagueInfo(
     throw new Error('League ID is required');
   }
 
+  const requestedSport = gameIdToSport(gameId) || 'football';
+  const requestSeason =
+    season ?? toPlatformYear(getDefaultSeasonYear(requestedSport), requestedSport, 'espn');
+
   // First, try the simpler endpoint with just mSettings view
-  const url = `https://lm-api-reads.fantasy.espn.com/apis/v3/games/${gameId}/seasons/${season}/segments/0/leagues/${leagueId}?view=mSettings`;
+  const url = `https://lm-api-reads.fantasy.espn.com/apis/v3/games/${gameId}/seasons/${requestSeason}/segments/0/leagues/${leagueId}?view=mSettings`;
   
   try {
     const response = await fetch(url, {
@@ -92,7 +98,7 @@ export async function getLeagueInfo(
         throw new EspnAuthenticationFailed('ESPN authentication failed - invalid or expired cookies');
       }
       if (response.status === 404) {
-        throw new EspnLeagueNotFound(`League with ID ${leagueId} not found for season ${season}`);
+        throw new EspnLeagueNotFound(`League with ID ${leagueId} not found for season ${requestSeason}`);
       }
       const errorText = await response.text().catch(() => 'Failed to read error response');
       console.error('API error response:', errorText);
@@ -123,13 +129,17 @@ export async function getLeagueInfo(
     }
 
     // Map the API response to our EspnLeagueInfo interface
-    const sport = gameIdToSport(gameId) || gameIdToSport(data.gameId.toString()) || 'football';
+    const sport = requestedSport;
+    const canonicalSeasonYear = toCanonicalYear(data.seasonId, sport, 'espn');
+    const canonicalPreviousSeasons = (data.status?.previousSeasons || []).map((year) =>
+      toCanonicalYear(year, sport, 'espn')
+    );
     
     return {
       leagueId: data.id,
       leagueName: data.name,
       sport: sport as SportName,
-      seasonYear: data.seasonId,
+      seasonYear: canonicalSeasonYear,
       gameId: data.gameId.toString(),
       scoringPeriodId: data.scoringPeriodId,
       firstScoringPeriod: data.firstScoringPeriod || 1,
@@ -137,13 +147,13 @@ export async function getLeagueInfo(
       status: {
         currentMatchupPeriod: data.status?.currentMatchupPeriod || 1,
         isActive: data.status?.isActive || false,
-        previousSeasons: data.status?.previousSeasons || []
+        previousSeasons: canonicalPreviousSeasons
       },
       settings: {
         name: data.settings?.name || '',
         size: data.settings?.size || 0,
         status: data.status?.statusType?.type || 'UNKNOWN',
-        season: data.seasonId,
+        season: canonicalSeasonYear,
         currentMatchupPeriod: data.status?.currentMatchupPeriod || 1,
         gameId: data.gameId,
         gameName: data.gameName || 'Unknown',
@@ -169,7 +179,8 @@ export async function getLeagueInfo(
  * @param swid - ESPN SWID cookie value
  * @param s2 - ESPN espn_s2 cookie value
  * @param leagueId - ESPN league ID
- * @param season - Season year (defaults to current year)
+ * @param season - ESPN-native request year. When omitted, derives from the
+ * canonical current season for the sport.
  * @param gameId - ESPN game ID (ffl, flb, fba, fhl) - defaults to 'ffl'
  * @returns League info or null if an error occurs
  */
@@ -177,7 +188,7 @@ export async function getLeagueInfoSafe(
   swid: string,
   s2: string,
   leagueId: string,
-  season: number = new Date().getFullYear(),
+  season?: number,
   gameId: string = 'ffl'
 ): Promise<EspnLeagueInfo | null> {
   try {

--- a/workers/auth-worker/src/v3/league-discovery.ts
+++ b/workers/auth-worker/src/v3/league-discovery.ts
@@ -16,7 +16,7 @@ import {
 } from '../espn-types';
 import { getLeagueInfo } from './get-league-info';
 import { getLeagueTeams } from './get-league-teams';
-import { toCanonicalYear } from '../season-utils';
+import { toCanonicalYear, toPlatformYear } from '../season-utils';
 
 // =============================================================================
 // FAN API TYPES
@@ -372,24 +372,22 @@ async function discoverHistoricalSeasons(
     const previousSeasons = leagueInfo.status.previousSeasons;
     console.log(`Found ${previousSeasons.length} historical seasons for league ${league.leagueId}`);
 
-    for (const year of previousSeasons) {
+    for (const canonicalYear of previousSeasons) {
       try {
+        const espnYear = toPlatformYear(canonicalYear, sport, 'espn');
+
         // FIRST: Validate membership - only count if user was a member
-        const teams = await getLeagueTeams(swid, s2, league.leagueId, year, league.gameId);
+        const teams = await getLeagueTeams(swid, s2, league.leagueId, espnYear, league.gameId);
         const historicalTeam = teams.find(t => t.teamId === String(league.teamId));
 
         if (!historicalTeam) {
           // User wasn't in this season - don't count it at all
-          console.log(`Skipping season ${year} for league ${league.leagueId}: teamId ${league.teamId} not found`);
+          console.log(`Skipping season ${canonicalYear} for league ${league.leagueId}: teamId ${league.teamId} not found`);
           continue;
         }
 
         // User was a member - count it as found
         result.found++;
-
-        // Normalize ESPN-native year to canonical for DB operations.
-        // `year` stays ESPN-native for API calls above; only DB writes use canonical.
-        const canonicalYear = toCanonicalYear(year, sport, 'espn');
 
         // Check if already saved (DB stores canonical year)
         const exists = await storage.leagueExists(userId, sport, league.leagueId, canonicalYear);
@@ -403,8 +401,8 @@ async function discoverHistoricalSeasons(
           continue;
         }
 
-        // Get league info for historical season (for league name) — uses ESPN-native year
-        const historicalInfo = await getLeagueInfo(swid, s2, league.leagueId, year, league.gameId);
+        // Get league info for historical season (for league name) using ESPN-native year.
+        const historicalInfo = await getLeagueInfo(swid, s2, league.leagueId, espnYear, league.gameId);
 
         const addResult = await storage.addLeague(userId, {
           leagueId: league.leagueId,
@@ -418,12 +416,12 @@ async function discoverHistoricalSeasons(
         if (addResult.success) {
           result.added++;
         } else if (addResult.code !== 'DUPLICATE') {
-          console.error(`Failed to add historical season ${year} for league ${league.leagueId}:`, addResult.error);
+          console.error(`Failed to add historical season ${canonicalYear} for league ${league.leagueId}:`, addResult.error);
         }
 
       } catch (seasonError) {
         // Per-season error handling - continue with other seasons
-        console.error(`Error fetching season ${year} for league ${league.leagueId}:`, seasonError);
+        console.error(`Error fetching season ${canonicalYear} for league ${league.leagueId}:`, seasonError);
         continue;
       }
     }

--- a/workers/espn-client/README.md
+++ b/workers/espn-client/README.md
@@ -39,7 +39,7 @@ interface ExecuteRequest {
   params: {
     sport: 'football' | 'baseball' | 'basketball' | 'hockey';
     league_id: string;
-    season_year: number;
+    season_year: number;  // canonical start year (e.g., 2024 for the 2024-25 NBA season)
     team_id?: string;
     week?: number;
     position?: string;
@@ -50,6 +50,10 @@ interface ExecuteRequest {
 ```
 
 `/execute` reads end-user auth from the HTTP `Authorization` header and requires `X-Flaim-Internal-Token` for internal calls. Manual ESPN onboarding now runs in the web server layer, not through public ESPN worker routes.
+
+**Season year convention:** Callers always pass canonical start-year (e.g., 2024 for the 2024-25 NBA season). The `/execute` route converts to ESPN-native year before dispatching to handlers via `toEspnSeasonYear()` in `src/shared/season.ts`. ESPN uses end-year for basketball and hockey (e.g., 2025 for 2024-25); football and baseball are unchanged.
+
+**Handler contract:** By the time a sport handler runs, `params.season_year` is already the ESPN-native year. Handlers use it directly for ESPN API URLs. Use `fromEspnSeasonYear()` (same module) when canonical year is needed for non-API operations — `seasonPhase` comparisons, response `seasonYear` echo fields.
 
 ## Supported Tools
 

--- a/workers/espn-client/README.md
+++ b/workers/espn-client/README.md
@@ -64,7 +64,7 @@ interface RoutedToolParams extends ToolParams {
 }
 ```
 
-Handlers should use `params.seasonContext.espnYear` for ESPN URLs, cache keys, and ESPN stat-season matches, while keeping `params.season_year` / `params.seasonContext.canonicalYear` for outward-facing logic and season-phase comparisons. Production callers should route through `/execute`; direct tests should add `seasonContext` explicitly with `withSeasonContext()`.
+Handlers should use `params.seasonContext.espnYear` for ESPN URLs, cache keys, and ESPN stat-season matches, while keeping `params.season_year` / `params.seasonContext.canonicalYear` for outward-facing logic and season-phase comparisons. For cross-calendar sports, outward `get_league_info` year fields such as `seasonId` and `status.previousSeasons` should stay canonical even though ESPN returns end-year values. Production callers should route through `/execute`; direct tests should add `seasonContext` explicitly with `withSeasonContext()`.
 
 ## Supported Tools
 

--- a/workers/espn-client/README.md
+++ b/workers/espn-client/README.md
@@ -2,7 +2,7 @@
 
 Internal ESPN API client used by the unified gateway (`fantasy-mcp`). Handles all ESPN Fantasy sports data fetching.
 
-> **Note**: Primarily called via service binding from `fantasy-mcp`. It also exposes onboarding endpoints used by the web app (manual ESPN setup).
+> **Note**: Primarily called via service binding from `fantasy-mcp`. It exposes only the internal `/execute` contract plus `/health`.
 
 ## Purpose
 
@@ -51,9 +51,20 @@ interface ExecuteRequest {
 
 `/execute` reads end-user auth from the HTTP `Authorization` header and requires `X-Flaim-Internal-Token` for internal calls. Manual ESPN onboarding now runs in the web server layer, not through public ESPN worker routes.
 
-**Season year convention:** Callers always pass canonical start-year (e.g., 2024 for the 2024-25 NBA season). The `/execute` route converts to ESPN-native year before dispatching to handlers via `toEspnSeasonYear()` in `src/shared/season.ts`. ESPN uses end-year for basketball and hockey (e.g., 2025 for 2024-25); football and baseball are unchanged.
+**Season year convention:** Callers always pass canonical start-year (e.g., 2024 for the 2024-25 NBA season). `/execute` preserves that external `params.season_year` value and adds explicit internal season context before dispatching to handlers. ESPN uses end-year for basketball and hockey (e.g., 2025 for 2024-25); football and baseball are unchanged.
 
-**Handler contract:** By the time a sport handler runs, `params.season_year` is already the ESPN-native year. Handlers use it directly for ESPN API URLs. Use `fromEspnSeasonYear()` (same module) when canonical year is needed for non-API operations — `seasonPhase` comparisons, response `seasonYear` echo fields.
+**Handler contract:** Routed handlers receive canonical request params plus explicit season context:
+
+```typescript
+interface RoutedToolParams extends ToolParams {
+  seasonContext: {
+    canonicalYear: number; // same value as params.season_year
+    espnYear: number;      // ESPN-native year for API calls
+  };
+}
+```
+
+Handlers should use `params.seasonContext.espnYear` for ESPN URLs, cache keys, and ESPN stat-season matches, while keeping `params.season_year` / `params.seasonContext.canonicalYear` for outward-facing logic and season-phase comparisons. Production callers should route through `/execute`; direct tests should add `seasonContext` explicitly with `withSeasonContext()`.
 
 ## Supported Tools
 

--- a/workers/espn-client/src/__tests__/index.test.ts
+++ b/workers/espn-client/src/__tests__/index.test.ts
@@ -1,0 +1,205 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { INTERNAL_SERVICE_TOKEN_HEADER } from '@flaim/worker-shared';
+import type { RoutedToolParams } from '../types';
+
+const footballGetStandings = vi.fn(async () => ({
+  success: true,
+  data: { handler: 'football' },
+}));
+
+const basketballGetStandings = vi.fn(async () => ({
+  success: true,
+  data: { handler: 'basketball' },
+}));
+
+const basketballGetMatchups = vi.fn(async () => ({
+  success: true,
+  data: { handler: 'basketball-matchups' },
+}));
+
+const hockeyGetFreeAgents = vi.fn(async () => ({
+  success: true,
+  data: { handler: 'hockey-free-agents' },
+}));
+
+vi.mock('../sports/football/handlers', () => ({
+  footballHandlers: {
+    get_standings: footballGetStandings,
+  },
+}));
+
+vi.mock('../sports/baseball/handlers', () => ({
+  baseballHandlers: {},
+}));
+
+vi.mock('../sports/basketball/handlers', () => ({
+  basketballHandlers: {
+    get_standings: basketballGetStandings,
+    get_matchups: basketballGetMatchups,
+  },
+}));
+
+vi.mock('../sports/hockey/handlers', () => ({
+  hockeyHandlers: {
+    get_free_agents: hockeyGetFreeAgents,
+  },
+}));
+
+const { default: app } = await import('../index');
+
+function makeRequest(body: unknown): Request {
+  return new Request('https://espn-client.test/execute', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer user-token',
+      [INTERNAL_SERVICE_TOKEN_HEADER]: 'internal-token',
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('/execute season boundary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('preserves canonical season_year and adds basketball seasonContext', async () => {
+    const response = await app.fetch(makeRequest({
+      tool: 'get_standings',
+      params: {
+        sport: 'basketball',
+        league_id: '123',
+        season_year: 2024,
+      },
+    }), {
+      INTERNAL_SERVICE_TOKEN: 'internal-token',
+    } as never);
+
+    expect(response.status).toBe(200);
+    expect(basketballGetStandings).toHaveBeenCalledOnce();
+
+    const basketballCalls = basketballGetStandings.mock.calls as unknown[][];
+    const routedParams = basketballCalls[0]?.[1] as RoutedToolParams;
+    expect(routedParams).toMatchObject({
+      sport: 'basketball',
+      league_id: '123',
+      season_year: 2024,
+      seasonContext: {
+        canonicalYear: 2024,
+        espnYear: 2025,
+      },
+    });
+    expect(basketballCalls[0]?.[2]).toBe('Bearer user-token');
+
+    const body = await response.json();
+    expect(body).toEqual({
+      success: true,
+      data: { handler: 'basketball' },
+    });
+  });
+
+  it('routes basketball get_matchups with explicit seasonContext', async () => {
+    const response = await app.fetch(makeRequest({
+      tool: 'get_matchups',
+      params: {
+        sport: 'basketball',
+        league_id: '321',
+        season_year: 2024,
+        week: 7,
+      },
+    }), {
+      INTERNAL_SERVICE_TOKEN: 'internal-token',
+    } as never);
+
+    expect(response.status).toBe(200);
+    expect(basketballGetMatchups).toHaveBeenCalledOnce();
+
+    const basketballCalls = basketballGetMatchups.mock.calls as unknown[][];
+    const routedParams = basketballCalls[0]?.[1] as RoutedToolParams;
+    expect(routedParams).toMatchObject({
+      sport: 'basketball',
+      league_id: '321',
+      season_year: 2024,
+      week: 7,
+      seasonContext: {
+        canonicalYear: 2024,
+        espnYear: 2025,
+      },
+    });
+    expect(basketballCalls[0]?.[2]).toBe('Bearer user-token');
+
+    const body = await response.json();
+    expect(body).toEqual({
+      success: true,
+      data: { handler: 'basketball-matchups' },
+    });
+  });
+
+  it('keeps football canonical and ESPN year aligned', async () => {
+    const response = await app.fetch(makeRequest({
+      tool: 'get_standings',
+      params: {
+        sport: 'football',
+        league_id: '999',
+        season_year: 2025,
+      },
+    }), {
+      INTERNAL_SERVICE_TOKEN: 'internal-token',
+    } as never);
+
+    expect(response.status).toBe(200);
+    expect(footballGetStandings).toHaveBeenCalledOnce();
+
+    const footballCalls = footballGetStandings.mock.calls as unknown[][];
+    const routedParams = footballCalls[0]?.[1] as RoutedToolParams;
+    expect(routedParams).toMatchObject({
+      sport: 'football',
+      league_id: '999',
+      season_year: 2025,
+      seasonContext: {
+        canonicalYear: 2025,
+        espnYear: 2025,
+      },
+    });
+  });
+
+  it('routes hockey get_free_agents with explicit seasonContext', async () => {
+    const response = await app.fetch(makeRequest({
+      tool: 'get_free_agents',
+      params: {
+        sport: 'hockey',
+        league_id: '456',
+        season_year: 2024,
+        position: 'C',
+        count: 15,
+      },
+    }), {
+      INTERNAL_SERVICE_TOKEN: 'internal-token',
+    } as never);
+
+    expect(response.status).toBe(200);
+    expect(hockeyGetFreeAgents).toHaveBeenCalledOnce();
+
+    const hockeyCalls = hockeyGetFreeAgents.mock.calls as unknown[][];
+    const routedParams = hockeyCalls[0]?.[1] as RoutedToolParams;
+    expect(routedParams).toMatchObject({
+      sport: 'hockey',
+      league_id: '456',
+      season_year: 2024,
+      position: 'C',
+      count: 15,
+      seasonContext: {
+        canonicalYear: 2024,
+        espnYear: 2025,
+      },
+    });
+    expect(hockeyCalls[0]?.[2]).toBe('Bearer user-token');
+
+    const body = await response.json();
+    expect(body).toEqual({
+      success: true,
+      data: { handler: 'hockey-free-agents' },
+    });
+  });
+});

--- a/workers/espn-client/src/__tests__/types.test.ts
+++ b/workers/espn-client/src/__tests__/types.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { Sport, ToolParams, ExecuteRequest, ExecuteResponse } from '../types';
+import type { Sport, ToolParams, RoutedToolParams, ExecuteRequest, ExecuteResponse } from '../types';
 
 describe('espn-client types', () => {
   describe('Sport type', () => {
@@ -50,6 +50,24 @@ describe('espn-client types', () => {
       };
       expect(request.tool).toBe('get_standings');
       expect(request.params.league_id).toBe('12345');
+    });
+  });
+
+  describe('RoutedToolParams interface', () => {
+    it('keeps canonical season_year and adds explicit seasonContext', () => {
+      const params: RoutedToolParams = {
+        sport: 'basketball',
+        league_id: '12345',
+        season_year: 2024,
+        seasonContext: {
+          canonicalYear: 2024,
+          espnYear: 2025,
+        },
+      };
+
+      expect(params.season_year).toBe(2024);
+      expect(params.seasonContext.canonicalYear).toBe(2024);
+      expect(params.seasonContext.espnYear).toBe(2025);
     });
   });
 

--- a/workers/espn-client/src/index.ts
+++ b/workers/espn-client/src/index.ts
@@ -1,7 +1,7 @@
 // workers/espn-client/src/index.ts
 import { Context, Hono } from 'hono';
 import { cors } from 'hono/cors';
-import type { Env, ExecuteRequest, ExecuteResponse, Sport, ToolParams } from './types';
+import type { Env, ExecuteRequest, ExecuteResponse, RoutedToolParams, Sport } from './types';
 import { baseballHandlers } from './sports/baseball/handlers';
 import { basketballHandlers } from './sports/basketball/handlers';
 import { footballHandlers } from './sports/football/handlers';
@@ -15,7 +15,7 @@ import {
   getEvalContext,
   validateInternalService,
 } from '@flaim/worker-shared';
-import { toEspnSeasonYear } from './shared/season';
+import { withSeasonContext } from './shared/season';
 import { logEvalEvent } from './logging';
 
 const app = new Hono<{ Bindings: Env }>();
@@ -49,13 +49,11 @@ app.post('/execute', async (c) => {
   const { tool, params } = body;
   const authHeader = c.req.header('Authorization');
   const { sport, league_id, season_year } = params;
-
-  // Translate canonical start-year to ESPN-native before routing to handlers.
-  // For basketball/hockey ESPN expects end-year; for football/baseball this is a no-op.
-  const espnParams = { ...params, season_year: toEspnSeasonYear(season_year, sport) };
+  const routedParams = withSeasonContext(params);
+  const { espnYear } = routedParams.seasonContext;
 
   const startTime = Date.now();
-  console.log(`[espn-client] ${correlationId} ${tool} ${sport} league=${league_id} season=${espnParams.season_year}`);
+  console.log(`[espn-client] ${correlationId} ${tool} ${sport} league=${league_id} season=${season_year} espnSeason=${espnYear}`);
   logEvalEvent({
     service: 'espn-client',
     phase: 'execute_start',
@@ -65,12 +63,12 @@ app.post('/execute', async (c) => {
     tool,
     sport,
     league_id,
-    message: `${tool} ${sport} league=${league_id} season=${espnParams.season_year}`,
+    message: `${tool} ${sport} league=${league_id} season=${season_year} espnSeason=${espnYear}`,
   });
 
   // Route to sport-specific handler
   try {
-    const result = await routeToSport(c.env, sport, tool, espnParams, authHeader, correlationId);
+    const result = await routeToSport(c.env, sport, tool, routedParams, authHeader, correlationId);
     const duration = Date.now() - startTime;
     console.log(`[espn-client] ${correlationId} ${tool} ${sport} completed in ${duration}ms success=${result.success}`);
     logEvalEvent({
@@ -125,7 +123,7 @@ async function routeToSport(
   env: Env,
   sport: Sport,
   tool: string,
-  params: ToolParams,
+  params: RoutedToolParams,
   authHeader?: string,
   correlationId?: string
 ): Promise<ExecuteResponse> {

--- a/workers/espn-client/src/shared/__tests__/season.test.ts
+++ b/workers/espn-client/src/shared/__tests__/season.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { toEspnSeasonYear } from '../season';
+import { toEspnSeasonYear, fromEspnSeasonYear } from '../season';
 
 describe('toEspnSeasonYear', () => {
   it('adds 1 for basketball', () => {
@@ -16,5 +16,31 @@ describe('toEspnSeasonYear', () => {
 
   it('passes through baseball', () => {
     expect(toEspnSeasonYear(2025, 'baseball')).toBe(2025);
+  });
+});
+
+describe('fromEspnSeasonYear', () => {
+  it('subtracts 1 for basketball', () => {
+    expect(fromEspnSeasonYear(2025, 'basketball')).toBe(2024);
+  });
+
+  it('subtracts 1 for hockey', () => {
+    expect(fromEspnSeasonYear(2025, 'hockey')).toBe(2024);
+  });
+
+  it('passes through football', () => {
+    expect(fromEspnSeasonYear(2025, 'football')).toBe(2025);
+  });
+
+  it('passes through baseball', () => {
+    expect(fromEspnSeasonYear(2025, 'baseball')).toBe(2025);
+  });
+
+  it('is the inverse of toEspnSeasonYear for basketball', () => {
+    expect(fromEspnSeasonYear(toEspnSeasonYear(2024, 'basketball'), 'basketball')).toBe(2024);
+  });
+
+  it('is the inverse of toEspnSeasonYear for hockey', () => {
+    expect(fromEspnSeasonYear(toEspnSeasonYear(2024, 'hockey'), 'hockey')).toBe(2024);
   });
 });

--- a/workers/espn-client/src/shared/__tests__/season.test.ts
+++ b/workers/espn-client/src/shared/__tests__/season.test.ts
@@ -4,6 +4,7 @@ import {
   createSeasonContext,
   fromEspnSeasonYear,
   getSeasonContext,
+  getCurrentSeasonYear,
   normalizeEspnLeagueStatus,
   toEspnSeasonYear,
   withSeasonContext,
@@ -59,6 +60,16 @@ describe('createSeasonContext', () => {
       canonicalYear: 2024,
       espnYear: 2025,
     });
+  });
+});
+
+describe('getCurrentSeasonYear', () => {
+  it('uses the shared rollover rules for football', () => {
+    expect(getCurrentSeasonYear('football', new Date('2026-01-15T12:00:00Z'))).toBe(2025);
+  });
+
+  it('uses the shared rollover rules for basketball', () => {
+    expect(getCurrentSeasonYear('basketball', new Date('2026-08-01T12:00:00Z'))).toBe(2026);
   });
 });
 

--- a/workers/espn-client/src/shared/__tests__/season.test.ts
+++ b/workers/espn-client/src/shared/__tests__/season.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import type { RoutedToolParams } from '../../types';
-import { createSeasonContext, getSeasonContext, toEspnSeasonYear, fromEspnSeasonYear, withSeasonContext } from '../season';
+import {
+  createSeasonContext,
+  fromEspnSeasonYear,
+  getSeasonContext,
+  normalizeEspnLeagueStatus,
+  toEspnSeasonYear,
+  withSeasonContext,
+} from '../season';
 
 describe('toEspnSeasonYear', () => {
   it('adds 1 for basketball', () => {
@@ -52,6 +59,22 @@ describe('createSeasonContext', () => {
       canonicalYear: 2024,
       espnYear: 2025,
     });
+  });
+});
+
+describe('normalizeEspnLeagueStatus', () => {
+  it('normalizes previousSeasons to canonical years for basketball', () => {
+    expect(normalizeEspnLeagueStatus({
+      currentMatchupPeriod: 5,
+      previousSeasons: [2024, 2025],
+    }, 'basketball')).toEqual({
+      currentMatchupPeriod: 5,
+      previousSeasons: [2023, 2024],
+    });
+  });
+
+  it('passes through non-object values unchanged', () => {
+    expect(normalizeEspnLeagueStatus(null, 'hockey')).toBeNull();
   });
 });
 

--- a/workers/espn-client/src/shared/__tests__/season.test.ts
+++ b/workers/espn-client/src/shared/__tests__/season.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { toEspnSeasonYear, fromEspnSeasonYear } from '../season';
+import type { RoutedToolParams } from '../../types';
+import { createSeasonContext, getSeasonContext, toEspnSeasonYear, fromEspnSeasonYear, withSeasonContext } from '../season';
 
 describe('toEspnSeasonYear', () => {
   it('adds 1 for basketball', () => {
@@ -42,5 +43,55 @@ describe('fromEspnSeasonYear', () => {
 
   it('is the inverse of toEspnSeasonYear for hockey', () => {
     expect(fromEspnSeasonYear(toEspnSeasonYear(2024, 'hockey'), 'hockey')).toBe(2024);
+  });
+});
+
+describe('createSeasonContext', () => {
+  it('tracks both canonical and ESPN year for basketball', () => {
+    expect(createSeasonContext(2024, 'basketball')).toEqual({
+      canonicalYear: 2024,
+      espnYear: 2025,
+    });
+  });
+});
+
+describe('withSeasonContext', () => {
+  it('preserves external params and adds seasonContext', () => {
+    expect(withSeasonContext({
+      sport: 'hockey',
+      league_id: '123',
+      season_year: 2024,
+    })).toEqual({
+      sport: 'hockey',
+      league_id: '123',
+      season_year: 2024,
+      seasonContext: {
+        canonicalYear: 2024,
+        espnYear: 2025,
+      },
+    });
+  });
+});
+
+describe('getSeasonContext', () => {
+  it('returns routed seasonContext when present', () => {
+    const params = withSeasonContext({
+      sport: 'basketball',
+      league_id: '123',
+      season_year: 2024,
+    });
+
+    expect(getSeasonContext(params)).toEqual({
+      canonicalYear: 2024,
+      espnYear: 2025,
+    });
+  });
+
+  it('throws when routed params are missing seasonContext', () => {
+    expect(() => getSeasonContext({
+      sport: 'football',
+      league_id: '123',
+      season_year: 2025,
+    } as unknown as RoutedToolParams)).toThrow(/Missing seasonContext/);
   });
 });

--- a/workers/espn-client/src/shared/season.ts
+++ b/workers/espn-client/src/shared/season.ts
@@ -1,3 +1,5 @@
+import type { EspnSeasonContext, RoutedToolParams, ToolParams } from '../types';
+
 /**
  * Season Year Translation for ESPN
  *
@@ -5,9 +7,7 @@
  * ESPN's API expects end-year for basketball/hockey (e.g., 2025).
  * This function converts canonical → ESPN-native.
  *
- * Called by index.ts at the /execute boundary — handlers receive ESPN year, not canonical.
- * Use fromEspnSeasonYear() inside handlers when canonical year is needed (e.g., seasonPhase
- * comparisons, response echoes).
+ * `/execute` computes this once and attaches it to the internal `seasonContext`.
  */
 export function toEspnSeasonYear(canonicalYear: number, sport: string): number {
   if (sport === 'basketball' || sport === 'hockey') {
@@ -22,6 +22,29 @@ export function fromEspnSeasonYear(espnYear: number, sport: string): number {
     return espnYear - 1;
   }
   return espnYear;
+}
+
+export function createSeasonContext(canonicalYear: number, sport: string): EspnSeasonContext {
+  return {
+    canonicalYear,
+    espnYear: toEspnSeasonYear(canonicalYear, sport),
+  };
+}
+
+export function withSeasonContext(params: ToolParams): RoutedToolParams {
+  return {
+    ...params,
+    seasonContext: createSeasonContext(params.season_year, params.sport),
+  };
+}
+
+export function getSeasonContext(params: RoutedToolParams): EspnSeasonContext {
+  if (!params.seasonContext) {
+    throw new Error(
+      'Missing seasonContext for routed handler params. Call handlers through /execute or wrap test params with withSeasonContext().'
+    );
+  }
+  return params.seasonContext;
 }
 
 /**

--- a/workers/espn-client/src/shared/season.ts
+++ b/workers/espn-client/src/shared/season.ts
@@ -4,12 +4,24 @@
  * Flaim stores canonical start-year (e.g., 2024 for the 2024-25 NBA season).
  * ESPN's API expects end-year for basketball/hockey (e.g., 2025).
  * This function converts canonical → ESPN-native.
+ *
+ * Called by index.ts at the /execute boundary — handlers receive ESPN year, not canonical.
+ * Use fromEspnSeasonYear() inside handlers when canonical year is needed (e.g., seasonPhase
+ * comparisons, response echoes).
  */
 export function toEspnSeasonYear(canonicalYear: number, sport: string): number {
   if (sport === 'basketball' || sport === 'hockey') {
     return canonicalYear + 1;
   }
   return canonicalYear;
+}
+
+/** Inverse of toEspnSeasonYear — converts ESPN-native year back to canonical start year. */
+export function fromEspnSeasonYear(espnYear: number, sport: string): number {
+  if (sport === 'basketball' || sport === 'hockey') {
+    return espnYear - 1;
+  }
+  return espnYear;
 }
 
 /**

--- a/workers/espn-client/src/shared/season.ts
+++ b/workers/espn-client/src/shared/season.ts
@@ -24,6 +24,24 @@ export function fromEspnSeasonYear(espnYear: number, sport: string): number {
   return espnYear;
 }
 
+export function normalizeEspnLeagueStatus(status: unknown, sport: string): unknown {
+  if (!status || typeof status !== 'object') {
+    return status;
+  }
+
+  const statusRecord = status as Record<string, unknown>;
+  const previousSeasons = Array.isArray(statusRecord.previousSeasons)
+    ? statusRecord.previousSeasons.map((season) =>
+        typeof season === 'number' ? fromEspnSeasonYear(season, sport) : season
+      )
+    : statusRecord.previousSeasons;
+
+  return {
+    ...statusRecord,
+    previousSeasons,
+  };
+}
+
 export function createSeasonContext(canonicalYear: number, sport: string): EspnSeasonContext {
   return {
     canonicalYear,

--- a/workers/espn-client/src/shared/season.ts
+++ b/workers/espn-client/src/shared/season.ts
@@ -1,4 +1,11 @@
 import type { EspnSeasonContext, RoutedToolParams, ToolParams } from '../types';
+import {
+  getDefaultSeasonYear as sharedGetDefaultSeasonYear,
+  toCanonicalYear as sharedToCanonicalYear,
+  toPlatformYear as sharedToPlatformYear,
+} from '@flaim/worker-shared';
+
+type SeasonSport = Parameters<typeof sharedGetDefaultSeasonYear>[0];
 
 /**
  * Season Year Translation for ESPN
@@ -9,22 +16,16 @@ import type { EspnSeasonContext, RoutedToolParams, ToolParams } from '../types';
  *
  * `/execute` computes this once and attaches it to the internal `seasonContext`.
  */
-export function toEspnSeasonYear(canonicalYear: number, sport: string): number {
-  if (sport === 'basketball' || sport === 'hockey') {
-    return canonicalYear + 1;
-  }
-  return canonicalYear;
+export function toEspnSeasonYear(canonicalYear: number, sport: SeasonSport): number {
+  return sharedToPlatformYear(canonicalYear, sport, 'espn');
 }
 
 /** Inverse of toEspnSeasonYear — converts ESPN-native year back to canonical start year. */
-export function fromEspnSeasonYear(espnYear: number, sport: string): number {
-  if (sport === 'basketball' || sport === 'hockey') {
-    return espnYear - 1;
-  }
-  return espnYear;
+export function fromEspnSeasonYear(espnYear: number, sport: SeasonSport): number {
+  return sharedToCanonicalYear(espnYear, sport, 'espn');
 }
 
-export function normalizeEspnLeagueStatus(status: unknown, sport: string): unknown {
+export function normalizeEspnLeagueStatus(status: unknown, sport: SeasonSport): unknown {
   if (!status || typeof status !== 'object') {
     return status;
   }
@@ -32,7 +33,7 @@ export function normalizeEspnLeagueStatus(status: unknown, sport: string): unkno
   const statusRecord = status as Record<string, unknown>;
   const previousSeasons = Array.isArray(statusRecord.previousSeasons)
     ? statusRecord.previousSeasons.map((season) =>
-        typeof season === 'number' ? fromEspnSeasonYear(season, sport) : season
+        typeof season === 'number' ? sharedToCanonicalYear(season, sport, 'espn') : season
       )
     : statusRecord.previousSeasons;
 
@@ -42,7 +43,7 @@ export function normalizeEspnLeagueStatus(status: unknown, sport: string): unkno
   };
 }
 
-export function createSeasonContext(canonicalYear: number, sport: string): EspnSeasonContext {
+export function createSeasonContext(canonicalYear: number, sport: SeasonSport): EspnSeasonContext {
   return {
     canonicalYear,
     espnYear: toEspnSeasonYear(canonicalYear, sport),
@@ -66,32 +67,11 @@ export function getSeasonContext(params: RoutedToolParams): EspnSeasonContext {
 }
 
 /**
- * Month (1-indexed) when each sport's season year rolls over to the next season.
- * Before this month: the current season is the previous year.
- * Mirrors the canonical rollover rules in workers/auth-worker/src/season-utils.ts.
- */
-const SEASON_ROLLOVER_MONTH: Record<string, number> = {
-  baseball: 2,    // Feb 1 — ~10 weeks before Opening Day
-  football: 7,    // Jul 1 — ~10 weeks before NFL kickoff
-  basketball: 8,  // Aug 1 — ~10 weeks before NBA opening night
-  hockey: 8,      // Aug 1 — ~10 weeks before NHL opening night
-};
-
-/**
  * Returns the canonical start-year of the current season for a sport,
  * using America/New_York time. Cross-calendar sports (basketball, hockey)
  * stay on the prior year until August, so January 2026 correctly returns
  * 2025 for football and 2025 for basketball/hockey until rollover.
  */
-export function getCurrentSeasonYear(sport: string, now = new Date()): number {
-  const ny = new Intl.DateTimeFormat('en-US', {
-    timeZone: 'America/New_York',
-    year: 'numeric',
-    month: '2-digit',
-  }).formatToParts(now);
-
-  const year = Number(ny.find((p) => p.type === 'year')?.value);
-  const month = Number(ny.find((p) => p.type === 'month')?.value);
-  const rollover = SEASON_ROLLOVER_MONTH[sport] ?? 1;
-  return month < rollover ? year - 1 : year;
+export function getCurrentSeasonYear(sport: SeasonSport, now = new Date()): number {
+  return sharedGetDefaultSeasonYear(sport, now);
 }

--- a/workers/espn-client/src/sports/__tests__/league-info-teams.test.ts
+++ b/workers/espn-client/src/sports/__tests__/league-info-teams.test.ts
@@ -3,9 +3,10 @@ import { baseballHandlers } from '../baseball/handlers';
 import { basketballHandlers } from '../basketball/handlers';
 import { footballHandlers } from '../football/handlers';
 import { hockeyHandlers } from '../hockey/handlers';
-import type { ToolParams } from '../../types';
+import type { HandlerToolParams, Sport } from '../../types';
 import { getCredentials } from '../../shared/auth';
 import { espnFetch } from '../../shared/espn-api';
+import { withSeasonContext } from '../../shared/season';
 
 vi.mock('../../shared/auth', () => ({
   getCredentials: vi.fn(),
@@ -20,11 +21,19 @@ vi.mock('../../shared/espn-api', async () => {
 });
 
 const scenarios = [
-  { label: 'football', sport: 'football', handlers: footballHandlers },
-  { label: 'baseball', sport: 'baseball', handlers: baseballHandlers },
-  { label: 'basketball', sport: 'basketball', handlers: basketballHandlers },
-  { label: 'hockey', sport: 'hockey', handlers: hockeyHandlers },
+  { label: 'football', sport: 'football', handlers: footballHandlers, expectedEspnYear: 2024 },
+  { label: 'baseball', sport: 'baseball', handlers: baseballHandlers, expectedEspnYear: 2024 },
+  { label: 'basketball', sport: 'basketball', handlers: basketballHandlers, expectedEspnYear: 2025 },
+  { label: 'hockey', sport: 'hockey', handlers: hockeyHandlers, expectedEspnYear: 2025 },
 ] as const;
+
+function makeParams(sport: Sport): HandlerToolParams {
+  return withSeasonContext({
+    sport,
+    league_id: '123',
+    season_year: 2024,
+  });
+}
 
 const mockLeagueResponse = {
   id: 123,
@@ -84,7 +93,7 @@ describe('espn cross-sport get_league_info teams array', () => {
       new Response(JSON.stringify(mockLeagueResponse), { status: 200 })
     );
 
-    const params: ToolParams = { sport, league_id: '123', season_year: 2025 };
+    const params = makeParams(sport);
     const result = await handlers.get_league_info({} as never, params, 'Bearer x', 'cid');
 
     expect(result.success).toBe(true);
@@ -137,15 +146,16 @@ describe('espn cross-sport get_league_info teams array', () => {
     });
   });
 
-  it.each(scenarios)('$label requests mTeam view in API path', async ({ sport, handlers }) => {
+  it.each(scenarios)('$label requests mTeam view in API path', async ({ sport, handlers, expectedEspnYear }) => {
     espnFetchMock.mockResolvedValue(
       new Response(JSON.stringify(mockLeagueResponse), { status: 200 })
     );
 
-    const params: ToolParams = { sport, league_id: '123', season_year: 2025 };
+    const params = makeParams(sport);
     await handlers.get_league_info({} as never, params, 'Bearer x', 'cid');
 
     const fetchPath = espnFetchMock.mock.calls[0][0] as string;
+    expect(fetchPath).toContain(`/seasons/${expectedEspnYear}/segments/0/leagues/123`);
     expect(fetchPath).toContain('view=mSettings');
     expect(fetchPath).toContain('view=mTeam');
   });

--- a/workers/espn-client/src/sports/__tests__/league-info-teams.test.ts
+++ b/workers/espn-client/src/sports/__tests__/league-info-teams.test.ts
@@ -27,6 +27,10 @@ const scenarios = [
   { label: 'hockey', sport: 'hockey', handlers: hockeyHandlers, expectedEspnYear: 2025 },
 ] as const;
 
+const crossCalendarScenarios = scenarios.filter(
+  (scenario) => scenario.sport === 'basketball' || scenario.sport === 'hockey'
+);
+
 function makeParams(sport: Sport): HandlerToolParams {
   return withSeasonContext({
     sport,
@@ -41,6 +45,11 @@ const mockLeagueResponse = {
   segmentId: 0,
   scoringPeriodId: 5,
   currentMatchupPeriod: 5,
+  status: {
+    currentMatchupPeriod: 5,
+    isActive: true,
+    previousSeasons: [2024, 2025],
+  },
   settings: {
     name: 'Test League',
     size: 10,
@@ -144,6 +153,38 @@ describe('espn cross-sport get_league_info teams array', () => {
       ownerName: undefined,
       owners: undefined,
     });
+  });
+
+  it.each(crossCalendarScenarios)('$label keeps outward seasonId canonical', async ({ sport, handlers }) => {
+    espnFetchMock.mockResolvedValue(
+      new Response(JSON.stringify(mockLeagueResponse), { status: 200 })
+    );
+
+    const params = makeParams(sport);
+    const result = await handlers.get_league_info({} as never, params, 'Bearer x', 'cid');
+
+    expect(result.success).toBe(true);
+    const data = result.data as { seasonId?: number };
+
+    expect(data.seasonId).toBe(2024);
+  });
+
+  it.each(crossCalendarScenarios)('$label normalizes status.previousSeasons to canonical years', async ({ sport, handlers }) => {
+    espnFetchMock.mockResolvedValue(
+      new Response(JSON.stringify(mockLeagueResponse), { status: 200 })
+    );
+
+    const params = makeParams(sport);
+    const result = await handlers.get_league_info({} as never, params, 'Bearer x', 'cid');
+
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      status?: {
+        previousSeasons?: number[];
+      };
+    };
+
+    expect(data.status?.previousSeasons).toEqual([2023, 2024]);
   });
 
   it.each(scenarios)('$label requests mTeam view in API path', async ({ sport, handlers, expectedEspnYear }) => {

--- a/workers/espn-client/src/sports/__tests__/league-info-teams.test.ts
+++ b/workers/espn-client/src/sports/__tests__/league-info-teams.test.ts
@@ -155,7 +155,7 @@ describe('espn cross-sport get_league_info teams array', () => {
     });
   });
 
-  it.each(crossCalendarScenarios)('$label keeps outward seasonId canonical', async ({ sport, handlers }) => {
+  it.each(scenarios)('$label keeps outward seasonId canonical', async ({ sport, handlers }) => {
     espnFetchMock.mockResolvedValue(
       new Response(JSON.stringify(mockLeagueResponse), { status: 200 })
     );

--- a/workers/espn-client/src/sports/__tests__/roster-owner.test.ts
+++ b/workers/espn-client/src/sports/__tests__/roster-owner.test.ts
@@ -3,9 +3,10 @@ import { baseballHandlers } from '../baseball/handlers';
 import { basketballHandlers } from '../basketball/handlers';
 import { footballHandlers } from '../football/handlers';
 import { hockeyHandlers } from '../hockey/handlers';
-import type { ToolParams } from '../../types';
+import type { HandlerToolParams, Sport, ToolParams } from '../../types';
 import { getCredentials } from '../../shared/auth';
 import { espnFetch } from '../../shared/espn-api';
+import { withSeasonContext } from '../../shared/season';
 
 vi.mock('../../shared/auth', () => ({
   getCredentials: vi.fn(),
@@ -20,11 +21,20 @@ vi.mock('../../shared/espn-api', async () => {
 });
 
 const scenarios = [
-  { label: 'football', sport: 'football', handlers: footballHandlers },
-  { label: 'baseball', sport: 'baseball', handlers: baseballHandlers },
-  { label: 'basketball', sport: 'basketball', handlers: basketballHandlers },
-  { label: 'hockey', sport: 'hockey', handlers: hockeyHandlers },
+  { label: 'football', sport: 'football', handlers: footballHandlers, expectedEspnYear: 2024 },
+  { label: 'baseball', sport: 'baseball', handlers: baseballHandlers, expectedEspnYear: 2024 },
+  { label: 'basketball', sport: 'basketball', handlers: basketballHandlers, expectedEspnYear: 2025 },
+  { label: 'hockey', sport: 'hockey', handlers: hockeyHandlers, expectedEspnYear: 2025 },
 ] as const;
+
+function makeParams(sport: Sport, overrides: Partial<ToolParams> = {}): HandlerToolParams {
+  return withSeasonContext({
+    sport,
+    league_id: '123',
+    season_year: 2024,
+    ...overrides,
+  });
+}
 
 const mockRosterResponse = {
   teams: [
@@ -73,7 +83,7 @@ describe('espn cross-sport get_roster ownerName', () => {
       new Response(JSON.stringify(mockRosterResponse), { status: 200 })
     );
 
-    const params: ToolParams = { sport, league_id: '123', season_year: 2025, team_id: '6' };
+    const params = makeParams(sport, { team_id: '6' });
     const result = await handlers.get_roster({} as never, params, 'Bearer x', 'cid');
 
     expect(result.success).toBe(true);
@@ -91,15 +101,16 @@ describe('espn cross-sport get_roster ownerName', () => {
     expect(data.roster[0].name).toBe('Paul Skenes');
   });
 
-  it.each(scenarios)('$label requests mTeam view alongside mRoster', async ({ sport, handlers }) => {
+  it.each(scenarios)('$label requests mTeam view alongside mRoster', async ({ sport, handlers, expectedEspnYear }) => {
     espnFetchMock.mockResolvedValue(
       new Response(JSON.stringify(mockRosterResponse), { status: 200 })
     );
 
-    const params: ToolParams = { sport, league_id: '123', season_year: 2025, team_id: '6' };
+    const params = makeParams(sport, { team_id: '6' });
     await handlers.get_roster({} as never, params, 'Bearer x', 'cid');
 
     const fetchPath = espnFetchMock.mock.calls[0][0] as string;
+    expect(fetchPath).toContain(`/seasons/${expectedEspnYear}/segments/0/leagues/123`);
     expect(fetchPath).toContain('view=mRoster');
     expect(fetchPath).toContain('view=mTeam');
   });
@@ -118,7 +129,7 @@ describe('espn cross-sport get_roster ownerName', () => {
       new Response(JSON.stringify(noOwnerResponse), { status: 200 })
     );
 
-    const params: ToolParams = { sport, league_id: '123', season_year: 2025, team_id: '3' };
+    const params = makeParams(sport, { team_id: '3' });
     const result = await handlers.get_roster({} as never, params, 'Bearer x', 'cid');
 
     expect(result.success).toBe(true);
@@ -140,7 +151,7 @@ describe('espn cross-sport get_roster ownerName', () => {
       new Response(JSON.stringify(emptyFirstOwnerResponse), { status: 200 })
     );
 
-    const params: ToolParams = { sport, league_id: '123', season_year: 2025, team_id: '5' };
+    const params = makeParams(sport, { team_id: '5' });
     const result = await handlers.get_roster({} as never, params, 'Bearer x', 'cid');
 
     expect(result.success).toBe(true);

--- a/workers/espn-client/src/sports/__tests__/search-players-cross-sport.test.ts
+++ b/workers/espn-client/src/sports/__tests__/search-players-cross-sport.test.ts
@@ -3,19 +3,30 @@ import { baseballHandlers } from '../baseball/handlers';
 import { basketballHandlers } from '../basketball/handlers';
 import { footballHandlers } from '../football/handlers';
 import { hockeyHandlers } from '../hockey/handlers';
-import type { ToolParams } from '../../types';
+import type { HandlerToolParams, Sport } from '../../types';
 import { getEspnPlayersIndex } from '../../shared/espn-players-cache';
+import { withSeasonContext } from '../../shared/season';
 
 vi.mock('../../shared/espn-players-cache', () => ({
   getEspnPlayersIndex: vi.fn(),
 }));
 
 const scenarios = [
-  { label: 'football', sport: 'football', handlers: footballHandlers },
-  { label: 'baseball', sport: 'baseball', handlers: baseballHandlers },
-  { label: 'basketball', sport: 'basketball', handlers: basketballHandlers },
-  { label: 'hockey', sport: 'hockey', handlers: hockeyHandlers },
+  { label: 'football', sport: 'football', handlers: footballHandlers, expectedEspnYear: 2024 },
+  { label: 'baseball', sport: 'baseball', handlers: baseballHandlers, expectedEspnYear: 2024 },
+  { label: 'basketball', sport: 'basketball', handlers: basketballHandlers, expectedEspnYear: 2025 },
+  { label: 'hockey', sport: 'hockey', handlers: hockeyHandlers, expectedEspnYear: 2025 },
 ] as const;
+
+function makeParams(sport: Sport): HandlerToolParams {
+  return withSeasonContext({
+    sport,
+    league_id: '123',
+    season_year: 2024,
+    query: ' ',
+    count: 10,
+  });
+}
 
 describe('espn cross-sport get_players handlers', () => {
   const getPlayersIndexMock = getEspnPlayersIndex as MockedFunction<typeof getEspnPlayersIndex>;
@@ -24,7 +35,7 @@ describe('espn cross-sport get_players handlers', () => {
     vi.clearAllMocks();
   });
 
-  it.each(scenarios)('$label maps market ownership with platform_global scope', async ({ sport, handlers }) => {
+  it.each(scenarios)('$label maps market ownership with platform_global scope', async ({ sport, handlers, expectedEspnYear }) => {
     getPlayersIndexMock.mockResolvedValue(
       new Map([
         [1, { id: 1, fullName: 'Giancarlo Stanton', defaultPositionId: 1, proTeamId: 1, percentOwned: 47 }],
@@ -32,16 +43,11 @@ describe('espn cross-sport get_players handlers', () => {
       ])
     );
 
-    const params: ToolParams = {
-      sport,
-      league_id: '123',
-      season_year: 2025,
-      query: ' ',
-      count: 10,
-    };
+    const params = makeParams(sport);
 
     const result = await handlers.get_players({} as never, params);
     expect(result.success).toBe(true);
+    expect(getPlayersIndexMock).toHaveBeenCalledWith(expect.anything(), sport, expectedEspnYear);
     if (!result.success) return;
 
     const data = result.data as {

--- a/workers/espn-client/src/sports/__tests__/transactions-cross-sport.test.ts
+++ b/workers/espn-client/src/sports/__tests__/transactions-cross-sport.test.ts
@@ -2,9 +2,10 @@ import { beforeEach, describe, expect, it, vi, type MockedFunction } from 'vites
 import { baseballHandlers } from '../baseball/handlers';
 import { basketballHandlers } from '../basketball/handlers';
 import { hockeyHandlers } from '../hockey/handlers';
-import type { ToolParams } from '../../types';
+import type { HandlerToolParams, Sport, ToolParams } from '../../types';
 import { getCredentials } from '../../shared/auth';
 import { fetchEspnTransactionsByWeeks, fetchEspnMTransactions2, mergeTradePlayerDetails, getEspnLeagueContext } from '../../shared/espn-transactions';
+import { withSeasonContext } from '../../shared/season';
 
 vi.mock('../../shared/auth', () => ({
   getCredentials: vi.fn(),
@@ -20,10 +21,19 @@ vi.mock('../../shared/espn-transactions', () => ({
 }));
 
 const scenarios = [
-  { label: 'baseball', sport: 'baseball', gameId: 'flb', handlers: baseballHandlers },
-  { label: 'basketball', sport: 'basketball', gameId: 'fba', handlers: basketballHandlers },
-  { label: 'hockey', sport: 'hockey', gameId: 'fhl', handlers: hockeyHandlers },
+  { label: 'baseball', sport: 'baseball', gameId: 'flb', handlers: baseballHandlers, expectedEspnYear: 2024 },
+  { label: 'basketball', sport: 'basketball', gameId: 'fba', handlers: basketballHandlers, expectedEspnYear: 2025 },
+  { label: 'hockey', sport: 'hockey', gameId: 'fhl', handlers: hockeyHandlers, expectedEspnYear: 2025 },
 ] as const;
+
+function makeParams(sport: Sport, overrides: Partial<ToolParams> = {}): HandlerToolParams {
+  return withSeasonContext({
+    sport,
+    league_id: '123',
+    season_year: 2024,
+    ...overrides,
+  });
+}
 
 describe('espn cross-sport get_transactions handlers', () => {
   const getCredentialsMock = getCredentials as MockedFunction<typeof getCredentials>;
@@ -36,7 +46,7 @@ describe('espn cross-sport get_transactions handlers', () => {
     vi.clearAllMocks();
   });
 
-  it.each(scenarios)('$label routes get_transactions using the sport game id', async ({ sport, gameId, handlers }) => {
+  it.each(scenarios)('$label routes get_transactions using the sport game id', async ({ sport, gameId, handlers, expectedEspnYear }) => {
     getCredentialsMock.mockResolvedValue({ s2: 'token', swid: '{swid}' });
     getLeagueContextMock.mockResolvedValue({ scoringPeriodId: 10, teams: { '1': 'Team One' } });
     fetchMTransactions2Mock.mockResolvedValue({ truncated: false, transactions: [
@@ -45,20 +55,17 @@ describe('espn cross-sport get_transactions handlers', () => {
       { transaction_id: 't2', type: 'trade', status: 'complete', timestamp: 1000, week: 7, players_added: [{ id: '2' }], players_dropped: [] },
     ] } as never);
 
-    const params: ToolParams = {
-      sport,
-      league_id: '123',
-      season_year: 2025,
+    const params = makeParams(sport, {
       week: 7,
       type: 'trade',
       count: 1,
-    };
+    });
 
     const result = await handlers.get_transactions({} as never, params, 'Bearer x', `cid-${sport}`);
 
     expect(result.success).toBe(true);
-    expect(getLeagueContextMock).toHaveBeenCalledWith(gameId, '123', 2025, { s2: 'token', swid: '{swid}' });
-    expect(fetchMTransactions2Mock).toHaveBeenCalledWith(gameId, '123', 2025, { s2: 'token', swid: '{swid}' }, [7]);
+    expect(getLeagueContextMock).toHaveBeenCalledWith(gameId, '123', expectedEspnYear, { s2: 'token', swid: '{swid}' });
+    expect(fetchMTransactions2Mock).toHaveBeenCalledWith(gameId, '123', expectedEspnYear, { s2: 'token', swid: '{swid}' }, [7]);
 
     if (!result.success) return;
     const data = result.data as { count: number; window: { mode: string; weeks: number[] }; teams: Record<string, string>; transactions: Array<{ transaction_id: string }> };
@@ -68,7 +75,7 @@ describe('espn cross-sport get_transactions handlers', () => {
     expect(data.teams).toEqual({ '1': 'Team One' });
   });
 
-  it.each(scenarios)('$label triggers trade fallback when empty trade items detected', async ({ sport, gameId, handlers }) => {
+  it.each(scenarios)('$label triggers trade fallback when empty trade items detected', async ({ sport, gameId, handlers, expectedEspnYear }) => {
     getCredentialsMock.mockResolvedValue({ s2: 'token', swid: '{swid}' });
     getLeagueContextMock.mockResolvedValue({ scoringPeriodId: 10, teams: {} });
     fetchMTransactions2Mock.mockResolvedValue({ truncated: false, transactions: [
@@ -87,22 +94,18 @@ describe('espn cross-sport get_transactions handlers', () => {
     ] } as never);
     fetchTransactionsMock.mockResolvedValue([] as never);
 
-    const params: ToolParams = { sport, league_id: '123', season_year: 2025 };
+    const params = makeParams(sport);
     const result = await handlers.get_transactions({} as never, params, 'Bearer x', `cid-fallback-${sport}`);
 
     expect(result.success).toBe(true);
-    expect(fetchTransactionsMock).toHaveBeenCalledWith(gameId, '123', 2025, { s2: 'token', swid: '{swid}' }, expect.any(Array));
+    expect(fetchTransactionsMock).toHaveBeenCalledWith(gameId, '123', expectedEspnYear, { s2: 'token', swid: '{swid}' }, expect.any(Array));
     expect(mergeTradeDetailsMock).toHaveBeenCalled();
   });
 
   it.each(scenarios)('$label returns credentials error when ESPN is not connected', async ({ sport, handlers }) => {
     getCredentialsMock.mockResolvedValue(null);
 
-    const params: ToolParams = {
-      sport,
-      league_id: '123',
-      season_year: 2025,
-    };
+    const params = makeParams(sport);
 
     const result = await handlers.get_transactions({} as never, params, 'Bearer x', `cid-missing-${sport}`);
 

--- a/workers/espn-client/src/sports/__tests__/transactions-cross-sport.test.ts
+++ b/workers/espn-client/src/sports/__tests__/transactions-cross-sport.test.ts
@@ -21,9 +21,9 @@ vi.mock('../../shared/espn-transactions', () => ({
 }));
 
 const scenarios = [
-  { label: 'baseball', sport: 'baseball', gameId: 'flb', handlers: baseballHandlers, expectedEspnYear: 2024 },
-  { label: 'basketball', sport: 'basketball', gameId: 'fba', handlers: basketballHandlers, expectedEspnYear: 2025 },
-  { label: 'hockey', sport: 'hockey', gameId: 'fhl', handlers: hockeyHandlers, expectedEspnYear: 2025 },
+  { label: 'baseball', sport: 'baseball', gameId: 'flb', handlers: baseballHandlers, expectedEspnYear: 2024, expectedResponseSeasonYear: 2024 },
+  { label: 'basketball', sport: 'basketball', gameId: 'fba', handlers: basketballHandlers, expectedEspnYear: 2025, expectedResponseSeasonYear: 2024 },
+  { label: 'hockey', sport: 'hockey', gameId: 'fhl', handlers: hockeyHandlers, expectedEspnYear: 2025, expectedResponseSeasonYear: 2024 },
 ] as const;
 
 function makeParams(sport: Sport, overrides: Partial<ToolParams> = {}): HandlerToolParams {
@@ -46,7 +46,7 @@ describe('espn cross-sport get_transactions handlers', () => {
     vi.clearAllMocks();
   });
 
-  it.each(scenarios)('$label routes get_transactions using the sport game id', async ({ sport, gameId, handlers, expectedEspnYear }) => {
+  it.each(scenarios)('$label routes get_transactions using the sport game id', async ({ sport, gameId, handlers, expectedEspnYear, expectedResponseSeasonYear }) => {
     getCredentialsMock.mockResolvedValue({ s2: 'token', swid: '{swid}' });
     getLeagueContextMock.mockResolvedValue({ scoringPeriodId: 10, teams: { '1': 'Team One' } });
     fetchMTransactions2Mock.mockResolvedValue({ truncated: false, transactions: [
@@ -68,8 +68,15 @@ describe('espn cross-sport get_transactions handlers', () => {
     expect(fetchMTransactions2Mock).toHaveBeenCalledWith(gameId, '123', expectedEspnYear, { s2: 'token', swid: '{swid}' }, [7]);
 
     if (!result.success) return;
-    const data = result.data as { count: number; window: { mode: string; weeks: number[] }; teams: Record<string, string>; transactions: Array<{ transaction_id: string }> };
+    const data = result.data as {
+      count: number;
+      season_year: number;
+      window: { mode: string; weeks: number[] };
+      teams: Record<string, string>;
+      transactions: Array<{ transaction_id: string }>;
+    };
     expect(data.window).toEqual({ mode: 'explicit_week', weeks: [7] });
+    expect(data.season_year).toBe(expectedResponseSeasonYear);
     expect(data.count).toBe(1);
     expect(data.transactions[0]?.transaction_id).toBe('t1');
     expect(data.teams).toEqual({ '1': 'Team One' });

--- a/workers/espn-client/src/sports/baseball/handlers.ts
+++ b/workers/espn-client/src/sports/baseball/handlers.ts
@@ -1,5 +1,5 @@
 // workers/espn-client/src/sports/baseball/handlers.ts
-import type { Env, ToolParams, ExecuteResponse, EspnLeagueResponse, EspnPlayerPoolResponse } from '../../types';
+import type { Env, RoutedToolParams, ExecuteResponse, EspnLeagueResponse, EspnPlayerPoolResponse } from '../../types';
 import { getCredentials } from '../../shared/auth';
 import { espnFetch, handleEspnError, requireCredentials } from '../../shared/espn-api';
 import { fetchEspnTransactionsByWeeks, fetchEspnMTransactions2, mergeTradePlayerDetails, getEspnLeagueContext, fetchEspnPlayersByIds, enrichTransactions } from '../../shared/espn-transactions';
@@ -22,7 +22,7 @@ const GAME_ID = 'flb'; // ESPN's game ID for fantasy baseball
 
 type HandlerFn = (
   env: Env,
-  params: ToolParams,
+  params: RoutedToolParams,
   authHeader?: string,
   correlationId?: string
 ) => Promise<ExecuteResponse>;
@@ -39,7 +39,7 @@ export const baseballHandlers: Record<string, HandlerFn> = {
 
 async function handleSearchPlayers(
   env: Env,
-  params: ToolParams,
+  params: RoutedToolParams,
   authHeader?: string,
   correlationId?: string,
 ): Promise<ExecuteResponse> {
@@ -103,7 +103,7 @@ async function handleSearchPlayers(
  */
 async function handleGetLeagueInfo(
   env: Env,
-  params: ToolParams,
+  params: RoutedToolParams,
   authHeader?: string,
   correlationId?: string
 ): Promise<ExecuteResponse> {
@@ -185,7 +185,7 @@ async function handleGetLeagueInfo(
  */
 async function handleGetStandings(
   env: Env,
-  params: ToolParams,
+  params: RoutedToolParams,
   authHeader?: string,
   correlationId?: string
 ): Promise<ExecuteResponse> {
@@ -307,7 +307,7 @@ async function handleGetStandings(
  */
 async function handleGetMatchups(
   env: Env,
-  params: ToolParams,
+  params: RoutedToolParams,
   authHeader?: string,
   correlationId?: string
 ): Promise<ExecuteResponse> {
@@ -386,7 +386,7 @@ async function handleGetMatchups(
  */
 async function handleGetRoster(
   env: Env,
-  params: ToolParams,
+  params: RoutedToolParams,
   authHeader?: string,
   correlationId?: string
 ): Promise<ExecuteResponse> {
@@ -479,7 +479,7 @@ async function handleGetRoster(
  */
 async function handleGetFreeAgents(
   env: Env,
-  params: ToolParams,
+  params: RoutedToolParams,
   authHeader?: string,
   correlationId?: string
 ): Promise<ExecuteResponse> {
@@ -567,7 +567,7 @@ async function handleGetFreeAgents(
 
 async function handleGetTransactions(
   env: Env,
-  params: ToolParams,
+  params: RoutedToolParams,
   authHeader?: string,
   correlationId?: string
 ): Promise<ExecuteResponse> {

--- a/workers/espn-client/src/sports/baseball/handlers.ts
+++ b/workers/espn-client/src/sports/baseball/handlers.ts
@@ -16,7 +16,7 @@ import {
   transformStats,
   POSITION_SLOTS,
 } from './mappings';
-import { getCurrentSeasonYear } from '../../shared/season';
+import { getCurrentSeasonYear, getSeasonContext, normalizeEspnLeagueStatus } from '../../shared/season';
 
 const GAME_ID = 'flb'; // ESPN's game ID for fantasy baseball
 
@@ -107,12 +107,13 @@ async function handleGetLeagueInfo(
   authHeader?: string,
   correlationId?: string
 ): Promise<ExecuteResponse> {
-  const { league_id, season_year } = params;
+  const { league_id } = params;
+  const { canonicalYear, espnYear } = getSeasonContext(params);
 
   try {
     const credentials = await getCredentials(env, authHeader, correlationId);
 
-    const path = `/seasons/${season_year}/segments/0/leagues/${league_id}?view=mSettings&view=mTeam`;
+    const path = `/seasons/${espnYear}/segments/0/leagues/${league_id}?view=mSettings&view=mTeam`;
     const response = await espnFetch(path, GAME_ID, { credentials, timeout: 7000 });
 
     if (!response.ok) {
@@ -149,10 +150,10 @@ async function handleGetLeagueInfo(
         id: data.id,
         name: data.settings.name,
         size: data.settings.size,
-        status: data.status,
+        status: normalizeEspnLeagueStatus(data.status, 'baseball'),
         scoringPeriodId: data.scoringPeriodId,
         currentMatchupPeriod: data.currentMatchupPeriod,
-        seasonId: data.seasonId,
+        seasonId: canonicalYear,
         segmentId: data.segmentId,
         teams,
         scoringSettings: {

--- a/workers/espn-client/src/sports/basketball/__tests__/standings.test.ts
+++ b/workers/espn-client/src/sports/basketball/__tests__/standings.test.ts
@@ -1,0 +1,186 @@
+import { beforeEach, describe, expect, it, vi, type MockedFunction } from 'vitest';
+import { basketballHandlers } from '../handlers';
+import type { ToolParams } from '../../../types';
+import { getCredentials } from '../../../shared/auth';
+import { espnFetch } from '../../../shared/espn-api';
+import { toEspnSeasonYear, getCurrentSeasonYear } from '../../../shared/season';
+
+vi.mock('../../../shared/auth', () => ({
+  getCredentials: vi.fn(),
+}));
+
+vi.mock('../../../shared/espn-api', async () => {
+  const actual = await vi.importActual('../../../shared/espn-api') as Record<string, unknown>;
+  return {
+    ...actual,
+    espnFetch: vi.fn(),
+  };
+});
+
+// Handlers receive ESPN year (index.ts converts at /execute boundary).
+// Use toEspnSeasonYear to mirror what index.ts sends.
+const CURRENT_CANONICAL_YEAR = getCurrentSeasonYear('basketball');
+const CURRENT_ESPN_YEAR = toEspnSeasonYear(CURRENT_CANONICAL_YEAR, 'basketball');
+const HISTORICAL_CANONICAL_YEAR = 2022;
+const HISTORICAL_ESPN_YEAR = toEspnSeasonYear(HISTORICAL_CANONICAL_YEAR, 'basketball');
+
+function makeParams(season_year: number): ToolParams {
+  return { sport: 'basketball', league_id: '123', season_year };
+}
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('basketball get_standings handler — seasonPhase and canonical year', () => {
+  const getCredentialsMock = getCredentials as MockedFunction<typeof getCredentials>;
+  const espnFetchMock = espnFetch as MockedFunction<typeof espnFetch>;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    getCredentialsMock.mockResolvedValue({ s2: 'token', swid: '{swid}' });
+  });
+
+  it('returns season_complete and champion outcome for historical season with rankFinal', async () => {
+    espnFetchMock.mockResolvedValue(jsonResponse({
+      scoringPeriodId: 25,
+      settings: { regularSeasonMatchupPeriods: 20 },
+      teams: [
+        {
+          id: 1,
+          location: 'Alpha', nickname: 'Ballers',
+          rankFinal: 1,
+          playoffSeed: 1,
+          record: { overall: { wins: 15, losses: 5, ties: 0, pointsFor: 1800, pointsAgainst: 1500 } },
+        },
+        {
+          id: 2,
+          location: 'Beta', nickname: 'Hoopers',
+          rankFinal: 2,
+          playoffSeed: 2,
+          record: { overall: { wins: 13, losses: 7, ties: 0, pointsFor: 1700, pointsAgainst: 1600 } },
+        },
+        {
+          id: 3,
+          location: 'Gamma', nickname: 'Dribblers',
+          rankFinal: 5,
+          record: { overall: { wins: 10, losses: 10, ties: 0, pointsFor: 1500, pointsAgainst: 1550 } },
+        },
+      ],
+    }));
+
+    const result = await basketballHandlers.get_standings({} as never, makeParams(HISTORICAL_ESPN_YEAR), 'Bearer x', 'cid');
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.seasonPhase).toBe('season_complete');
+    expect(data.seasonComplete).toBe(true);
+    // Response must echo canonical year, not ESPN year
+    expect(data.seasonYear).toBe(HISTORICAL_CANONICAL_YEAR);
+
+    const standings = data.standings as Array<Record<string, unknown>>;
+    const champion = standings.find((s) => s.teamId === 1);
+    expect(champion?.finalRank).toBe(1);
+    expect(champion?.championshipWon).toBe(true);
+    expect(champion?.playoffOutcome).toBe('champion');
+    expect(champion?.madePlayoffs).toBe(true);
+
+    const nonPlayoff = standings.find((s) => s.teamId === 3);
+    expect(nonPlayoff?.finalRank).toBe(5);
+    expect(nonPlayoff?.playoffOutcome).toBe('missed_playoffs');
+    expect(nonPlayoff?.madePlayoffs).toBe(false);
+  });
+
+  it('returns season_complete for historical year even without rankFinal', async () => {
+    espnFetchMock.mockResolvedValue(jsonResponse({
+      scoringPeriodId: 25,
+      settings: { regularSeasonMatchupPeriods: 20 },
+      teams: [
+        {
+          id: 1,
+          location: 'Alpha', nickname: 'Ballers',
+          record: { overall: { wins: 15, losses: 5, ties: 0, pointsFor: 1800, pointsAgainst: 1500 } },
+        },
+      ],
+    }));
+
+    const result = await basketballHandlers.get_standings({} as never, makeParams(HISTORICAL_ESPN_YEAR), 'Bearer x', 'cid');
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.seasonPhase).toBe('season_complete');
+    expect(data.seasonYear).toBe(HISTORICAL_CANONICAL_YEAR);
+  });
+
+  it('returns playoffs_in_progress for current season past regular season periods', async () => {
+    espnFetchMock.mockResolvedValue(jsonResponse({
+      scoringPeriodId: 22,
+      settings: { regularSeasonMatchupPeriods: 20 },
+      teams: [
+        {
+          id: 1,
+          location: 'Alpha', nickname: 'Ballers',
+          playoffSeed: 1,
+          record: { overall: { wins: 15, losses: 5, ties: 0, pointsFor: 1800, pointsAgainst: 1500 } },
+        },
+      ],
+    }));
+
+    const result = await basketballHandlers.get_standings({} as never, makeParams(CURRENT_ESPN_YEAR), 'Bearer x', 'cid');
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.seasonPhase).toBe('playoffs_in_progress');
+    expect(data.seasonComplete).toBe(false);
+    // Response must echo canonical year, not ESPN year
+    expect(data.seasonYear).toBe(CURRENT_CANONICAL_YEAR);
+  });
+
+  it('returns regular_season for current season within regular season periods', async () => {
+    espnFetchMock.mockResolvedValue(jsonResponse({
+      scoringPeriodId: 10,
+      settings: { regularSeasonMatchupPeriods: 20 },
+      teams: [
+        {
+          id: 1,
+          location: 'Alpha', nickname: 'Ballers',
+          record: { overall: { wins: 7, losses: 3, ties: 0, pointsFor: 900, pointsAgainst: 800 } },
+        },
+      ],
+    }));
+
+    const result = await basketballHandlers.get_standings({} as never, makeParams(CURRENT_ESPN_YEAR), 'Bearer x', 'cid');
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.seasonPhase).toBe('regular_season');
+    expect(data.seasonComplete).toBe(false);
+    expect(data.seasonYear).toBe(CURRENT_CANONICAL_YEAR);
+  });
+
+  it('uses rankCalculatedFinal when rankFinal is absent', async () => {
+    espnFetchMock.mockResolvedValue(jsonResponse({
+      scoringPeriodId: 25,
+      settings: { regularSeasonMatchupPeriods: 20 },
+      teams: [
+        {
+          id: 1,
+          location: 'Alpha', nickname: 'Ballers',
+          rankCalculatedFinal: 1,
+          record: { overall: { wins: 15, losses: 5, ties: 0, pointsFor: 1800, pointsAgainst: 1500 } },
+        },
+      ],
+    }));
+
+    const result = await basketballHandlers.get_standings({} as never, makeParams(HISTORICAL_ESPN_YEAR), 'Bearer x', 'cid');
+
+    const data = result.data as Record<string, unknown>;
+    const standings = data.standings as Array<Record<string, unknown>>;
+    expect(standings[0].finalRank).toBe(1);
+    expect(standings[0].championshipWon).toBe(true);
+    expect(standings[0].outcomeConfidence).toBe('explicit');
+  });
+});

--- a/workers/espn-client/src/sports/basketball/__tests__/standings.test.ts
+++ b/workers/espn-client/src/sports/basketball/__tests__/standings.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, vi, type MockedFunction } from 'vitest';
 import { basketballHandlers } from '../handlers';
-import type { ToolParams } from '../../../types';
+import type { RoutedToolParams } from '../../../types';
 import { getCredentials } from '../../../shared/auth';
 import { espnFetch } from '../../../shared/espn-api';
-import { toEspnSeasonYear, getCurrentSeasonYear } from '../../../shared/season';
+import { getCurrentSeasonYear, withSeasonContext } from '../../../shared/season';
 
 vi.mock('../../../shared/auth', () => ({
   getCredentials: vi.fn(),
@@ -17,15 +17,21 @@ vi.mock('../../../shared/espn-api', async () => {
   };
 });
 
-// Handlers receive ESPN year (index.ts converts at /execute boundary).
-// Use toEspnSeasonYear to mirror what index.ts sends.
 const CURRENT_CANONICAL_YEAR = getCurrentSeasonYear('basketball');
-const CURRENT_ESPN_YEAR = toEspnSeasonYear(CURRENT_CANONICAL_YEAR, 'basketball');
 const HISTORICAL_CANONICAL_YEAR = 2022;
-const HISTORICAL_ESPN_YEAR = toEspnSeasonYear(HISTORICAL_CANONICAL_YEAR, 'basketball');
+const CURRENT_ESPN_YEAR = withSeasonContext({
+  sport: 'basketball',
+  league_id: '123',
+  season_year: CURRENT_CANONICAL_YEAR,
+}).seasonContext.espnYear;
+const HISTORICAL_ESPN_YEAR = withSeasonContext({
+  sport: 'basketball',
+  league_id: '123',
+  season_year: HISTORICAL_CANONICAL_YEAR,
+}).seasonContext.espnYear;
 
-function makeParams(season_year: number): ToolParams {
-  return { sport: 'basketball', league_id: '123', season_year };
+function makeParams(season_year: number): RoutedToolParams {
+  return withSeasonContext({ sport: 'basketball', league_id: '123', season_year });
 }
 
 function jsonResponse(payload: unknown, status = 200): Response {
@@ -72,9 +78,10 @@ describe('basketball get_standings handler — seasonPhase and canonical year', 
       ],
     }));
 
-    const result = await basketballHandlers.get_standings({} as never, makeParams(HISTORICAL_ESPN_YEAR), 'Bearer x', 'cid');
+    const result = await basketballHandlers.get_standings({} as never, makeParams(HISTORICAL_CANONICAL_YEAR), 'Bearer x', 'cid');
 
     expect(result.success).toBe(true);
+    expect(espnFetchMock.mock.calls[0]?.[0]).toContain(`/seasons/${HISTORICAL_ESPN_YEAR}/segments/0/leagues/123`);
     const data = result.data as Record<string, unknown>;
     expect(data.seasonPhase).toBe('season_complete');
     expect(data.seasonComplete).toBe(true);
@@ -107,7 +114,7 @@ describe('basketball get_standings handler — seasonPhase and canonical year', 
       ],
     }));
 
-    const result = await basketballHandlers.get_standings({} as never, makeParams(HISTORICAL_ESPN_YEAR), 'Bearer x', 'cid');
+    const result = await basketballHandlers.get_standings({} as never, makeParams(HISTORICAL_CANONICAL_YEAR), 'Bearer x', 'cid');
 
     expect(result.success).toBe(true);
     const data = result.data as Record<string, unknown>;
@@ -129,9 +136,10 @@ describe('basketball get_standings handler — seasonPhase and canonical year', 
       ],
     }));
 
-    const result = await basketballHandlers.get_standings({} as never, makeParams(CURRENT_ESPN_YEAR), 'Bearer x', 'cid');
+    const result = await basketballHandlers.get_standings({} as never, makeParams(CURRENT_CANONICAL_YEAR), 'Bearer x', 'cid');
 
     expect(result.success).toBe(true);
+    expect(espnFetchMock.mock.calls[0]?.[0]).toContain(`/seasons/${CURRENT_ESPN_YEAR}/segments/0/leagues/123`);
     const data = result.data as Record<string, unknown>;
     expect(data.seasonPhase).toBe('playoffs_in_progress');
     expect(data.seasonComplete).toBe(false);
@@ -152,7 +160,7 @@ describe('basketball get_standings handler — seasonPhase and canonical year', 
       ],
     }));
 
-    const result = await basketballHandlers.get_standings({} as never, makeParams(CURRENT_ESPN_YEAR), 'Bearer x', 'cid');
+    const result = await basketballHandlers.get_standings({} as never, makeParams(CURRENT_CANONICAL_YEAR), 'Bearer x', 'cid');
 
     expect(result.success).toBe(true);
     const data = result.data as Record<string, unknown>;
@@ -175,7 +183,7 @@ describe('basketball get_standings handler — seasonPhase and canonical year', 
       ],
     }));
 
-    const result = await basketballHandlers.get_standings({} as never, makeParams(HISTORICAL_ESPN_YEAR), 'Bearer x', 'cid');
+    const result = await basketballHandlers.get_standings({} as never, makeParams(HISTORICAL_CANONICAL_YEAR), 'Bearer x', 'cid');
 
     const data = result.data as Record<string, unknown>;
     const standings = data.standings as Array<Record<string, unknown>>;

--- a/workers/espn-client/src/sports/basketball/handlers.ts
+++ b/workers/espn-client/src/sports/basketball/handlers.ts
@@ -1,5 +1,5 @@
 // workers/espn-client/src/sports/basketball/handlers.ts
-import type { Env, ToolParams, ExecuteResponse, EspnLeagueResponse, EspnPlayerPoolResponse } from '../../types';
+import type { Env, RoutedToolParams, ExecuteResponse, EspnLeagueResponse, EspnPlayerPoolResponse } from '../../types';
 import { getCredentials } from '../../shared/auth';
 import { espnFetch, handleEspnError, requireCredentials } from '../../shared/espn-api';
 import { fetchEspnTransactionsByWeeks, fetchEspnMTransactions2, mergeTradePlayerDetails, getEspnLeagueContext, fetchEspnPlayersByIds, enrichTransactions } from '../../shared/espn-transactions';
@@ -16,13 +16,13 @@ import {
   transformStats,
   POSITION_SLOTS,
 } from './mappings';
-import { getCurrentSeasonYear, fromEspnSeasonYear } from '../../shared/season';
+import { getCurrentSeasonYear, getSeasonContext } from '../../shared/season';
 
 const GAME_ID = 'fba'; // ESPN's game ID for fantasy basketball
 
 type HandlerFn = (
   env: Env,
-  params: ToolParams,
+  params: RoutedToolParams,
   authHeader?: string,
   correlationId?: string
 ) => Promise<ExecuteResponse>;
@@ -39,11 +39,12 @@ export const basketballHandlers: Record<string, HandlerFn> = {
 
 async function handleSearchPlayers(
   env: Env,
-  params: ToolParams,
+  params: RoutedToolParams,
   authHeader?: string,
   correlationId?: string,
 ): Promise<ExecuteResponse> {
-  const { query, position, count, season_year, league_id } = params;
+  const { query, position, count, league_id } = params;
+  const { espnYear } = getSeasonContext(params);
 
   if (!query) {
     return { success: false, error: 'query is required for get_players', code: 'MISSING_PARAM' };
@@ -51,7 +52,7 @@ async function handleSearchPlayers(
 
   try {
     const limit = Math.max(1, Math.min(25, Math.trunc(Number.isFinite(Number(count)) ? Number(count) : 10)));
-    const playersIndex = await getEspnPlayersIndex(env, 'basketball', season_year);
+    const playersIndex = await getEspnPlayersIndex(env, 'basketball', espnYear);
     const normalizedQuery = query.toLowerCase();
     const normalizedPosition = position?.trim().toUpperCase();
     const filterByPosition = normalizedPosition && normalizedPosition !== 'ALL';
@@ -66,7 +67,7 @@ async function handleSearchPlayers(
 
     // League ownership enrichment (null if no credentials or league_id)
     const ownerMap = league_id
-      ? await fetchLeagueOwnershipMap(env, GAME_ID, league_id, season_year, authHeader, correlationId)
+      ? await fetchLeagueOwnershipMap(env, GAME_ID, league_id, espnYear, authHeader, correlationId)
       : null;
 
     const players = matched.map((p) => ({
@@ -103,16 +104,17 @@ async function handleSearchPlayers(
  */
 async function handleGetLeagueInfo(
   env: Env,
-  params: ToolParams,
+  params: RoutedToolParams,
   authHeader?: string,
   correlationId?: string
 ): Promise<ExecuteResponse> {
-  const { league_id, season_year } = params;
+  const { league_id } = params;
+  const { espnYear } = getSeasonContext(params);
 
   try {
     const credentials = await getCredentials(env, authHeader, correlationId);
 
-    const path = `/seasons/${season_year}/segments/0/leagues/${league_id}?view=mSettings&view=mTeam`;
+    const path = `/seasons/${espnYear}/segments/0/leagues/${league_id}?view=mSettings&view=mTeam`;
     const response = await espnFetch(path, GAME_ID, { credentials, timeout: 7000 });
 
     if (!response.ok) {
@@ -185,18 +187,17 @@ async function handleGetLeagueInfo(
  */
 async function handleGetStandings(
   env: Env,
-  params: ToolParams,
+  params: RoutedToolParams,
   authHeader?: string,
   correlationId?: string
 ): Promise<ExecuteResponse> {
-  const { league_id, season_year } = params;
-  // season_year is ESPN year here (converted by index.ts). Reverse for non-API comparisons.
-  const canonicalSeasonYear = fromEspnSeasonYear(season_year, 'basketball');
+  const { league_id } = params;
+  const { canonicalYear, espnYear } = getSeasonContext(params);
 
   try {
     const credentials = await getCredentials(env, authHeader, correlationId);
 
-    const path = `/seasons/${season_year}/segments/0/leagues/${league_id}?view=mStandings&view=mTeam`;
+    const path = `/seasons/${espnYear}/segments/0/leagues/${league_id}?view=mStandings&view=mTeam`;
     const response = await espnFetch(path, GAME_ID, { credentials, timeout: 7000 });
 
     if (!response.ok) {
@@ -215,14 +216,14 @@ async function handleGetStandings(
       (t) => t.rankFinal != null || t.rankCalculatedFinal != null
     );
     let seasonPhase: 'regular_season' | 'playoffs_in_progress' | 'season_complete';
-    if (hasExplicitCompletionData || canonicalSeasonYear < currentSeasonYear) {
+    if (hasExplicitCompletionData || canonicalYear < currentSeasonYear) {
       seasonPhase = 'season_complete';
-    } else if (canonicalSeasonYear === currentSeasonYear) {
+    } else if (canonicalYear === currentSeasonYear) {
       const regularPeriods = data.settings?.regularSeasonMatchupPeriods ?? 0;
       const scoringPeriod = data.scoringPeriodId ?? 0;
       seasonPhase = scoringPeriod > regularPeriods ? 'playoffs_in_progress' : 'regular_season';
     } else {
-      // canonicalSeasonYear > currentSeasonYear — future season, treat as not yet started
+      // canonicalYear > currentSeasonYear — future season, treat as not yet started
       seasonPhase = 'regular_season';
     }
     const seasonComplete = seasonPhase === 'season_complete';
@@ -290,7 +291,7 @@ async function handleGetStandings(
       success: true,
       data: {
         leagueId: league_id,
-        seasonYear: canonicalSeasonYear,
+        seasonYear: canonicalYear,
         seasonPhase,
         seasonComplete,
         standings
@@ -310,17 +311,17 @@ async function handleGetStandings(
  */
 async function handleGetMatchups(
   env: Env,
-  params: ToolParams,
+  params: RoutedToolParams,
   authHeader?: string,
   correlationId?: string
 ): Promise<ExecuteResponse> {
-  const { league_id, season_year, week } = params;
-  const canonicalSeasonYear = fromEspnSeasonYear(season_year, 'basketball');
+  const { league_id, week } = params;
+  const { canonicalYear, espnYear } = getSeasonContext(params);
 
   try {
     const credentials = await getCredentials(env, authHeader, correlationId);
 
-    let path = `/seasons/${season_year}/segments/0/leagues/${league_id}?view=mMatchupScore&view=mScoreboard&view=mTeam`;
+    let path = `/seasons/${espnYear}/segments/0/leagues/${league_id}?view=mMatchupScore&view=mScoreboard&view=mTeam`;
     if (week) {
       path += `&scoringPeriodId=${week}&matchupPeriodId=${week}`;
     }
@@ -370,7 +371,7 @@ async function handleGetMatchups(
       success: true,
       data: {
         leagueId: league_id,
-        seasonYear: canonicalSeasonYear,
+        seasonYear: canonicalYear,
         currentScoringPeriod: data.scoringPeriodId,
         matchupPeriod: matchupPeriod ?? null,
         matchups
@@ -390,17 +391,18 @@ async function handleGetMatchups(
  */
 async function handleGetRoster(
   env: Env,
-  params: ToolParams,
+  params: RoutedToolParams,
   authHeader?: string,
   correlationId?: string
 ): Promise<ExecuteResponse> {
-  const { league_id, season_year, team_id, week } = params;
+  const { league_id, team_id, week } = params;
+  const { espnYear } = getSeasonContext(params);
 
   try {
     const credentials = await getCredentials(env, authHeader, correlationId);
     requireCredentials(credentials, 'roster data');
 
-    let path = `/seasons/${season_year}/segments/0/leagues/${league_id}?view=mRoster&view=mTeam`;
+    let path = `/seasons/${espnYear}/segments/0/leagues/${league_id}?view=mRoster&view=mTeam`;
     if (week) {
       path += `&scoringPeriodId=${week}`;
     }
@@ -436,7 +438,7 @@ async function handleGetRoster(
 
       // Get current season stats if available
       const currentStats = stats.find((s) =>
-        s.seasonId === season_year && s.statSourceId === 0
+        s.seasonId === espnYear && s.statSourceId === 0
       );
 
       return {
@@ -483,12 +485,12 @@ async function handleGetRoster(
  */
 async function handleGetFreeAgents(
   env: Env,
-  params: ToolParams,
+  params: RoutedToolParams,
   authHeader?: string,
   correlationId?: string
 ): Promise<ExecuteResponse> {
-  const { league_id, season_year, position, count } = params;
-  const canonicalSeasonYear = fromEspnSeasonYear(season_year, 'basketball');
+  const { league_id, position, count } = params;
+  const { canonicalYear, espnYear } = getSeasonContext(params);
 
   try {
     const credentials = await getCredentials(env, authHeader, correlationId);
@@ -498,7 +500,7 @@ async function handleGetFreeAgents(
     const slotIds = POSITION_SLOTS[positionKey] || POSITION_SLOTS['ALL'];
     const limit = Math.min(Math.max(1, count || 25), 100);
 
-    const path = `/seasons/${season_year}/segments/0/leagues/${league_id}?view=kona_player_info`;
+    const path = `/seasons/${espnYear}/segments/0/leagues/${league_id}?view=kona_player_info`;
 
     // Build the X-Fantasy-Filter header for free agents
     const filter = {
@@ -533,7 +535,7 @@ async function handleGetFreeAgents(
 
       // Get current season stats if available
       const currentStats = stats.find((s) =>
-        s.seasonId === season_year && s.statSourceId === 0
+        s.seasonId === espnYear && s.statSourceId === 0
       );
 
       return {
@@ -555,7 +557,7 @@ async function handleGetFreeAgents(
       success: true,
       data: {
         leagueId: league_id,
-        seasonYear: canonicalSeasonYear,
+        seasonYear: canonicalYear,
         position: positionKey,
         count: freeAgents.length,
         freeAgents
@@ -572,17 +574,18 @@ async function handleGetFreeAgents(
 
 async function handleGetTransactions(
   env: Env,
-  params: ToolParams,
+  params: RoutedToolParams,
   authHeader?: string,
   correlationId?: string
 ): Promise<ExecuteResponse> {
-  const { league_id, season_year, week, count, type } = params;
+  const { league_id, week, count, type } = params;
+  const { canonicalYear, espnYear } = getSeasonContext(params);
 
   try {
     const credentials = await getCredentials(env, authHeader, correlationId);
     requireCredentials(credentials, 'get_transactions');
 
-    const ctx = await getEspnLeagueContext(GAME_ID, league_id, season_year, credentials);
+    const ctx = await getEspnLeagueContext(GAME_ID, league_id, espnYear, credentials);
     const currentWeek = ctx.scoringPeriodId;
     const weeks = week != null
       ? [Math.max(0, week)]
@@ -599,7 +602,7 @@ async function handleGetTransactions(
     let merged: NormalizedTransaction[];
     let truncated = false;
     try {
-      const mResult = await fetchEspnMTransactions2(GAME_ID, league_id, season_year, credentials, weeks);
+      const mResult = await fetchEspnMTransactions2(GAME_ID, league_id, espnYear, credentials, weeks);
       truncated = mResult.truncated;
 
       // Trade player detail fallback: activity feed for accepted/upheld trades (ESPN items bug)
@@ -610,7 +613,7 @@ async function handleGetTransactions(
       merged = mResult.transactions;
       if (hasEmptyTrades) {
         try {
-          const activityRows = await fetchEspnTransactionsByWeeks(GAME_ID, league_id, season_year, credentials, weeks);
+          const activityRows = await fetchEspnTransactionsByWeeks(GAME_ID, league_id, espnYear, credentials, weeks);
           merged = mergeTradePlayerDetails(mResult.transactions, activityRows);
         } catch (fallbackErr) {
           console.warn('[get_transactions] Activity feed trade fallback failed:', fallbackErr instanceof Error ? fallbackErr.message : fallbackErr);
@@ -618,7 +621,7 @@ async function handleGetTransactions(
       }
     } catch (mTxnErr) {
       console.warn('[get_transactions] mTransactions2 failed, falling back to activity feed:', mTxnErr instanceof Error ? mTxnErr.message : mTxnErr);
-      merged = await fetchEspnTransactionsByWeeks(GAME_ID, league_id, season_year, credentials, weeks);
+      merged = await fetchEspnTransactionsByWeeks(GAME_ID, league_id, espnYear, credentials, weeks);
     }
 
     let filtered = merged
@@ -631,7 +634,7 @@ async function handleGetTransactions(
     ]))];
     if (allIds.length > 0) {
       try {
-        const playerMap = await fetchEspnPlayersByIds(GAME_ID, season_year, allIds);
+        const playerMap = await fetchEspnPlayersByIds(GAME_ID, espnYear, allIds);
         if (playerMap) {
           filtered = enrichTransactions(filtered, playerMap, getPositionName, getProTeamAbbrev);
         }
@@ -647,7 +650,7 @@ async function handleGetTransactions(
         platform: 'espn',
         sport: params.sport,
         league_id,
-        season_year,
+        season_year: canonicalYear,
         window: {
           mode: week ? 'explicit_week' : 'recent_two_weeks',
           weeks

--- a/workers/espn-client/src/sports/basketball/handlers.ts
+++ b/workers/espn-client/src/sports/basketball/handlers.ts
@@ -16,7 +16,7 @@ import {
   transformStats,
   POSITION_SLOTS,
 } from './mappings';
-import { getCurrentSeasonYear, getSeasonContext } from '../../shared/season';
+import { getCurrentSeasonYear, getSeasonContext, normalizeEspnLeagueStatus } from '../../shared/season';
 
 const GAME_ID = 'fba'; // ESPN's game ID for fantasy basketball
 
@@ -109,7 +109,7 @@ async function handleGetLeagueInfo(
   correlationId?: string
 ): Promise<ExecuteResponse> {
   const { league_id } = params;
-  const { espnYear } = getSeasonContext(params);
+  const { canonicalYear, espnYear } = getSeasonContext(params);
 
   try {
     const credentials = await getCredentials(env, authHeader, correlationId);
@@ -151,10 +151,10 @@ async function handleGetLeagueInfo(
         id: data.id,
         name: data.settings.name,
         size: data.settings.size,
-        status: data.status,
+        status: normalizeEspnLeagueStatus(data.status, 'basketball'),
         scoringPeriodId: data.scoringPeriodId,
         currentMatchupPeriod: data.currentMatchupPeriod,
-        seasonId: data.seasonId,
+        seasonId: canonicalYear,
         segmentId: data.segmentId,
         teams,
         scoringSettings: {

--- a/workers/espn-client/src/sports/basketball/handlers.ts
+++ b/workers/espn-client/src/sports/basketball/handlers.ts
@@ -16,7 +16,7 @@ import {
   transformStats,
   POSITION_SLOTS,
 } from './mappings';
-import { getCurrentSeasonYear } from '../../shared/season';
+import { getCurrentSeasonYear, fromEspnSeasonYear } from '../../shared/season';
 
 const GAME_ID = 'fba'; // ESPN's game ID for fantasy basketball
 
@@ -190,6 +190,8 @@ async function handleGetStandings(
   correlationId?: string
 ): Promise<ExecuteResponse> {
   const { league_id, season_year } = params;
+  // season_year is ESPN year here (converted by index.ts). Reverse for non-API comparisons.
+  const canonicalSeasonYear = fromEspnSeasonYear(season_year, 'basketball');
 
   try {
     const credentials = await getCredentials(env, authHeader, correlationId);
@@ -213,14 +215,14 @@ async function handleGetStandings(
       (t) => t.rankFinal != null || t.rankCalculatedFinal != null
     );
     let seasonPhase: 'regular_season' | 'playoffs_in_progress' | 'season_complete';
-    if (hasExplicitCompletionData || season_year < currentSeasonYear) {
+    if (hasExplicitCompletionData || canonicalSeasonYear < currentSeasonYear) {
       seasonPhase = 'season_complete';
-    } else if (season_year === currentSeasonYear) {
+    } else if (canonicalSeasonYear === currentSeasonYear) {
       const regularPeriods = data.settings?.regularSeasonMatchupPeriods ?? 0;
       const scoringPeriod = data.scoringPeriodId ?? 0;
       seasonPhase = scoringPeriod > regularPeriods ? 'playoffs_in_progress' : 'regular_season';
     } else {
-      // season_year > currentSeasonYear — future season, treat as not yet started
+      // canonicalSeasonYear > currentSeasonYear — future season, treat as not yet started
       seasonPhase = 'regular_season';
     }
     const seasonComplete = seasonPhase === 'season_complete';
@@ -288,7 +290,7 @@ async function handleGetStandings(
       success: true,
       data: {
         leagueId: league_id,
-        seasonYear: season_year,
+        seasonYear: canonicalSeasonYear,
         seasonPhase,
         seasonComplete,
         standings
@@ -313,6 +315,7 @@ async function handleGetMatchups(
   correlationId?: string
 ): Promise<ExecuteResponse> {
   const { league_id, season_year, week } = params;
+  const canonicalSeasonYear = fromEspnSeasonYear(season_year, 'basketball');
 
   try {
     const credentials = await getCredentials(env, authHeader, correlationId);
@@ -367,7 +370,7 @@ async function handleGetMatchups(
       success: true,
       data: {
         leagueId: league_id,
-        seasonYear: season_year,
+        seasonYear: canonicalSeasonYear,
         currentScoringPeriod: data.scoringPeriodId,
         matchupPeriod: matchupPeriod ?? null,
         matchups
@@ -485,6 +488,7 @@ async function handleGetFreeAgents(
   correlationId?: string
 ): Promise<ExecuteResponse> {
   const { league_id, season_year, position, count } = params;
+  const canonicalSeasonYear = fromEspnSeasonYear(season_year, 'basketball');
 
   try {
     const credentials = await getCredentials(env, authHeader, correlationId);
@@ -551,7 +555,7 @@ async function handleGetFreeAgents(
       success: true,
       data: {
         leagueId: league_id,
-        seasonYear: season_year,
+        seasonYear: canonicalSeasonYear,
         position: positionKey,
         count: freeAgents.length,
         freeAgents

--- a/workers/espn-client/src/sports/football/__tests__/matchups.test.ts
+++ b/workers/espn-client/src/sports/football/__tests__/matchups.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi, type MockedFunction } from 'vitest';
 import { footballHandlers } from '../handlers';
-import type { ToolParams } from '../../../types';
+import { withSeasonContext } from '../../../shared/season';
 import { getCredentials } from '../../../shared/auth';
 import { espnFetch } from '../../../shared/espn-api';
 
@@ -46,7 +46,7 @@ describe('football get_matchups handler', () => {
       }), { status: 200, headers: { 'Content-Type': 'application/json' } })
     );
 
-    const params: ToolParams = { sport: 'football', league_id: '123', season_year: 2025 };
+    const params = withSeasonContext({ sport: 'football', league_id: '123', season_year: 2025 });
     const result = await footballHandlers.get_matchups({} as never, params, 'Bearer x', 'cid');
 
     expect(result.success).toBe(true);
@@ -68,7 +68,7 @@ describe('football get_matchups handler', () => {
       }), { status: 200, headers: { 'Content-Type': 'application/json' } })
     );
 
-    const params: ToolParams = { sport: 'football', league_id: '123', season_year: 2025, week: 3 };
+    const params = withSeasonContext({ sport: 'football', league_id: '123', season_year: 2025, week: 3 });
     const result = await footballHandlers.get_matchups({} as never, params, 'Bearer x', 'cid');
 
     expect(result.success).toBe(true);
@@ -97,7 +97,7 @@ describe('football get_matchups handler', () => {
       }), { status: 200, headers: { 'Content-Type': 'application/json' } })
     );
 
-    const params: ToolParams = { sport: 'football', league_id: '123', season_year: 2025 };
+    const params = withSeasonContext({ sport: 'football', league_id: '123', season_year: 2025 });
     const result = await footballHandlers.get_matchups({} as never, params, 'Bearer x', 'cid');
 
     expect(result.success).toBe(true);

--- a/workers/espn-client/src/sports/football/__tests__/standings.test.ts
+++ b/workers/espn-client/src/sports/football/__tests__/standings.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, vi, type MockedFunction } from 'vitest';
 import { footballHandlers } from '../handlers';
-import type { ToolParams } from '../../../types';
+import type { RoutedToolParams } from '../../../types';
 import { getCredentials } from '../../../shared/auth';
 import { espnFetch } from '../../../shared/espn-api';
-import { getCurrentSeasonYear } from '../../../shared/season';
+import { getCurrentSeasonYear, withSeasonContext } from '../../../shared/season';
 
 vi.mock('../../../shared/auth', () => ({
   getCredentials: vi.fn(),
@@ -21,8 +21,8 @@ const HISTORICAL_YEAR = 2022;
 // Use sport-aware current season year — matches what the handler uses internally
 const CURRENT_SEASON_YEAR = getCurrentSeasonYear('football');
 
-function makeParams(season_year: number): ToolParams {
-  return { sport: 'football', league_id: '123', season_year };
+function makeParams(season_year: number): RoutedToolParams {
+  return withSeasonContext({ sport: 'football', league_id: '123', season_year });
 }
 
 function jsonResponse(payload: unknown, status = 200): Response {

--- a/workers/espn-client/src/sports/football/__tests__/transactions.test.ts
+++ b/workers/espn-client/src/sports/football/__tests__/transactions.test.ts
@@ -3,6 +3,16 @@ import { footballHandlers } from '../handlers';
 import type { ToolParams } from '../../../types';
 import { getCredentials } from '../../../shared/auth';
 import { fetchEspnTransactionsByWeeks, fetchEspnMTransactions2, mergeTradePlayerDetails, getEspnLeagueContext, fetchEspnPlayersByIds, enrichTransactions } from '../../../shared/espn-transactions';
+import { withSeasonContext } from '../../../shared/season';
+
+function makeParams(overrides: Partial<ToolParams> = {}) {
+  return withSeasonContext({
+    sport: 'football',
+    league_id: '123',
+    season_year: 2025,
+    ...overrides,
+  });
+}
 
 vi.mock('../../../shared/auth', () => ({
   getCredentials: vi.fn(),
@@ -38,12 +48,7 @@ describe('football get_transactions handler', () => {
       { transaction_id: 't1', type: 'add', status: 'complete', timestamp: 1000, week: 9 },
     ] } as never);
 
-    const params: ToolParams = {
-      sport: 'football',
-      league_id: '123',
-      season_year: 2025,
-      count: 999,
-    };
+    const params = makeParams({ count: 999 });
 
     const result = await footballHandlers.get_transactions({} as never, params, 'Bearer x', 'cid-1');
 
@@ -67,14 +72,7 @@ describe('football get_transactions handler', () => {
       { transaction_id: 't2', type: 'trade', status: 'complete', timestamp: 1000, week: 7, players_added: [{ id: '2' }], players_dropped: [] },
     ] } as never);
 
-    const params: ToolParams = {
-      sport: 'football',
-      league_id: '123',
-      season_year: 2025,
-      week: 7,
-      type: 'trade',
-      count: 1,
-    };
+    const params = makeParams({ week: 7, type: 'trade', count: 1 });
 
     const result = await footballHandlers.get_transactions({} as never, params, 'Bearer x', 'cid-2');
 
@@ -121,12 +119,7 @@ describe('football get_transactions handler', () => {
       }));
     });
 
-    const params: ToolParams = {
-      sport: 'football',
-      league_id: '123',
-      season_year: 2025,
-      week: 8,
-    };
+    const params = makeParams({ week: 8 });
 
     const result = await footballHandlers.get_transactions({} as never, params, 'Bearer x', 'cid-enrich');
 
@@ -154,12 +147,7 @@ describe('football get_transactions handler', () => {
     ] } as never);
     fetchPlayersByIdsMock.mockRejectedValue(new Error('ESPN API error'));
 
-    const params: ToolParams = {
-      sport: 'football',
-      league_id: '123',
-      season_year: 2025,
-      week: 8,
-    };
+    const params = makeParams({ week: 8 });
 
     const result = await footballHandlers.get_transactions({} as never, params, 'Bearer x', 'cid-degrade');
 
@@ -208,7 +196,7 @@ describe('football get_transactions handler', () => {
       { ...activityRows[0], transaction_id: '400', type: 'trade' as const, status: 'complete' as const },
     ] as never);
 
-    const params: ToolParams = { sport: 'football', league_id: '123', season_year: 2025 };
+    const params = makeParams();
     const result = await footballHandlers.get_transactions({} as never, params, 'Bearer x', 'cid-merge');
 
     expect(result.success).toBe(true);
@@ -234,7 +222,7 @@ describe('football get_transactions handler', () => {
       },
     ] } as never);
 
-    const params: ToolParams = { sport: 'football', league_id: '123', season_year: 2025 };
+    const params = makeParams();
     const result = await footballHandlers.get_transactions({} as never, params, 'Bearer x', 'cid-no-merge');
 
     expect(result.success).toBe(true);
@@ -250,7 +238,7 @@ describe('football get_transactions handler', () => {
       { transaction_id: 'a1', type: 'add', status: 'complete', timestamp: 1000, week: 10 },
     ] as never);
 
-    const params: ToolParams = { sport: 'football', league_id: '123', season_year: 2025 };
+    const params = makeParams();
     const result = await footballHandlers.get_transactions({} as never, params, 'Bearer x', 'cid-fallback');
 
     expect(result.success).toBe(true);
@@ -263,11 +251,7 @@ describe('football get_transactions handler', () => {
   it('returns credentials error when ESPN is not connected', async () => {
     getCredentialsMock.mockResolvedValue(null);
 
-    const params: ToolParams = {
-      sport: 'football',
-      league_id: '123',
-      season_year: 2025,
-    };
+    const params = makeParams();
 
     const result = await footballHandlers.get_transactions({} as never, params, 'Bearer x', 'cid-3');
 

--- a/workers/espn-client/src/sports/football/handlers.ts
+++ b/workers/espn-client/src/sports/football/handlers.ts
@@ -16,7 +16,7 @@ import {
   transformStats,
   POSITION_SLOTS,
 } from './mappings';
-import { getCurrentSeasonYear } from '../../shared/season';
+import { getCurrentSeasonYear, getSeasonContext, normalizeEspnLeagueStatus } from '../../shared/season';
 
 const GAME_ID = 'ffl'; // ESPN's game ID for fantasy football
 
@@ -46,12 +46,13 @@ async function handleGetLeagueInfo(
   authHeader?: string,
   correlationId?: string
 ): Promise<ExecuteResponse> {
-  const { league_id, season_year } = params;
+  const { league_id } = params;
+  const { canonicalYear, espnYear } = getSeasonContext(params);
 
   try {
     const credentials = await getCredentials(env, authHeader, correlationId);
 
-    const path = `/seasons/${season_year}/segments/0/leagues/${league_id}?view=mSettings&view=mTeam`;
+    const path = `/seasons/${espnYear}/segments/0/leagues/${league_id}?view=mSettings&view=mTeam`;
     const response = await espnFetch(path, GAME_ID, { credentials, timeout: 7000 });
 
     if (!response.ok) {
@@ -88,10 +89,10 @@ async function handleGetLeagueInfo(
         id: data.id,
         name: data.settings.name,
         size: data.settings.size,
-        status: data.status,
+        status: normalizeEspnLeagueStatus(data.status, 'football'),
         scoringPeriodId: data.scoringPeriodId,
         currentMatchupPeriod: data.currentMatchupPeriod,
-        seasonId: data.seasonId,
+        seasonId: canonicalYear,
         segmentId: data.segmentId,
         teams,
         scoringSettings: {

--- a/workers/espn-client/src/sports/football/handlers.ts
+++ b/workers/espn-client/src/sports/football/handlers.ts
@@ -1,5 +1,5 @@
 // workers/espn-client/src/sports/football/handlers.ts
-import type { Env, ToolParams, ExecuteResponse, EspnLeagueResponse, EspnPlayerPoolResponse } from '../../types';
+import type { Env, RoutedToolParams, ExecuteResponse, EspnLeagueResponse, EspnPlayerPoolResponse } from '../../types';
 import { getCredentials } from '../../shared/auth';
 import { espnFetch, handleEspnError, requireCredentials } from '../../shared/espn-api';
 import { fetchEspnTransactionsByWeeks, fetchEspnMTransactions2, mergeTradePlayerDetails, getEspnLeagueContext, fetchEspnPlayersByIds, enrichTransactions } from '../../shared/espn-transactions';
@@ -22,7 +22,7 @@ const GAME_ID = 'ffl'; // ESPN's game ID for fantasy football
 
 type HandlerFn = (
   env: Env,
-  params: ToolParams,
+  params: RoutedToolParams,
   authHeader?: string,
   correlationId?: string
 ) => Promise<ExecuteResponse>;
@@ -42,7 +42,7 @@ export const footballHandlers: Record<string, HandlerFn> = {
  */
 async function handleGetLeagueInfo(
   env: Env,
-  params: ToolParams,
+  params: RoutedToolParams,
   authHeader?: string,
   correlationId?: string
 ): Promise<ExecuteResponse> {
@@ -124,7 +124,7 @@ async function handleGetLeagueInfo(
  */
 async function handleGetStandings(
   env: Env,
-  params: ToolParams,
+  params: RoutedToolParams,
   authHeader?: string,
   correlationId?: string
 ): Promise<ExecuteResponse> {
@@ -247,7 +247,7 @@ async function handleGetStandings(
  */
 async function handleGetMatchups(
   env: Env,
-  params: ToolParams,
+  params: RoutedToolParams,
   authHeader?: string,
   correlationId?: string
 ): Promise<ExecuteResponse> {
@@ -326,7 +326,7 @@ async function handleGetMatchups(
  */
 async function handleGetRoster(
   env: Env,
-  params: ToolParams,
+  params: RoutedToolParams,
   authHeader?: string,
   correlationId?: string
 ): Promise<ExecuteResponse> {
@@ -419,7 +419,7 @@ async function handleGetRoster(
  */
 async function handleGetFreeAgents(
   env: Env,
-  params: ToolParams,
+  params: RoutedToolParams,
   authHeader?: string,
   correlationId?: string
 ): Promise<ExecuteResponse> {
@@ -507,7 +507,7 @@ async function handleGetFreeAgents(
 
 async function handleSearchPlayers(
   env: Env,
-  params: ToolParams,
+  params: RoutedToolParams,
   authHeader?: string,
   correlationId?: string,
 ): Promise<ExecuteResponse> {
@@ -570,7 +570,7 @@ async function handleSearchPlayers(
 
 async function handleGetTransactions(
   env: Env,
-  params: ToolParams,
+  params: RoutedToolParams,
   authHeader?: string,
   correlationId?: string
 ): Promise<ExecuteResponse> {

--- a/workers/espn-client/src/sports/hockey/__tests__/standings.test.ts
+++ b/workers/espn-client/src/sports/hockey/__tests__/standings.test.ts
@@ -1,0 +1,186 @@
+import { beforeEach, describe, expect, it, vi, type MockedFunction } from 'vitest';
+import { hockeyHandlers } from '../handlers';
+import type { ToolParams } from '../../../types';
+import { getCredentials } from '../../../shared/auth';
+import { espnFetch } from '../../../shared/espn-api';
+import { toEspnSeasonYear, getCurrentSeasonYear } from '../../../shared/season';
+
+vi.mock('../../../shared/auth', () => ({
+  getCredentials: vi.fn(),
+}));
+
+vi.mock('../../../shared/espn-api', async () => {
+  const actual = await vi.importActual('../../../shared/espn-api') as Record<string, unknown>;
+  return {
+    ...actual,
+    espnFetch: vi.fn(),
+  };
+});
+
+// Handlers receive ESPN year (index.ts converts at /execute boundary).
+// Use toEspnSeasonYear to mirror what index.ts sends.
+const CURRENT_CANONICAL_YEAR = getCurrentSeasonYear('hockey');
+const CURRENT_ESPN_YEAR = toEspnSeasonYear(CURRENT_CANONICAL_YEAR, 'hockey');
+const HISTORICAL_CANONICAL_YEAR = 2022;
+const HISTORICAL_ESPN_YEAR = toEspnSeasonYear(HISTORICAL_CANONICAL_YEAR, 'hockey');
+
+function makeParams(season_year: number): ToolParams {
+  return { sport: 'hockey', league_id: '456', season_year };
+}
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('hockey get_standings handler — seasonPhase and canonical year', () => {
+  const getCredentialsMock = getCredentials as MockedFunction<typeof getCredentials>;
+  const espnFetchMock = espnFetch as MockedFunction<typeof espnFetch>;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    getCredentialsMock.mockResolvedValue({ s2: 'token', swid: '{swid}' });
+  });
+
+  it('returns season_complete and champion outcome for historical season with rankFinal', async () => {
+    espnFetchMock.mockResolvedValue(jsonResponse({
+      scoringPeriodId: 25,
+      settings: { regularSeasonMatchupPeriods: 22 },
+      teams: [
+        {
+          id: 1,
+          location: 'Alpha', nickname: 'Pucks',
+          rankFinal: 1,
+          playoffSeed: 1,
+          record: { overall: { wins: 16, losses: 6, ties: 0, pointsFor: 1900, pointsAgainst: 1500 } },
+        },
+        {
+          id: 2,
+          location: 'Beta', nickname: 'Ice',
+          rankFinal: 2,
+          playoffSeed: 2,
+          record: { overall: { wins: 14, losses: 8, ties: 0, pointsFor: 1750, pointsAgainst: 1600 } },
+        },
+        {
+          id: 3,
+          location: 'Gamma', nickname: 'Skates',
+          rankFinal: 6,
+          record: { overall: { wins: 10, losses: 12, ties: 0, pointsFor: 1400, pointsAgainst: 1550 } },
+        },
+      ],
+    }));
+
+    const result = await hockeyHandlers.get_standings({} as never, makeParams(HISTORICAL_ESPN_YEAR), 'Bearer x', 'cid');
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.seasonPhase).toBe('season_complete');
+    expect(data.seasonComplete).toBe(true);
+    // Response must echo canonical year, not ESPN year
+    expect(data.seasonYear).toBe(HISTORICAL_CANONICAL_YEAR);
+
+    const standings = data.standings as Array<Record<string, unknown>>;
+    const champion = standings.find((s) => s.teamId === 1);
+    expect(champion?.finalRank).toBe(1);
+    expect(champion?.championshipWon).toBe(true);
+    expect(champion?.playoffOutcome).toBe('champion');
+    expect(champion?.madePlayoffs).toBe(true);
+
+    const nonPlayoff = standings.find((s) => s.teamId === 3);
+    expect(nonPlayoff?.finalRank).toBe(6);
+    expect(nonPlayoff?.playoffOutcome).toBe('missed_playoffs');
+    expect(nonPlayoff?.madePlayoffs).toBe(false);
+  });
+
+  it('returns season_complete for historical year even without rankFinal', async () => {
+    espnFetchMock.mockResolvedValue(jsonResponse({
+      scoringPeriodId: 25,
+      settings: { regularSeasonMatchupPeriods: 22 },
+      teams: [
+        {
+          id: 1,
+          location: 'Alpha', nickname: 'Pucks',
+          record: { overall: { wins: 16, losses: 6, ties: 0, pointsFor: 1900, pointsAgainst: 1500 } },
+        },
+      ],
+    }));
+
+    const result = await hockeyHandlers.get_standings({} as never, makeParams(HISTORICAL_ESPN_YEAR), 'Bearer x', 'cid');
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.seasonPhase).toBe('season_complete');
+    expect(data.seasonYear).toBe(HISTORICAL_CANONICAL_YEAR);
+  });
+
+  it('returns playoffs_in_progress for current season past regular season periods', async () => {
+    espnFetchMock.mockResolvedValue(jsonResponse({
+      scoringPeriodId: 24,
+      settings: { regularSeasonMatchupPeriods: 22 },
+      teams: [
+        {
+          id: 1,
+          location: 'Alpha', nickname: 'Pucks',
+          playoffSeed: 1,
+          record: { overall: { wins: 16, losses: 6, ties: 0, pointsFor: 1900, pointsAgainst: 1500 } },
+        },
+      ],
+    }));
+
+    const result = await hockeyHandlers.get_standings({} as never, makeParams(CURRENT_ESPN_YEAR), 'Bearer x', 'cid');
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.seasonPhase).toBe('playoffs_in_progress');
+    expect(data.seasonComplete).toBe(false);
+    // Response must echo canonical year, not ESPN year
+    expect(data.seasonYear).toBe(CURRENT_CANONICAL_YEAR);
+  });
+
+  it('returns regular_season for current season within regular season periods', async () => {
+    espnFetchMock.mockResolvedValue(jsonResponse({
+      scoringPeriodId: 10,
+      settings: { regularSeasonMatchupPeriods: 22 },
+      teams: [
+        {
+          id: 1,
+          location: 'Alpha', nickname: 'Pucks',
+          record: { overall: { wins: 8, losses: 2, ties: 0, pointsFor: 950, pointsAgainst: 820 } },
+        },
+      ],
+    }));
+
+    const result = await hockeyHandlers.get_standings({} as never, makeParams(CURRENT_ESPN_YEAR), 'Bearer x', 'cid');
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.seasonPhase).toBe('regular_season');
+    expect(data.seasonComplete).toBe(false);
+    expect(data.seasonYear).toBe(CURRENT_CANONICAL_YEAR);
+  });
+
+  it('uses rankCalculatedFinal when rankFinal is absent', async () => {
+    espnFetchMock.mockResolvedValue(jsonResponse({
+      scoringPeriodId: 25,
+      settings: { regularSeasonMatchupPeriods: 22 },
+      teams: [
+        {
+          id: 1,
+          location: 'Alpha', nickname: 'Pucks',
+          rankCalculatedFinal: 1,
+          record: { overall: { wins: 16, losses: 6, ties: 0, pointsFor: 1900, pointsAgainst: 1500 } },
+        },
+      ],
+    }));
+
+    const result = await hockeyHandlers.get_standings({} as never, makeParams(HISTORICAL_ESPN_YEAR), 'Bearer x', 'cid');
+
+    const data = result.data as Record<string, unknown>;
+    const standings = data.standings as Array<Record<string, unknown>>;
+    expect(standings[0].finalRank).toBe(1);
+    expect(standings[0].championshipWon).toBe(true);
+    expect(standings[0].outcomeConfidence).toBe('explicit');
+  });
+});

--- a/workers/espn-client/src/sports/hockey/__tests__/standings.test.ts
+++ b/workers/espn-client/src/sports/hockey/__tests__/standings.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, vi, type MockedFunction } from 'vitest';
 import { hockeyHandlers } from '../handlers';
-import type { ToolParams } from '../../../types';
+import type { RoutedToolParams } from '../../../types';
 import { getCredentials } from '../../../shared/auth';
 import { espnFetch } from '../../../shared/espn-api';
-import { toEspnSeasonYear, getCurrentSeasonYear } from '../../../shared/season';
+import { getCurrentSeasonYear, withSeasonContext } from '../../../shared/season';
 
 vi.mock('../../../shared/auth', () => ({
   getCredentials: vi.fn(),
@@ -17,15 +17,21 @@ vi.mock('../../../shared/espn-api', async () => {
   };
 });
 
-// Handlers receive ESPN year (index.ts converts at /execute boundary).
-// Use toEspnSeasonYear to mirror what index.ts sends.
 const CURRENT_CANONICAL_YEAR = getCurrentSeasonYear('hockey');
-const CURRENT_ESPN_YEAR = toEspnSeasonYear(CURRENT_CANONICAL_YEAR, 'hockey');
 const HISTORICAL_CANONICAL_YEAR = 2022;
-const HISTORICAL_ESPN_YEAR = toEspnSeasonYear(HISTORICAL_CANONICAL_YEAR, 'hockey');
+const CURRENT_ESPN_YEAR = withSeasonContext({
+  sport: 'hockey',
+  league_id: '456',
+  season_year: CURRENT_CANONICAL_YEAR,
+}).seasonContext.espnYear;
+const HISTORICAL_ESPN_YEAR = withSeasonContext({
+  sport: 'hockey',
+  league_id: '456',
+  season_year: HISTORICAL_CANONICAL_YEAR,
+}).seasonContext.espnYear;
 
-function makeParams(season_year: number): ToolParams {
-  return { sport: 'hockey', league_id: '456', season_year };
+function makeParams(season_year: number): RoutedToolParams {
+  return withSeasonContext({ sport: 'hockey', league_id: '456', season_year });
 }
 
 function jsonResponse(payload: unknown, status = 200): Response {
@@ -72,9 +78,10 @@ describe('hockey get_standings handler — seasonPhase and canonical year', () =
       ],
     }));
 
-    const result = await hockeyHandlers.get_standings({} as never, makeParams(HISTORICAL_ESPN_YEAR), 'Bearer x', 'cid');
+    const result = await hockeyHandlers.get_standings({} as never, makeParams(HISTORICAL_CANONICAL_YEAR), 'Bearer x', 'cid');
 
     expect(result.success).toBe(true);
+    expect(espnFetchMock.mock.calls[0]?.[0]).toContain(`/seasons/${HISTORICAL_ESPN_YEAR}/segments/0/leagues/456`);
     const data = result.data as Record<string, unknown>;
     expect(data.seasonPhase).toBe('season_complete');
     expect(data.seasonComplete).toBe(true);
@@ -107,7 +114,7 @@ describe('hockey get_standings handler — seasonPhase and canonical year', () =
       ],
     }));
 
-    const result = await hockeyHandlers.get_standings({} as never, makeParams(HISTORICAL_ESPN_YEAR), 'Bearer x', 'cid');
+    const result = await hockeyHandlers.get_standings({} as never, makeParams(HISTORICAL_CANONICAL_YEAR), 'Bearer x', 'cid');
 
     expect(result.success).toBe(true);
     const data = result.data as Record<string, unknown>;
@@ -129,9 +136,10 @@ describe('hockey get_standings handler — seasonPhase and canonical year', () =
       ],
     }));
 
-    const result = await hockeyHandlers.get_standings({} as never, makeParams(CURRENT_ESPN_YEAR), 'Bearer x', 'cid');
+    const result = await hockeyHandlers.get_standings({} as never, makeParams(CURRENT_CANONICAL_YEAR), 'Bearer x', 'cid');
 
     expect(result.success).toBe(true);
+    expect(espnFetchMock.mock.calls[0]?.[0]).toContain(`/seasons/${CURRENT_ESPN_YEAR}/segments/0/leagues/456`);
     const data = result.data as Record<string, unknown>;
     expect(data.seasonPhase).toBe('playoffs_in_progress');
     expect(data.seasonComplete).toBe(false);
@@ -152,7 +160,7 @@ describe('hockey get_standings handler — seasonPhase and canonical year', () =
       ],
     }));
 
-    const result = await hockeyHandlers.get_standings({} as never, makeParams(CURRENT_ESPN_YEAR), 'Bearer x', 'cid');
+    const result = await hockeyHandlers.get_standings({} as never, makeParams(CURRENT_CANONICAL_YEAR), 'Bearer x', 'cid');
 
     expect(result.success).toBe(true);
     const data = result.data as Record<string, unknown>;
@@ -175,7 +183,7 @@ describe('hockey get_standings handler — seasonPhase and canonical year', () =
       ],
     }));
 
-    const result = await hockeyHandlers.get_standings({} as never, makeParams(HISTORICAL_ESPN_YEAR), 'Bearer x', 'cid');
+    const result = await hockeyHandlers.get_standings({} as never, makeParams(HISTORICAL_CANONICAL_YEAR), 'Bearer x', 'cid');
 
     const data = result.data as Record<string, unknown>;
     const standings = data.standings as Array<Record<string, unknown>>;

--- a/workers/espn-client/src/sports/hockey/handlers.ts
+++ b/workers/espn-client/src/sports/hockey/handlers.ts
@@ -16,7 +16,7 @@ import {
   transformStats,
   POSITION_SLOTS,
 } from './mappings';
-import { getCurrentSeasonYear } from '../../shared/season';
+import { getCurrentSeasonYear, fromEspnSeasonYear } from '../../shared/season';
 
 const GAME_ID = 'fhl'; // ESPN's game ID for fantasy hockey
 
@@ -190,6 +190,8 @@ async function handleGetStandings(
   correlationId?: string
 ): Promise<ExecuteResponse> {
   const { league_id, season_year } = params;
+  // season_year is ESPN year here (converted by index.ts). Reverse for non-API comparisons.
+  const canonicalSeasonYear = fromEspnSeasonYear(season_year, 'hockey');
 
   try {
     const credentials = await getCredentials(env, authHeader, correlationId);
@@ -213,14 +215,14 @@ async function handleGetStandings(
       (t) => t.rankFinal != null || t.rankCalculatedFinal != null
     );
     let seasonPhase: 'regular_season' | 'playoffs_in_progress' | 'season_complete';
-    if (hasExplicitCompletionData || season_year < currentSeasonYear) {
+    if (hasExplicitCompletionData || canonicalSeasonYear < currentSeasonYear) {
       seasonPhase = 'season_complete';
-    } else if (season_year === currentSeasonYear) {
+    } else if (canonicalSeasonYear === currentSeasonYear) {
       const regularPeriods = data.settings?.regularSeasonMatchupPeriods ?? 0;
       const scoringPeriod = data.scoringPeriodId ?? 0;
       seasonPhase = scoringPeriod > regularPeriods ? 'playoffs_in_progress' : 'regular_season';
     } else {
-      // season_year > currentSeasonYear — future season, treat as not yet started
+      // canonicalSeasonYear > currentSeasonYear — future season, treat as not yet started
       seasonPhase = 'regular_season';
     }
     const seasonComplete = seasonPhase === 'season_complete';
@@ -288,7 +290,7 @@ async function handleGetStandings(
       success: true,
       data: {
         leagueId: league_id,
-        seasonYear: season_year,
+        seasonYear: canonicalSeasonYear,
         seasonPhase,
         seasonComplete,
         standings
@@ -313,6 +315,7 @@ async function handleGetMatchups(
   correlationId?: string
 ): Promise<ExecuteResponse> {
   const { league_id, season_year, week } = params;
+  const canonicalSeasonYear = fromEspnSeasonYear(season_year, 'hockey');
 
   try {
     const credentials = await getCredentials(env, authHeader, correlationId);
@@ -367,7 +370,7 @@ async function handleGetMatchups(
       success: true,
       data: {
         leagueId: league_id,
-        seasonYear: season_year,
+        seasonYear: canonicalSeasonYear,
         currentScoringPeriod: data.scoringPeriodId,
         matchupPeriod: matchupPeriod ?? null,
         matchups
@@ -485,6 +488,7 @@ async function handleGetFreeAgents(
   correlationId?: string
 ): Promise<ExecuteResponse> {
   const { league_id, season_year, position, count } = params;
+  const canonicalSeasonYear = fromEspnSeasonYear(season_year, 'hockey');
 
   try {
     const credentials = await getCredentials(env, authHeader, correlationId);
@@ -551,7 +555,7 @@ async function handleGetFreeAgents(
       success: true,
       data: {
         leagueId: league_id,
-        seasonYear: season_year,
+        seasonYear: canonicalSeasonYear,
         position: positionKey,
         count: freeAgents.length,
         freeAgents

--- a/workers/espn-client/src/sports/hockey/handlers.ts
+++ b/workers/espn-client/src/sports/hockey/handlers.ts
@@ -16,7 +16,7 @@ import {
   transformStats,
   POSITION_SLOTS,
 } from './mappings';
-import { getCurrentSeasonYear, getSeasonContext } from '../../shared/season';
+import { getCurrentSeasonYear, getSeasonContext, normalizeEspnLeagueStatus } from '../../shared/season';
 
 const GAME_ID = 'fhl'; // ESPN's game ID for fantasy hockey
 
@@ -109,7 +109,7 @@ async function handleGetLeagueInfo(
   correlationId?: string
 ): Promise<ExecuteResponse> {
   const { league_id } = params;
-  const { espnYear } = getSeasonContext(params);
+  const { canonicalYear, espnYear } = getSeasonContext(params);
 
   try {
     const credentials = await getCredentials(env, authHeader, correlationId);
@@ -151,10 +151,10 @@ async function handleGetLeagueInfo(
         id: data.id,
         name: data.settings.name,
         size: data.settings.size,
-        status: data.status,
+        status: normalizeEspnLeagueStatus(data.status, 'hockey'),
         scoringPeriodId: data.scoringPeriodId,
         currentMatchupPeriod: data.currentMatchupPeriod,
-        seasonId: data.seasonId,
+        seasonId: canonicalYear,
         segmentId: data.segmentId,
         teams,
         scoringSettings: {

--- a/workers/espn-client/src/sports/hockey/handlers.ts
+++ b/workers/espn-client/src/sports/hockey/handlers.ts
@@ -1,5 +1,5 @@
 // workers/espn-client/src/sports/hockey/handlers.ts
-import type { Env, ToolParams, ExecuteResponse, EspnLeagueResponse, EspnPlayerPoolResponse } from '../../types';
+import type { Env, RoutedToolParams, ExecuteResponse, EspnLeagueResponse, EspnPlayerPoolResponse } from '../../types';
 import { getCredentials } from '../../shared/auth';
 import { espnFetch, handleEspnError, requireCredentials } from '../../shared/espn-api';
 import { fetchEspnTransactionsByWeeks, fetchEspnMTransactions2, mergeTradePlayerDetails, getEspnLeagueContext, fetchEspnPlayersByIds, enrichTransactions } from '../../shared/espn-transactions';
@@ -16,13 +16,13 @@ import {
   transformStats,
   POSITION_SLOTS,
 } from './mappings';
-import { getCurrentSeasonYear, fromEspnSeasonYear } from '../../shared/season';
+import { getCurrentSeasonYear, getSeasonContext } from '../../shared/season';
 
 const GAME_ID = 'fhl'; // ESPN's game ID for fantasy hockey
 
 type HandlerFn = (
   env: Env,
-  params: ToolParams,
+  params: RoutedToolParams,
   authHeader?: string,
   correlationId?: string
 ) => Promise<ExecuteResponse>;
@@ -39,11 +39,12 @@ export const hockeyHandlers: Record<string, HandlerFn> = {
 
 async function handleSearchPlayers(
   env: Env,
-  params: ToolParams,
+  params: RoutedToolParams,
   authHeader?: string,
   correlationId?: string,
 ): Promise<ExecuteResponse> {
-  const { query, position, count, season_year, league_id } = params;
+  const { query, position, count, league_id } = params;
+  const { espnYear } = getSeasonContext(params);
 
   if (!query) {
     return { success: false, error: 'query is required for get_players', code: 'MISSING_PARAM' };
@@ -51,7 +52,7 @@ async function handleSearchPlayers(
 
   try {
     const limit = Math.max(1, Math.min(25, Math.trunc(Number.isFinite(Number(count)) ? Number(count) : 10)));
-    const playersIndex = await getEspnPlayersIndex(env, 'hockey', season_year);
+    const playersIndex = await getEspnPlayersIndex(env, 'hockey', espnYear);
     const normalizedQuery = query.toLowerCase();
     const normalizedPosition = position?.trim().toUpperCase();
     const filterByPosition = normalizedPosition && normalizedPosition !== 'ALL';
@@ -66,7 +67,7 @@ async function handleSearchPlayers(
 
     // League ownership enrichment (null if no credentials or league_id)
     const ownerMap = league_id
-      ? await fetchLeagueOwnershipMap(env, GAME_ID, league_id, season_year, authHeader, correlationId)
+      ? await fetchLeagueOwnershipMap(env, GAME_ID, league_id, espnYear, authHeader, correlationId)
       : null;
 
     const players = matched.map((p) => ({
@@ -103,16 +104,17 @@ async function handleSearchPlayers(
  */
 async function handleGetLeagueInfo(
   env: Env,
-  params: ToolParams,
+  params: RoutedToolParams,
   authHeader?: string,
   correlationId?: string
 ): Promise<ExecuteResponse> {
-  const { league_id, season_year } = params;
+  const { league_id } = params;
+  const { espnYear } = getSeasonContext(params);
 
   try {
     const credentials = await getCredentials(env, authHeader, correlationId);
 
-    const path = `/seasons/${season_year}/segments/0/leagues/${league_id}?view=mSettings&view=mTeam`;
+    const path = `/seasons/${espnYear}/segments/0/leagues/${league_id}?view=mSettings&view=mTeam`;
     const response = await espnFetch(path, GAME_ID, { credentials, timeout: 7000 });
 
     if (!response.ok) {
@@ -185,18 +187,17 @@ async function handleGetLeagueInfo(
  */
 async function handleGetStandings(
   env: Env,
-  params: ToolParams,
+  params: RoutedToolParams,
   authHeader?: string,
   correlationId?: string
 ): Promise<ExecuteResponse> {
-  const { league_id, season_year } = params;
-  // season_year is ESPN year here (converted by index.ts). Reverse for non-API comparisons.
-  const canonicalSeasonYear = fromEspnSeasonYear(season_year, 'hockey');
+  const { league_id } = params;
+  const { canonicalYear, espnYear } = getSeasonContext(params);
 
   try {
     const credentials = await getCredentials(env, authHeader, correlationId);
 
-    const path = `/seasons/${season_year}/segments/0/leagues/${league_id}?view=mStandings&view=mTeam`;
+    const path = `/seasons/${espnYear}/segments/0/leagues/${league_id}?view=mStandings&view=mTeam`;
     const response = await espnFetch(path, GAME_ID, { credentials, timeout: 7000 });
 
     if (!response.ok) {
@@ -215,14 +216,14 @@ async function handleGetStandings(
       (t) => t.rankFinal != null || t.rankCalculatedFinal != null
     );
     let seasonPhase: 'regular_season' | 'playoffs_in_progress' | 'season_complete';
-    if (hasExplicitCompletionData || canonicalSeasonYear < currentSeasonYear) {
+    if (hasExplicitCompletionData || canonicalYear < currentSeasonYear) {
       seasonPhase = 'season_complete';
-    } else if (canonicalSeasonYear === currentSeasonYear) {
+    } else if (canonicalYear === currentSeasonYear) {
       const regularPeriods = data.settings?.regularSeasonMatchupPeriods ?? 0;
       const scoringPeriod = data.scoringPeriodId ?? 0;
       seasonPhase = scoringPeriod > regularPeriods ? 'playoffs_in_progress' : 'regular_season';
     } else {
-      // canonicalSeasonYear > currentSeasonYear — future season, treat as not yet started
+      // canonicalYear > currentSeasonYear — future season, treat as not yet started
       seasonPhase = 'regular_season';
     }
     const seasonComplete = seasonPhase === 'season_complete';
@@ -290,7 +291,7 @@ async function handleGetStandings(
       success: true,
       data: {
         leagueId: league_id,
-        seasonYear: canonicalSeasonYear,
+        seasonYear: canonicalYear,
         seasonPhase,
         seasonComplete,
         standings
@@ -310,17 +311,17 @@ async function handleGetStandings(
  */
 async function handleGetMatchups(
   env: Env,
-  params: ToolParams,
+  params: RoutedToolParams,
   authHeader?: string,
   correlationId?: string
 ): Promise<ExecuteResponse> {
-  const { league_id, season_year, week } = params;
-  const canonicalSeasonYear = fromEspnSeasonYear(season_year, 'hockey');
+  const { league_id, week } = params;
+  const { canonicalYear, espnYear } = getSeasonContext(params);
 
   try {
     const credentials = await getCredentials(env, authHeader, correlationId);
 
-    let path = `/seasons/${season_year}/segments/0/leagues/${league_id}?view=mMatchupScore&view=mScoreboard&view=mTeam`;
+    let path = `/seasons/${espnYear}/segments/0/leagues/${league_id}?view=mMatchupScore&view=mScoreboard&view=mTeam`;
     if (week) {
       path += `&scoringPeriodId=${week}&matchupPeriodId=${week}`;
     }
@@ -370,7 +371,7 @@ async function handleGetMatchups(
       success: true,
       data: {
         leagueId: league_id,
-        seasonYear: canonicalSeasonYear,
+        seasonYear: canonicalYear,
         currentScoringPeriod: data.scoringPeriodId,
         matchupPeriod: matchupPeriod ?? null,
         matchups
@@ -390,17 +391,18 @@ async function handleGetMatchups(
  */
 async function handleGetRoster(
   env: Env,
-  params: ToolParams,
+  params: RoutedToolParams,
   authHeader?: string,
   correlationId?: string
 ): Promise<ExecuteResponse> {
-  const { league_id, season_year, team_id, week } = params;
+  const { league_id, team_id, week } = params;
+  const { espnYear } = getSeasonContext(params);
 
   try {
     const credentials = await getCredentials(env, authHeader, correlationId);
     requireCredentials(credentials, 'roster data');
 
-    let path = `/seasons/${season_year}/segments/0/leagues/${league_id}?view=mRoster&view=mTeam`;
+    let path = `/seasons/${espnYear}/segments/0/leagues/${league_id}?view=mRoster&view=mTeam`;
     if (week) {
       path += `&scoringPeriodId=${week}`;
     }
@@ -436,7 +438,7 @@ async function handleGetRoster(
 
       // Get current season stats if available
       const currentStats = stats.find((s) =>
-        s.seasonId === season_year && s.statSourceId === 0
+        s.seasonId === espnYear && s.statSourceId === 0
       );
 
       return {
@@ -483,12 +485,12 @@ async function handleGetRoster(
  */
 async function handleGetFreeAgents(
   env: Env,
-  params: ToolParams,
+  params: RoutedToolParams,
   authHeader?: string,
   correlationId?: string
 ): Promise<ExecuteResponse> {
-  const { league_id, season_year, position, count } = params;
-  const canonicalSeasonYear = fromEspnSeasonYear(season_year, 'hockey');
+  const { league_id, position, count } = params;
+  const { canonicalYear, espnYear } = getSeasonContext(params);
 
   try {
     const credentials = await getCredentials(env, authHeader, correlationId);
@@ -498,7 +500,7 @@ async function handleGetFreeAgents(
     const slotIds = POSITION_SLOTS[positionKey] || POSITION_SLOTS['ALL'];
     const limit = Math.min(Math.max(1, count || 25), 100);
 
-    const path = `/seasons/${season_year}/segments/0/leagues/${league_id}?view=kona_player_info`;
+    const path = `/seasons/${espnYear}/segments/0/leagues/${league_id}?view=kona_player_info`;
 
     // Build the X-Fantasy-Filter header for free agents
     const filter = {
@@ -533,7 +535,7 @@ async function handleGetFreeAgents(
 
       // Get current season stats if available
       const currentStats = stats.find((s) =>
-        s.seasonId === season_year && s.statSourceId === 0
+        s.seasonId === espnYear && s.statSourceId === 0
       );
 
       return {
@@ -555,7 +557,7 @@ async function handleGetFreeAgents(
       success: true,
       data: {
         leagueId: league_id,
-        seasonYear: canonicalSeasonYear,
+        seasonYear: canonicalYear,
         position: positionKey,
         count: freeAgents.length,
         freeAgents
@@ -572,17 +574,18 @@ async function handleGetFreeAgents(
 
 async function handleGetTransactions(
   env: Env,
-  params: ToolParams,
+  params: RoutedToolParams,
   authHeader?: string,
   correlationId?: string
 ): Promise<ExecuteResponse> {
-  const { league_id, season_year, week, count, type } = params;
+  const { league_id, week, count, type } = params;
+  const { canonicalYear, espnYear } = getSeasonContext(params);
 
   try {
     const credentials = await getCredentials(env, authHeader, correlationId);
     requireCredentials(credentials, 'get_transactions');
 
-    const ctx = await getEspnLeagueContext(GAME_ID, league_id, season_year, credentials);
+    const ctx = await getEspnLeagueContext(GAME_ID, league_id, espnYear, credentials);
     const currentWeek = ctx.scoringPeriodId;
     const weeks = week != null
       ? [Math.max(0, week)]
@@ -599,7 +602,7 @@ async function handleGetTransactions(
     let merged: NormalizedTransaction[];
     let truncated = false;
     try {
-      const mResult = await fetchEspnMTransactions2(GAME_ID, league_id, season_year, credentials, weeks);
+      const mResult = await fetchEspnMTransactions2(GAME_ID, league_id, espnYear, credentials, weeks);
       truncated = mResult.truncated;
 
       // Trade player detail fallback: activity feed for accepted/upheld trades (ESPN items bug)
@@ -610,7 +613,7 @@ async function handleGetTransactions(
       merged = mResult.transactions;
       if (hasEmptyTrades) {
         try {
-          const activityRows = await fetchEspnTransactionsByWeeks(GAME_ID, league_id, season_year, credentials, weeks);
+          const activityRows = await fetchEspnTransactionsByWeeks(GAME_ID, league_id, espnYear, credentials, weeks);
           merged = mergeTradePlayerDetails(mResult.transactions, activityRows);
         } catch (fallbackErr) {
           console.warn('[get_transactions] Activity feed trade fallback failed:', fallbackErr instanceof Error ? fallbackErr.message : fallbackErr);
@@ -618,7 +621,7 @@ async function handleGetTransactions(
       }
     } catch (mTxnErr) {
       console.warn('[get_transactions] mTransactions2 failed, falling back to activity feed:', mTxnErr instanceof Error ? mTxnErr.message : mTxnErr);
-      merged = await fetchEspnTransactionsByWeeks(GAME_ID, league_id, season_year, credentials, weeks);
+      merged = await fetchEspnTransactionsByWeeks(GAME_ID, league_id, espnYear, credentials, weeks);
     }
 
     let filtered = merged
@@ -631,7 +634,7 @@ async function handleGetTransactions(
     ]))];
     if (allIds.length > 0) {
       try {
-        const playerMap = await fetchEspnPlayersByIds(GAME_ID, season_year, allIds);
+        const playerMap = await fetchEspnPlayersByIds(GAME_ID, espnYear, allIds);
         if (playerMap) {
           filtered = enrichTransactions(filtered, playerMap, getPositionName, getProTeamAbbrev);
         }
@@ -647,7 +650,7 @@ async function handleGetTransactions(
         platform: 'espn',
         sport: params.sport,
         league_id,
-        season_year,
+        season_year: canonicalYear,
         window: {
           mode: week ? 'explicit_week' : 'recent_two_weeks',
           weeks

--- a/workers/espn-client/src/types.ts
+++ b/workers/espn-client/src/types.ts
@@ -1,5 +1,5 @@
 // workers/espn-client/src/types.ts
-import type { BaseEnvWithAuth } from '@flaim/worker-shared';
+import type { BaseEnvWithAuth, ExecuteResponse as SharedExecuteResponse } from '@flaim/worker-shared';
 
 // ---------------------------------------------------------------------------
 // ESPN Fantasy API response types
@@ -152,5 +152,23 @@ export interface ToolParams {
   count?: number;
   query?: string;
 }
+
+export interface EspnSeasonContext {
+  canonicalYear: number;
+  espnYear: number;
+}
+
+export interface RoutedToolParams extends ToolParams {
+  seasonContext: EspnSeasonContext;
+}
+
+export type HandlerToolParams = RoutedToolParams;
+
+export type SportHandler = (
+  env: Env,
+  params: RoutedToolParams,
+  authHeader?: string,
+  correlationId?: string
+) => Promise<SharedExecuteResponse>;
 
 export type { ExecuteResponse } from '@flaim/worker-shared';

--- a/workers/fantasy-mcp/src/__tests__/tools.test.ts
+++ b/workers/fantasy-mcp/src/__tests__/tools.test.ts
@@ -75,6 +75,36 @@ describe('fantasy-mcp tools', () => {
     expect((result.structuredContent as Record<string, unknown>).totalLeaguesFound).toBe(0);
   });
 
+  it('get_user_session keeps canonical current-season labels in the session payload', async () => {
+    const tool = getUnifiedTools().find((t) => t.name === 'get_user_session');
+    expect(tool).toBeTruthy();
+
+    const env = {
+      INTERNAL_SERVICE_TOKEN: 'internal-secret',
+      AUTH_WORKER: {
+        fetch: async () =>
+          new Response(JSON.stringify({ leagues: [] }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+      },
+    } as unknown as Env;
+
+    const result = await tool!.handler({}, env, 'Bearer test-token');
+    const payload = JSON.parse(result.content[0].text) as {
+      currentSeasons: Record<string, { year: number; label: string }>;
+    };
+
+    expect(payload.currentSeasons.football.label).toBe(String(payload.currentSeasons.football.year));
+    expect(payload.currentSeasons.baseball.label).toBe(String(payload.currentSeasons.baseball.year));
+    expect(payload.currentSeasons.basketball.label).toBe(
+      `${payload.currentSeasons.basketball.year}-${String(payload.currentSeasons.basketball.year + 1).slice(2)}`
+    );
+    expect(payload.currentSeasons.hockey.label).toBe(
+      `${payload.currentSeasons.hockey.year}-${String(payload.currentSeasons.hockey.year + 1).slice(2)}`
+    );
+  });
+
   it('get_user_session includes widgetUri in tool definition', () => {
     const tool = getUnifiedTools().find((t) => t.name === 'get_user_session');
     expect(tool?.widgetUri).toBe('ui://widget/user-session.html');

--- a/workers/fantasy-mcp/src/mcp/tools.ts
+++ b/workers/fantasy-mcp/src/mcp/tools.ts
@@ -3,7 +3,13 @@ import { z } from 'zod';
 import type { ZodRawShapeCompat } from '@modelcontextprotocol/sdk/server/zod-compat.js';
 import type { Env, Platform, Sport, ToolParams } from '../types';
 import { routeToClient, type RouteResult } from '../router';
-import { withCorrelationId, withEvalHeaders, withInternalServiceToken } from '@flaim/worker-shared';
+import {
+  getDefaultSeasonYear,
+  getSeasonLabel,
+  withCorrelationId,
+  withEvalHeaders,
+  withInternalServiceToken,
+} from '@flaim/worker-shared';
 import { logEvalEvent } from '../logging';
 
 // =============================================================================
@@ -398,48 +404,6 @@ async function withToolLogging<T>(
 }
 
 // =============================================================================
-// HELPER: Get current season for a sport
-// =============================================================================
-
-function getCurrentSeason(sport: Sport): number {
-  const now = new Date();
-  const ny = new Intl.DateTimeFormat('en-US', {
-    timeZone: 'America/New_York',
-    year: 'numeric',
-    month: '2-digit',
-  }).formatToParts(now);
-
-  const year = Number(ny.find((p) => p.type === 'year')?.value);
-  const month = Number(ny.find((p) => p.type === 'month')?.value);
-
-  // Rollover months — must match auth-worker's ROLLOVER_MONTHS.
-  // Returns canonical start year for the current season.
-  switch (sport) {
-    case 'baseball':
-      return month < 2 ? year - 1 : year;   // Feb 1
-    case 'football':
-      return month < 7 ? year - 1 : year;   // Jul 1
-    case 'basketball':
-      return month < 8 ? year - 1 : year;   // Aug 1
-    case 'hockey':
-      return month < 8 ? year - 1 : year;   // Aug 1
-    default:
-      return year;
-  }
-}
-
-/**
- * Get a human-readable season label from a canonical start year.
- * Cross-year sports (basketball, hockey) → "2024-25"; others → "2025".
- */
-function getSeasonLabel(canonicalYear: number, sport: string): string {
-  if (sport === 'basketball' || sport === 'hockey') {
-    return `${canonicalYear}-${String(canonicalYear + 1).slice(2)}`;
-  }
-  return String(canonicalYear);
-}
-
-// =============================================================================
 // UNIFIED TOOLS
 // =============================================================================
 
@@ -523,7 +487,7 @@ export function getUnifiedTools(): UnifiedTool[] {
             if (mostRecentYear >= thresholdYear) {
               // Determine current season for this league's sport
               const sport = (groupSeasons[0]?.sport || '').toLowerCase();
-              const currentYear = getCurrentSeason(sport as Sport);
+              const currentYear = getDefaultSeasonYear(sport as Sport);
               // Take only the current-season entry (or most recent if no exact match)
               const currentSeason = groupSeasons.find(s => s.seasonYear === currentYear);
               if (currentSeason) {
@@ -665,10 +629,10 @@ export function getUnifiedTools(): UnifiedTool[] {
             success: true,
             currentDate: new Date().toISOString(),
             currentSeasons: {
-              football: { year: getCurrentSeason('football'), label: getSeasonLabel(getCurrentSeason('football'), 'football') },
-              baseball: { year: getCurrentSeason('baseball'), label: getSeasonLabel(getCurrentSeason('baseball'), 'baseball') },
-              basketball: { year: getCurrentSeason('basketball'), label: getSeasonLabel(getCurrentSeason('basketball'), 'basketball') },
-              hockey: { year: getCurrentSeason('hockey'), label: getSeasonLabel(getCurrentSeason('hockey'), 'hockey') },
+              football: { year: getDefaultSeasonYear('football'), label: getSeasonLabel(getDefaultSeasonYear('football'), 'football') },
+              baseball: { year: getDefaultSeasonYear('baseball'), label: getSeasonLabel(getDefaultSeasonYear('baseball'), 'baseball') },
+              basketball: { year: getDefaultSeasonYear('basketball'), label: getSeasonLabel(getDefaultSeasonYear('basketball'), 'basketball') },
+              hockey: { year: getDefaultSeasonYear('hockey'), label: getSeasonLabel(getDefaultSeasonYear('hockey'), 'hockey') },
             },
             timezone: 'America/New_York',
             totalLeaguesFound: leagues.length,
@@ -681,7 +645,7 @@ export function getUnifiedTools(): UnifiedTool[] {
                   leagueId: defaultLeague.leagueId,
                   teamId: defaultLeague.teamId,
                   seasonYear: defaultLeague.seasonYear,
-                  season: getSeasonLabel(defaultLeague.seasonYear || getCurrentSeason(defaultLeague.sport as Sport), defaultLeague.sport || ''),
+                  season: getSeasonLabel(defaultLeague.seasonYear || getDefaultSeasonYear(defaultLeague.sport as Sport), defaultLeague.sport as Sport),
                   leagueName: defaultLeague.leagueName,
                   teamName: defaultLeague.teamName,
                 }
@@ -695,7 +659,7 @@ export function getUnifiedTools(): UnifiedTool[] {
                   leagueName: league.leagueName,
                   sport: league.sport,
                   seasonYear: league.seasonYear,
-                  season: getSeasonLabel(league.seasonYear || getCurrentSeason(sport as Sport), sport),
+                  season: getSeasonLabel(league.seasonYear || getDefaultSeasonYear(sport as Sport), sport as Sport),
                   teamId: league.teamId,
                   teamName: league.teamName,
                 },
@@ -790,7 +754,7 @@ export function getUnifiedTools(): UnifiedTool[] {
             } else {
               // Active league - include everything except the current season
               const sport = (groupSeasons[0]?.sport || '').toLowerCase();
-              const currentYear = getCurrentSeason(sport as Sport);
+              const currentYear = getDefaultSeasonYear(sport as Sport);
               const ancientSeasons = groupSeasons.filter(s => s.seasonYear !== currentYear);
               if (ancientSeasons.length > 0) {
                 oldSeasons[key] = ancientSeasons;

--- a/workers/shared/src/__tests__/season.test.ts
+++ b/workers/shared/src/__tests__/season.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getDefaultSeasonYear,
+  getSeasonLabel,
+  isCurrentSeason,
+  toCanonicalYear,
+  toPlatformYear,
+} from '../season.js';
+
+describe('season helpers', () => {
+  describe('getDefaultSeasonYear', () => {
+    it('returns the previous baseball season before Feb 1', () => {
+      expect(getDefaultSeasonYear('baseball', new Date('2026-01-15T12:00:00-05:00'))).toBe(2025);
+    });
+
+    it('returns the current baseball season on Feb 1', () => {
+      expect(getDefaultSeasonYear('baseball', new Date('2026-02-01T00:00:00-05:00'))).toBe(2026);
+    });
+
+    it('returns the previous football season before Jul 1', () => {
+      expect(getDefaultSeasonYear('football', new Date('2026-06-15T12:00:00-04:00'))).toBe(2025);
+    });
+
+    it('returns the current football season on Jul 1', () => {
+      expect(getDefaultSeasonYear('football', new Date('2026-07-01T00:00:00-04:00'))).toBe(2026);
+    });
+
+    it('returns the previous basketball season before Aug 1', () => {
+      expect(getDefaultSeasonYear('basketball', new Date('2026-07-15T12:00:00-04:00'))).toBe(2025);
+    });
+
+    it('returns the current hockey season on Aug 1', () => {
+      expect(getDefaultSeasonYear('hockey', new Date('2026-08-01T00:00:00-04:00'))).toBe(2026);
+    });
+  });
+
+  describe('isCurrentSeason', () => {
+    it('compares against the canonical season year', () => {
+      const now = new Date('2026-02-15T12:00:00-05:00');
+      expect(isCurrentSeason('baseball', 2026, now)).toBe(true);
+      expect(isCurrentSeason('baseball', 2025, now)).toBe(false);
+    });
+  });
+
+  describe('canonical year translation', () => {
+    it('normalizes ESPN basketball and hockey end years', () => {
+      expect(toCanonicalYear(2025, 'basketball', 'espn')).toBe(2024);
+      expect(toCanonicalYear(2025, 'hockey', 'espn')).toBe(2024);
+    });
+
+    it('round-trips canonical years back to ESPN end years', () => {
+      expect(toPlatformYear(2024, 'basketball', 'espn')).toBe(2025);
+      expect(toPlatformYear(2024, 'hockey', 'espn')).toBe(2025);
+    });
+
+    it('passes through non-ESPN values unchanged', () => {
+      expect(toCanonicalYear(2025, 'football', 'yahoo')).toBe(2025);
+      expect(toPlatformYear(2025, 'football', 'yahoo')).toBe(2025);
+    });
+  });
+
+  describe('getSeasonLabel', () => {
+    it('formats cross-year sports with a short trailing year', () => {
+      expect(getSeasonLabel(2024, 'basketball')).toBe('2024-25');
+      expect(getSeasonLabel(2099, 'hockey')).toBe('2099-00');
+    });
+
+    it('formats single-year sports as a plain year', () => {
+      expect(getSeasonLabel(2025, 'baseball')).toBe('2025');
+      expect(getSeasonLabel(2025, 'football')).toBe('2025');
+    });
+  });
+});

--- a/workers/shared/src/browser.ts
+++ b/workers/shared/src/browser.ts
@@ -17,3 +17,11 @@
  * extension-less form, so both consumers stay happy.
  */
 export { isValidRedirectUri } from './oauth-redirect';
+export {
+  getDefaultSeasonYear,
+  isCurrentSeason,
+  toCanonicalYear,
+  toPlatformYear,
+  getSeasonLabel,
+} from './season';
+export type { SeasonSport } from './season';

--- a/workers/shared/src/index.ts
+++ b/workers/shared/src/index.ts
@@ -29,6 +29,16 @@ export {
   getPathname,
 } from './prefix-strip.js';
 
+// Season utilities
+export {
+  getDefaultSeasonYear,
+  isCurrentSeason,
+  toCanonicalYear,
+  toPlatformYear,
+  getSeasonLabel,
+} from './season.js';
+export type { SeasonSport } from './season.js';
+
 // Auth-worker fetch helper
 export { authWorkerFetch } from './auth-fetch.js';
 

--- a/workers/shared/src/season.ts
+++ b/workers/shared/src/season.ts
@@ -1,0 +1,91 @@
+/**
+ * Season helpers shared across Flaim workers.
+ *
+ * Canonical season years always use the START year of the season.
+ * Rollover dates use America/New_York so current-season behavior is stable
+ * regardless of where the worker runs.
+ */
+
+export type SeasonSport = 'baseball' | 'football' | 'basketball' | 'hockey';
+
+const ROLLOVER_MONTHS: Record<SeasonSport, number> = {
+  baseball: 2, // Feb 1
+  football: 7, // Jul 1
+  basketball: 8, // Aug 1
+  hockey: 8, // Aug 1
+};
+
+const CROSS_YEAR_SPORTS = new Set<SeasonSport>(['basketball', 'hockey']);
+
+function getNewYorkDateParts(now: Date): { year: number; month: number } {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/New_York',
+    year: 'numeric',
+    month: '2-digit',
+  }).formatToParts(now);
+
+  const yearPart = parts.find((part) => part.type === 'year')?.value;
+  const monthPart = parts.find((part) => part.type === 'month')?.value;
+
+  const year = Number(yearPart);
+  const month = Number(monthPart);
+
+  if (!Number.isFinite(year) || !Number.isFinite(month)) {
+    throw new Error('Unable to determine America/New_York calendar date');
+  }
+
+  return { year, month };
+}
+
+function isCrossYearSport(sport: SeasonSport): boolean {
+  return CROSS_YEAR_SPORTS.has(sport);
+}
+
+/**
+ * Return the canonical season year for the provided sport and date.
+ */
+export function getDefaultSeasonYear(sport: SeasonSport, now = new Date()): number {
+  const { year, month } = getNewYorkDateParts(now);
+  const rolloverMonth = ROLLOVER_MONTHS[sport];
+  return month < rolloverMonth ? year - 1 : year;
+}
+
+/**
+ * Check whether a season year matches the current canonical season.
+ */
+export function isCurrentSeason(sport: SeasonSport, seasonYear: number, now = new Date()): boolean {
+  return seasonYear === getDefaultSeasonYear(sport, now);
+}
+
+/**
+ * Convert a platform-native season year to Flaim's canonical start year.
+ */
+export function toCanonicalYear(platformYear: number, sport: SeasonSport, platform: string): number {
+  if (platform === 'espn' && isCrossYearSport(sport)) {
+    return platformYear - 1;
+  }
+
+  return platformYear;
+}
+
+/**
+ * Convert a canonical start year to the platform-native season year.
+ */
+export function toPlatformYear(canonicalYear: number, sport: SeasonSport, platform: string): number {
+  if (platform === 'espn' && isCrossYearSport(sport)) {
+    return canonicalYear + 1;
+  }
+
+  return canonicalYear;
+}
+
+/**
+ * Format a canonical start year for display.
+ */
+export function getSeasonLabel(canonicalYear: number, sport: SeasonSport): string {
+  if (isCrossYearSport(sport)) {
+    return `${canonicalYear}-${String(canonicalYear + 1).slice(2)}`;
+  }
+
+  return String(canonicalYear);
+}


### PR DESCRIPTION
## Summary
- normalize ESPN season-year handling around a single canonical start-year contract across workers and web onboarding
- consolidate shared season helpers into `@flaim/worker-shared` and adopt them in `auth-worker`, `espn-client`, `fantasy-mcp`, and web onboarding
- fix the remaining ESPN outward response leaks for league info, transactions, and web onboarding flows
- add targeted web onboarding regression coverage for canonical NBA/NHL years and January rollover behavior

## Included issues
- FLA-111
- FLA-112
- FLA-113
- FLA-114
- FLA-117
- FLA-118

## Not included
- FLA-115 stays separate as a Sleeper session/history change

## Verification
- `corepack pnpm --dir workers/shared test`
- `corepack pnpm --dir workers/auth-worker test`
- `corepack pnpm --dir workers/espn-client test`
- `corepack pnpm --dir workers/fantasy-mcp test`
- `corepack pnpm --dir web test`
- `corepack pnpm --dir web exec tsc --noEmit`
- `corepack pnpm --dir web run lint`
- `git diff --check`

## Notes
- checks in this branch were run under Node `25.9.0`; the repo declares Node `24.x`
- this PR intentionally keeps the commit boundaries intact rather than squashing the refactor/fix slices together