### PR TITLE
Fix Sleeper recurring season session grouping

### DIFF
--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -86,11 +86,16 @@ One row per user + league + sport + season.
 | season_year | int | Season year |
 | league_name | text | League name (optional) |
 | roster_id | integer | User's roster ID in this league (optional, found during discovery) |
+| recurring_league_id | text | Stable recurring root ID derived from Sleeper's `previous_league_id` chain (optional on legacy rows) |
 | sleeper_user_id | text | Sleeper user ID (not null) |
 
 Constraints/Indexes:
 - Unique per season: unique on `(clerk_user_id, league_id, season_year)`.
 - Index on `clerk_user_id` for fast user lookups.
+
+Notes:
+- New discovery writes persist `recurring_league_id` when the column is available.
+- During rollout, auth-worker retries writes without `recurring_league_id` if the live schema does not have the column yet; those legacy rows still rely on read-time fallback until they are rediscovered.
 
 ### platform_oauth_states
 Short-lived OAuth state values for platform-connect flows (separate from MCP OAuth state table).

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -94,8 +94,8 @@ Constraints/Indexes:
 - Index on `clerk_user_id` for fast user lookups.
 
 Notes:
-- New discovery writes persist `recurring_league_id` when the column is available.
-- During rollout, auth-worker retries writes without `recurring_league_id` if the live schema does not have the column yet; those legacy rows still rely on read-time fallback until they are rediscovered.
+- New discovery writes persist `recurring_league_id` when the column is available and the full Sleeper history chain resolves successfully.
+- During rollout, auth-worker retries writes without `recurring_league_id` if the live schema does not have the column yet; those legacy or unresolved rows still rely on read-time fallback until they are rediscovered.
 
 ### platform_oauth_states
 Short-lived OAuth state values for platform-connect flows (separate from MCP OAuth state table).

--- a/web/app/(site)/leagues/page.tsx
+++ b/web/app/(site)/leagues/page.tsx
@@ -76,6 +76,7 @@ interface SleeperLeague {
   leagueId: string;  // Sleeper's numeric string league ID
   leagueName: string;
   rosterId: number | null;
+  recurringLeagueId?: string;
 }
 
 interface LeagueDefault {
@@ -124,6 +125,7 @@ interface UnifiedLeague {
   yahooId?: string;      // UUID for Yahoo league (for API calls)
   // Sleeper-specific
   sleeperId?: string;    // DB UUID for deletion (Sleeper only)
+  recurringLeagueId?: string;
 }
 
 interface UnifiedLeagueGroup {
@@ -215,6 +217,7 @@ function sleeperToUnified(
       teamId: sl.rosterId != null ? String(sl.rosterId) : undefined,
       isDefault,
       sleeperId: sl.id,
+      recurringLeagueId: sl.recurringLeagueId,
     };
   });
 }
@@ -325,16 +328,17 @@ function LeaguesPageContent() {
       ...sleeperToUnified(sleeperLeagues, preferences),
     ];
 
-    // Group by platform + leagueId (ESPN) or leagueName (Yahoo)
-    // Yahoo uses unique leagueKey per season, so we group by name instead
+    // Group by stable recurring identity where available.
+    // Yahoo uses league name in the web UI because leagueKey is season-scoped.
+    // Sleeper keeps season-specific leagueId for actions, but can group by recurringLeagueId.
     const grouped = new Map<string, UnifiedLeagueGroup>();
 
     for (const league of allLeagues) {
-      // Yahoo: group by league name since leagueKey differs per season
-      // ESPN: group by leagueId which stays consistent across seasons
       const groupKey = league.platform === 'yahoo'
         ? `${league.platform}:${league.sport}:${league.leagueName}`
-        : `${league.platform}:${league.sport}:${league.leagueId}`;
+        : league.platform === 'sleeper'
+          ? `${league.platform}:${league.sport}:${league.recurringLeagueId || league.leagueId}`
+          : `${league.platform}:${league.sport}:${league.leagueId}`;
 
       if (!grouped.has(groupKey)) {
         grouped.set(groupKey, {

--- a/workers/auth-worker/README.md
+++ b/workers/auth-worker/README.md
@@ -194,4 +194,5 @@ npm run deploy       # Deploy
 - Deleting a league removes all seasons for that league.
 - Shared season helper logic now lives in `@flaim/worker-shared` (`src/season.ts`); `src/season-utils.ts` stays as a backward-compatible wrapper for local imports.
 - `src/v3/get-league-info.ts` returns canonical start years in `seasonYear`, `settings.season`, and `status.previousSeasons`; ESPN-native end years are only used for upstream ESPN requests.
-- Sleeper league responses keep the season-specific `leagueId` for direct tool calls, and also compute a `recurringLeagueId` on read by following Sleeper's `previous_league_id` chain so downstream consumers can group recurring seasons safely.
+- Sleeper league responses keep the season-specific `leagueId` for direct tool calls, and also persist a `recurringLeagueId` during discovery by following Sleeper's `previous_league_id` chain. Read paths prefer the stored recurring ID and only fall back to live chain resolution for legacy rows that do not have it yet.
+- During the `sleeper_leagues.recurring_league_id` rollout, discovery writes retry without that column if the live database schema has not been migrated yet, which preserves the legacy read fallback until the migration lands.

--- a/workers/auth-worker/README.md
+++ b/workers/auth-worker/README.md
@@ -56,6 +56,17 @@ These endpoints manage the OAuth 2.0 client flow with Yahoo Fantasy.
 | `GET /internal/leagues/yahoo` | Internal + Clerk JWT / OAuth / Eval key | Get stored Yahoo leagues for internal workers |
 | `DELETE /leagues/yahoo/:id` | Clerk JWT | Delete a Yahoo league |
 
+### Sleeper Connect
+
+| Endpoint | Auth | Purpose |
+|----------|------|---------|
+| `POST /connect/sleeper/discover` | Clerk JWT | Discover Sleeper leagues and prior seasons |
+| `GET /connect/sleeper/status` | Clerk JWT | Check Sleeper connection status |
+| `DELETE /connect/sleeper/disconnect` | Clerk JWT | Remove Sleeper connection |
+| `GET /leagues/sleeper` | Clerk JWT | Get stored Sleeper leagues |
+| `GET /internal/leagues/sleeper` | Internal + Clerk JWT / OAuth / Eval key | Get stored Sleeper leagues for internal workers |
+| `DELETE /leagues/sleeper/:id` | Clerk JWT | Delete a Sleeper league |
+
 ### Extension APIs
 
 | Endpoint | Auth | Purpose |
@@ -116,6 +127,7 @@ A static Bearer token that resolves to a specific Clerk user ID with `mcp:read` 
 - `GET /auth/internal/connect/yahoo/credentials`
 - `GET /auth/internal/leagues`
 - `GET /auth/internal/leagues/yahoo`
+- `GET /auth/internal/leagues/sleeper`
 - `GET /auth/internal/user/preferences`
 
 **Current mapping:** `EVAL_USER_ID` → `user_36UBCM4x2hK1aJYY1F7iV1svNw6` (test email on Clerk prod).
@@ -182,3 +194,4 @@ npm run deploy       # Deploy
 - Deleting a league removes all seasons for that league.
 - Shared season helper logic now lives in `@flaim/worker-shared` (`src/season.ts`); `src/season-utils.ts` stays as a backward-compatible wrapper for local imports.
 - `src/v3/get-league-info.ts` returns canonical start years in `seasonYear`, `settings.season`, and `status.previousSeasons`; ESPN-native end years are only used for upstream ESPN requests.
+- Sleeper league responses keep the season-specific `leagueId` for direct tool calls, and also compute a `recurringLeagueId` on read by following Sleeper's `previous_league_id` chain so downstream consumers can group recurring seasons safely.

--- a/workers/auth-worker/README.md
+++ b/workers/auth-worker/README.md
@@ -194,5 +194,5 @@ npm run deploy       # Deploy
 - Deleting a league removes all seasons for that league.
 - Shared season helper logic now lives in `@flaim/worker-shared` (`src/season.ts`); `src/season-utils.ts` stays as a backward-compatible wrapper for local imports.
 - `src/v3/get-league-info.ts` returns canonical start years in `seasonYear`, `settings.season`, and `status.previousSeasons`; ESPN-native end years are only used for upstream ESPN requests.
-- Sleeper league responses keep the season-specific `leagueId` for direct tool calls, and also persist a `recurringLeagueId` during discovery by following Sleeper's `previous_league_id` chain. Read paths prefer the stored recurring ID and only fall back to live chain resolution for legacy rows that do not have it yet.
+- Sleeper league responses keep the season-specific `leagueId` for direct tool calls, and also persist a `recurringLeagueId` during discovery when auth-worker can successfully follow Sleeper's `previous_league_id` chain. Read paths prefer the stored recurring ID and only fall back to live chain resolution for legacy rows or unresolved discovery rows that do not have it yet.
 - During the `sleeper_leagues.recurring_league_id` rollout, discovery writes retry without that column if the live database schema has not been migrated yet, which preserves the legacy read fallback until the migration lands.

--- a/workers/auth-worker/src/__tests__/sleeper-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/sleeper-connect-handlers.test.ts
@@ -578,6 +578,37 @@ describe('sleeper-connect-handlers', () => {
     ]);
   });
 
+  it('falls back to the raw leagueId when Sleeper returns a null league body for legacy rows', async () => {
+    mockStorage.getSleeperLeagues.mockResolvedValue([
+      {
+        id: 'row-null',
+        clerkUserId: 'user_1',
+        leagueId: 'null-2025',
+        sport: 'football',
+        seasonYear: 2025,
+        leagueName: 'Dynasty Squad',
+        rosterId: 7,
+        recurringLeagueId: undefined,
+        sleeperUserId: 'sleeper_123',
+      },
+    ]);
+
+    mockFetch.mockResolvedValue(jsonResponse(null, 200));
+
+    const response = await handleSleeperLeagues(env, 'user_1', corsHeaders);
+    const body = (await response.json()) as {
+      leagues: Array<{ leagueId: string; recurringLeagueId: string }>;
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.leagues).toEqual([
+      expect.objectContaining({
+        leagueId: 'null-2025',
+        recurringLeagueId: 'null-2025',
+      }),
+    ]);
+  });
+
   it('falls back to the raw leagueId when recurring history contains a cycle for legacy rows', async () => {
     mockStorage.getSleeperLeagues.mockResolvedValue([
       {

--- a/workers/auth-worker/src/__tests__/sleeper-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/sleeper-connect-handlers.test.ts
@@ -292,6 +292,68 @@ describe('sleeper-connect-handlers', () => {
     );
   });
 
+  it('does not persist a synthetic recurringLeagueId when history lookup fails during discovery', async () => {
+    mockFetch.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith('/user/history_gap')) {
+        return jsonResponse({
+          user_id: 'sleeper_gap',
+          username: 'history_gap',
+          display_name: 'History Gap',
+        });
+      }
+      if (url.includes('/user/sleeper_gap/leagues/nfl/2025')) {
+        return jsonResponse([
+          {
+            league_id: 'gap-2025',
+            name: 'Dynasty Squad',
+            sport: 'nfl',
+            season: '2025',
+            previous_league_id: 'gap-2024',
+          },
+        ]);
+      }
+      if (url.includes('/user/sleeper_gap/leagues/nba/2024')) {
+        return jsonResponse([]);
+      }
+      if (url.endsWith('/league/gap-2024')) {
+        return new Response(null, { status: 503 });
+      }
+      if (url.includes('/league/gap-2025/rosters')) {
+        return jsonResponse([
+          { roster_id: 7, owner_id: 'sleeper_gap' },
+        ]);
+      }
+      return new Response(null, { status: 404 });
+    });
+
+    const request = new Request('https://api.flaim.app/connect/sleeper/discover', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 'history_gap' }),
+    });
+
+    const response = await handleSleeperDiscover(request, env, 'user_1', corsHeaders);
+    const body = (await response.json()) as {
+      success: boolean;
+      leagues_found: number;
+      seasons_discovered: number;
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.leagues_found).toBe(1);
+    expect(body.seasons_discovered).toBe(1);
+    expect(mockStorage.saveSleeperLeague).toHaveBeenCalledOnce();
+    expect(mockStorage.saveSleeperLeague).toHaveBeenCalledWith(
+      expect.objectContaining({
+        leagueId: 'gap-2025',
+        seasonYear: 2025,
+      }),
+    );
+    expect(mockStorage.saveSleeperLeague.mock.calls[0][0]).not.toHaveProperty('recurringLeagueId');
+  });
+
   it('returns stored recurringLeagueId without extra Sleeper fetches', async () => {
     mockStorage.getSleeperLeagues.mockResolvedValue([
       {

--- a/workers/auth-worker/src/__tests__/sleeper-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/sleeper-connect-handlers.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi, type MockedFunction } from 'vitest';
-import { handleSleeperDiscover, type SleeperConnectEnv } from '../sleeper-connect-handlers';
+import { handleSleeperDiscover, handleSleeperLeagues, type SleeperConnectEnv } from '../sleeper-connect-handlers';
 import { SleeperStorage } from '../sleeper-storage';
 import { getDefaultSeasonYear } from '../season-utils';
 
@@ -36,6 +36,7 @@ describe('sleeper-connect-handlers', () => {
   let mockStorage: {
     saveSleeperConnection: ReturnType<typeof vi.fn>;
     saveSleeperLeague: ReturnType<typeof vi.fn>;
+    getSleeperLeagues: ReturnType<typeof vi.fn>;
   };
 
   beforeEach(() => {
@@ -45,6 +46,7 @@ describe('sleeper-connect-handlers', () => {
     mockStorage = {
       saveSleeperConnection: vi.fn().mockResolvedValue(undefined),
       saveSleeperLeague: vi.fn().mockResolvedValue(undefined),
+      getSleeperLeagues: vi.fn().mockResolvedValue([]),
     };
 
     vi.mocked(SleeperStorage.fromEnvironment).mockReturnValue(mockStorage as unknown as SleeperStorage);
@@ -203,5 +205,102 @@ describe('sleeper-connect-handlers', () => {
         rosterId: 7,
       }),
     );
+  });
+
+  it('includes recurringLeagueId when the Sleeper history chain resolves', async () => {
+    mockStorage.getSleeperLeagues.mockResolvedValue([
+      {
+        id: 'row-2025',
+        clerkUserId: 'user_1',
+        leagueId: 'sleeper-2025',
+        sport: 'football',
+        seasonYear: 2025,
+        leagueName: 'Dynasty Squad',
+        rosterId: 7,
+        sleeperUserId: 'sleeper_123',
+      },
+      {
+        id: 'row-2024',
+        clerkUserId: 'user_1',
+        leagueId: 'sleeper-2024',
+        sport: 'football',
+        seasonYear: 2024,
+        leagueName: 'Dynasty Squad',
+        rosterId: 7,
+        sleeperUserId: 'sleeper_123',
+      },
+    ]);
+
+    mockFetch.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith('/league/sleeper-2025')) {
+        return jsonResponse({
+          league_id: 'sleeper-2025',
+          name: 'Dynasty Squad',
+          sport: 'nfl',
+          season: '2025',
+          previous_league_id: 'sleeper-2024',
+        });
+      }
+      if (url.endsWith('/league/sleeper-2024')) {
+        return jsonResponse({
+          league_id: 'sleeper-2024',
+          name: 'Dynasty Squad',
+          sport: 'nfl',
+          season: '2024',
+          previous_league_id: null,
+        });
+      }
+      return new Response(null, { status: 404 });
+    });
+
+    const response = await handleSleeperLeagues(env, 'user_1', corsHeaders);
+    const body = (await response.json()) as {
+      leagues: Array<{ leagueId: string; recurringLeagueId: string; seasonYear: number }>;
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.leagues).toEqual([
+      expect.objectContaining({
+        leagueId: 'sleeper-2025',
+        recurringLeagueId: 'sleeper-2024',
+        seasonYear: 2025,
+      }),
+      expect.objectContaining({
+        leagueId: 'sleeper-2024',
+        recurringLeagueId: 'sleeper-2024',
+        seasonYear: 2024,
+      }),
+    ]);
+  });
+
+  it('falls back to the raw leagueId when recurring chain lookup fails', async () => {
+    mockStorage.getSleeperLeagues.mockResolvedValue([
+      {
+        id: 'row-2025',
+        clerkUserId: 'user_1',
+        leagueId: 'sleeper-2025',
+        sport: 'football',
+        seasonYear: 2025,
+        leagueName: 'Dynasty Squad',
+        rosterId: 7,
+        sleeperUserId: 'sleeper_123',
+      },
+    ]);
+
+    mockFetch.mockResolvedValue(new Response(null, { status: 503 }));
+
+    const response = await handleSleeperLeagues(env, 'user_1', corsHeaders);
+    const body = (await response.json()) as {
+      leagues: Array<{ leagueId: string; recurringLeagueId: string }>;
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.leagues).toEqual([
+      expect.objectContaining({
+        leagueId: 'sleeper-2025',
+        recurringLeagueId: 'sleeper-2025',
+      }),
+    ]);
   });
 });

--- a/workers/auth-worker/src/__tests__/sleeper-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/sleeper-connect-handlers.test.ts
@@ -292,6 +292,92 @@ describe('sleeper-connect-handlers', () => {
     );
   });
 
+  it('persists the verified recurring root for long Sleeper history chains', async () => {
+    const currentYear = 2025;
+    const rootYear = 1998;
+
+    mockFetch.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith('/user/deep_history')) {
+        return jsonResponse({
+          user_id: 'sleeper_deep',
+          username: 'deep_history',
+          display_name: 'Deep History',
+        });
+      }
+      if (url.includes('/user/sleeper_deep/leagues/nfl/2025')) {
+        return jsonResponse([
+          {
+            league_id: `deep-${currentYear}`,
+            name: 'Dynasty Squad',
+            sport: 'nfl',
+            season: String(currentYear),
+            previous_league_id: `deep-${currentYear - 1}`,
+          },
+        ]);
+      }
+      if (url.includes('/user/sleeper_deep/leagues/nba/2024')) {
+        return jsonResponse([]);
+      }
+
+      const rosterMatch = url.match(/\/league\/deep-(\d{4})\/rosters$/);
+      if (rosterMatch) {
+        return jsonResponse([
+          { roster_id: 7, owner_id: 'sleeper_deep' },
+        ]);
+      }
+
+      const leagueMatch = url.match(/\/league\/deep-(\d{4})$/);
+      if (leagueMatch) {
+        const year = Number(leagueMatch[1]);
+        return jsonResponse({
+          league_id: `deep-${year}`,
+          name: 'Dynasty Squad',
+          sport: 'nfl',
+          season: String(year),
+          previous_league_id: year > rootYear ? `deep-${year - 1}` : null,
+        });
+      }
+
+      return new Response(null, { status: 404 });
+    });
+
+    const request = new Request('https://api.flaim.app/connect/sleeper/discover', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 'deep_history' }),
+    });
+
+    const response = await handleSleeperDiscover(request, env, 'user_1', corsHeaders);
+    const body = (await response.json()) as {
+      success: boolean;
+      leagues_found: number;
+      seasons_discovered: number;
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.leagues_found).toBe(5);
+    expect(body.seasons_discovered).toBe(5);
+    expect(mockStorage.saveSleeperLeague).toHaveBeenCalledTimes(5);
+    expect(mockStorage.saveSleeperLeague).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        leagueId: 'deep-2025',
+        seasonYear: 2025,
+        recurringLeagueId: `deep-${rootYear}`,
+      }),
+    );
+    expect(mockStorage.saveSleeperLeague).toHaveBeenNthCalledWith(
+      5,
+      expect.objectContaining({
+        leagueId: 'deep-2021',
+        seasonYear: 2021,
+        recurringLeagueId: `deep-${rootYear}`,
+      }),
+    );
+  });
+
   it('does not persist a synthetic recurringLeagueId when history lookup fails during discovery', async () => {
     mockFetch.mockImplementation(async (input) => {
       const url = String(input);

--- a/workers/auth-worker/src/__tests__/sleeper-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/sleeper-connect-handlers.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, it, vi, type MockedFunction } from 'vitest';
-import { handleSleeperDiscover, handleSleeperLeagues, type SleeperConnectEnv } from '../sleeper-connect-handlers';
+import {
+  handleSleeperDiscover,
+  handleSleeperLeagueDelete,
+  handleSleeperLeagues,
+  type SleeperConnectEnv,
+} from '../sleeper-connect-handlers';
 import { SleeperStorage } from '../sleeper-storage';
 import { getDefaultSeasonYear } from '../season-utils';
 
@@ -36,6 +41,7 @@ describe('sleeper-connect-handlers', () => {
   let mockStorage: {
     saveSleeperConnection: ReturnType<typeof vi.fn>;
     saveSleeperLeague: ReturnType<typeof vi.fn>;
+    deleteSleeperLeague: ReturnType<typeof vi.fn>;
     getSleeperLeagues: ReturnType<typeof vi.fn>;
   };
 
@@ -46,6 +52,7 @@ describe('sleeper-connect-handlers', () => {
     mockStorage = {
       saveSleeperConnection: vi.fn().mockResolvedValue(undefined),
       saveSleeperLeague: vi.fn().mockResolvedValue(undefined),
+      deleteSleeperLeague: vi.fn().mockResolvedValue(undefined),
       getSleeperLeagues: vi.fn().mockResolvedValue([]),
     };
 
@@ -203,11 +210,136 @@ describe('sleeper-connect-handlers', () => {
         sport: 'football',
         seasonYear: 2025,
         rosterId: 7,
+        recurringLeagueId: 'league_nfl_1',
       }),
     );
   });
 
-  it('includes recurringLeagueId when the Sleeper history chain resolves', async () => {
+  it('persists recurringLeagueId during discovery for every season in the history chain', async () => {
+    mockFetch.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith('/user/history_user')) {
+        return jsonResponse({
+          user_id: 'sleeper_history',
+          username: 'history_user',
+          display_name: 'History User',
+        });
+      }
+      if (url.includes('/user/sleeper_history/leagues/nfl/2025')) {
+        return jsonResponse([
+          {
+            league_id: 'chain-2025',
+            name: 'Dynasty Squad',
+            sport: 'nfl',
+            season: '2025',
+            previous_league_id: 'chain-2024',
+          },
+        ]);
+      }
+      if (url.includes('/user/sleeper_history/leagues/nba/2024')) {
+        return jsonResponse([]);
+      }
+      if (url.endsWith('/league/chain-2024')) {
+        return jsonResponse({
+          league_id: 'chain-2024',
+          name: 'Dynasty Squad',
+          sport: 'nfl',
+          season: '2024',
+          previous_league_id: null,
+        });
+      }
+      if (url.includes('/league/chain-2025/rosters') || url.includes('/league/chain-2024/rosters')) {
+        return jsonResponse([
+          { roster_id: 7, owner_id: 'sleeper_history' },
+        ]);
+      }
+      return new Response(null, { status: 404 });
+    });
+
+    const request = new Request('https://api.flaim.app/connect/sleeper/discover', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 'history_user' }),
+    });
+
+    const response = await handleSleeperDiscover(request, env, 'user_1', corsHeaders);
+    const body = (await response.json()) as {
+      success: boolean;
+      leagues_found: number;
+      seasons_discovered: number;
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.leagues_found).toBe(2);
+    expect(body.seasons_discovered).toBe(2);
+    expect(mockStorage.saveSleeperLeague).toHaveBeenCalledTimes(2);
+    expect(mockStorage.saveSleeperLeague).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        leagueId: 'chain-2025',
+        seasonYear: 2025,
+        recurringLeagueId: 'chain-2024',
+      }),
+    );
+    expect(mockStorage.saveSleeperLeague).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        leagueId: 'chain-2024',
+        seasonYear: 2024,
+        recurringLeagueId: 'chain-2024',
+      }),
+    );
+  });
+
+  it('returns stored recurringLeagueId without extra Sleeper fetches', async () => {
+    mockStorage.getSleeperLeagues.mockResolvedValue([
+      {
+        id: 'row-2025',
+        clerkUserId: 'user_1',
+        leagueId: 'sleeper-2025',
+        sport: 'football',
+        seasonYear: 2025,
+        leagueName: 'Dynasty Squad',
+        rosterId: 7,
+        recurringLeagueId: 'sleeper-root',
+        sleeperUserId: 'sleeper_123',
+      },
+      {
+        id: 'row-2024',
+        clerkUserId: 'user_1',
+        leagueId: 'sleeper-2024',
+        sport: 'football',
+        seasonYear: 2024,
+        leagueName: 'Dynasty Squad',
+        rosterId: 7,
+        recurringLeagueId: 'sleeper-root',
+        sleeperUserId: 'sleeper_123',
+      },
+    ]);
+
+    const response = await handleSleeperLeagues(env, 'user_1', corsHeaders);
+    const body = (await response.json()) as {
+      leagues: Array<{ leagueId: string; recurringLeagueId: string; seasonYear: number }>;
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.leagues).toEqual([
+      expect.objectContaining({
+        leagueId: 'sleeper-2025',
+        recurringLeagueId: 'sleeper-root',
+        seasonYear: 2025,
+      }),
+      expect.objectContaining({
+        leagueId: 'sleeper-2024',
+        recurringLeagueId: 'sleeper-root',
+        seasonYear: 2024,
+      }),
+    ]);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('uses stored recurringLeagueId values before legacy fallback fetches', async () => {
     mockStorage.getSleeperLeagues.mockResolvedValue([
       {
         id: 'row-2025',
@@ -227,6 +359,7 @@ describe('sleeper-connect-handlers', () => {
         seasonYear: 2024,
         leagueName: 'Dynasty Squad',
         rosterId: 7,
+        recurringLeagueId: 'sleeper-root',
         sleeperUserId: 'sleeper_123',
       },
     ]);
@@ -242,15 +375,6 @@ describe('sleeper-connect-handlers', () => {
           previous_league_id: 'sleeper-2024',
         });
       }
-      if (url.endsWith('/league/sleeper-2024')) {
-        return jsonResponse({
-          league_id: 'sleeper-2024',
-          name: 'Dynasty Squad',
-          sport: 'nfl',
-          season: '2024',
-          previous_league_id: null,
-        });
-      }
       return new Response(null, { status: 404 });
     });
 
@@ -263,18 +387,19 @@ describe('sleeper-connect-handlers', () => {
     expect(body.leagues).toEqual([
       expect.objectContaining({
         leagueId: 'sleeper-2025',
-        recurringLeagueId: 'sleeper-2024',
+        recurringLeagueId: 'sleeper-root',
         seasonYear: 2025,
       }),
       expect.objectContaining({
         leagueId: 'sleeper-2024',
-        recurringLeagueId: 'sleeper-2024',
+        recurringLeagueId: 'sleeper-root',
         seasonYear: 2024,
       }),
     ]);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
-  it('falls back to the raw leagueId when recurring chain lookup fails', async () => {
+  it('falls back to the raw leagueId when recurring chain lookup fails for legacy rows', async () => {
     mockStorage.getSleeperLeagues.mockResolvedValue([
       {
         id: 'row-2025',
@@ -284,6 +409,7 @@ describe('sleeper-connect-handlers', () => {
         seasonYear: 2025,
         leagueName: 'Dynasty Squad',
         rosterId: 7,
+        recurringLeagueId: undefined,
         sleeperUserId: 'sleeper_123',
       },
     ]);
@@ -302,5 +428,38 @@ describe('sleeper-connect-handlers', () => {
         recurringLeagueId: 'sleeper-2025',
       }),
     ]);
+  });
+
+  it('returns recurringLeagueId on the delete response without refetching legacy chain data', async () => {
+    mockStorage.getSleeperLeagues.mockResolvedValue([
+      {
+        id: 'row-2024',
+        clerkUserId: 'user_1',
+        leagueId: 'sleeper-2024',
+        sport: 'football',
+        seasonYear: 2024,
+        leagueName: 'Dynasty Squad',
+        rosterId: 7,
+        recurringLeagueId: 'sleeper-root',
+        sleeperUserId: 'sleeper_123',
+      },
+    ]);
+
+    const response = await handleSleeperLeagueDelete(env, 'user_1', 'row-2025', corsHeaders);
+    const body = (await response.json()) as {
+      success: boolean;
+      leagues: Array<{ leagueId: string; recurringLeagueId: string }>;
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(mockStorage.deleteSleeperLeague).toHaveBeenCalledWith('user_1', 'row-2025');
+    expect(body.leagues).toEqual([
+      expect.objectContaining({
+        leagueId: 'sleeper-2024',
+        recurringLeagueId: 'sleeper-root',
+      }),
+    ]);
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 });

--- a/workers/auth-worker/src/__tests__/sleeper-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/sleeper-connect-handlers.test.ts
@@ -492,6 +492,59 @@ describe('sleeper-connect-handlers', () => {
     ]);
   });
 
+  it('falls back to the raw leagueId when recurring history contains a cycle for legacy rows', async () => {
+    mockStorage.getSleeperLeagues.mockResolvedValue([
+      {
+        id: 'row-cycle',
+        clerkUserId: 'user_1',
+        leagueId: 'cycle-2025',
+        sport: 'football',
+        seasonYear: 2025,
+        leagueName: 'Dynasty Squad',
+        rosterId: 7,
+        recurringLeagueId: undefined,
+        sleeperUserId: 'sleeper_123',
+      },
+    ]);
+
+    mockFetch.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith('/league/cycle-2025')) {
+        return jsonResponse({
+          league_id: 'cycle-2025',
+          name: 'Dynasty Squad',
+          sport: 'nfl',
+          season: '2025',
+          previous_league_id: 'cycle-2024',
+        });
+      }
+      if (url.endsWith('/league/cycle-2024')) {
+        return jsonResponse({
+          league_id: 'cycle-2024',
+          name: 'Dynasty Squad',
+          sport: 'nfl',
+          season: '2024',
+          previous_league_id: 'cycle-2025',
+        });
+      }
+      return new Response(null, { status: 404 });
+    });
+
+    const response = await handleSleeperLeagues(env, 'user_1', corsHeaders);
+    const body = (await response.json()) as {
+      leagues: Array<{ leagueId: string; recurringLeagueId: string }>;
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.leagues).toEqual([
+      expect.objectContaining({
+        leagueId: 'cycle-2025',
+        recurringLeagueId: 'cycle-2025',
+      }),
+    ]);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
   it('returns recurringLeagueId on the delete response without refetching legacy chain data', async () => {
     mockStorage.getSleeperLeagues.mockResolvedValue([
       {

--- a/workers/auth-worker/src/__tests__/sleeper-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/sleeper-storage.test.ts
@@ -122,6 +122,59 @@ describe('SleeperStorage', () => {
       expect(mockUpsert).toHaveBeenCalledOnce();
       expect(mockUpsert.mock.calls[0][0]).not.toHaveProperty('recurring_league_id');
     });
+
+    it('retries without recurringLeagueId when PostgREST schema cache is stale', async () => {
+      mockUpsert
+        .mockReturnValueOnce({
+          error: {
+            code: 'PGRST204',
+            message: "Could not find the 'recurring_league_id' column in the schema cache",
+          },
+        })
+        .mockReturnValue({ error: null });
+
+      await storage.saveSleeperLeague({
+        clerkUserId: 'user_123',
+        leagueId: 'league-2026',
+        sport: 'football',
+        seasonYear: 2026,
+        leagueName: 'Dynasty Squad',
+        rosterId: 7,
+        recurringLeagueId: 'league-root',
+        sleeperUserId: 'sleeper_123',
+      });
+
+      expect(mockUpsert).toHaveBeenCalledTimes(2);
+      expect(mockUpsert.mock.calls[0][0]).toMatchObject({
+        league_id: 'league-2026',
+        recurring_league_id: 'league-root',
+      });
+      expect(mockUpsert.mock.calls[1][0]).not.toHaveProperty('recurring_league_id');
+    });
+
+    it('does not treat unrelated errors as a missing recurringLeagueId column', async () => {
+      mockUpsert.mockReturnValueOnce({
+        error: {
+          code: '42501',
+          message: 'permission denied while writing recurring_league_id',
+        },
+      });
+
+      await expect(
+        storage.saveSleeperLeague({
+          clerkUserId: 'user_123',
+          leagueId: 'league-2027',
+          sport: 'football',
+          seasonYear: 2027,
+          leagueName: 'Dynasty Squad',
+          rosterId: 7,
+          recurringLeagueId: 'league-root',
+          sleeperUserId: 'sleeper_123',
+        })
+      ).rejects.toThrow('Failed to save Sleeper league: permission denied while writing recurring_league_id');
+
+      expect(mockUpsert).toHaveBeenCalledOnce();
+    });
   });
 
   // ===========================================================================

--- a/workers/auth-worker/src/__tests__/sleeper-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/sleeper-storage.test.ts
@@ -53,6 +53,77 @@ describe('SleeperStorage', () => {
     vi.restoreAllMocks();
   });
 
+  describe('saveSleeperLeague', () => {
+    it('persists recurringLeagueId when the column is available', async () => {
+      await storage.saveSleeperLeague({
+        clerkUserId: 'user_123',
+        leagueId: 'league-2025',
+        sport: 'football',
+        seasonYear: 2025,
+        leagueName: 'Dynasty Squad',
+        rosterId: 7,
+        recurringLeagueId: 'league-root',
+        sleeperUserId: 'sleeper_123',
+      });
+
+      expect(mockFrom).toHaveBeenCalledWith('sleeper_leagues');
+      expect(mockUpsert).toHaveBeenCalledOnce();
+      const payload = mockUpsert.mock.calls[0][0];
+      expect(payload).toMatchObject({
+        league_id: 'league-2025',
+        recurring_league_id: 'league-root',
+      });
+    });
+
+    it('retries without recurringLeagueId when the column is unavailable', async () => {
+      mockUpsert
+        .mockReturnValueOnce({
+          error: {
+            code: '42703',
+            message: 'column sleeper_leagues.recurring_league_id does not exist',
+          },
+        })
+        .mockReturnValue({ error: null });
+
+      await storage.saveSleeperLeague({
+        clerkUserId: 'user_123',
+        leagueId: 'league-2025',
+        sport: 'football',
+        seasonYear: 2025,
+        leagueName: 'Dynasty Squad',
+        rosterId: 7,
+        recurringLeagueId: 'league-root',
+        sleeperUserId: 'sleeper_123',
+      });
+
+      expect(mockUpsert).toHaveBeenCalledTimes(2);
+      expect(mockUpsert.mock.calls[0][0]).toMatchObject({
+        league_id: 'league-2025',
+        recurring_league_id: 'league-root',
+      });
+      expect(mockUpsert.mock.calls[1][0]).toMatchObject({
+        league_id: 'league-2025',
+      });
+      expect(mockUpsert.mock.calls[1][0]).not.toHaveProperty('recurring_league_id');
+
+      mockUpsert.mockClear();
+
+      await storage.saveSleeperLeague({
+        clerkUserId: 'user_123',
+        leagueId: 'league-2024',
+        sport: 'football',
+        seasonYear: 2024,
+        leagueName: 'Dynasty Squad',
+        rosterId: 7,
+        recurringLeagueId: 'league-root',
+        sleeperUserId: 'sleeper_123',
+      });
+
+      expect(mockUpsert).toHaveBeenCalledOnce();
+      expect(mockUpsert.mock.calls[0][0]).not.toHaveProperty('recurring_league_id');
+    });
+  });
+
   // ===========================================================================
   // deleteSleeperLeague Tests
   // ===========================================================================

--- a/workers/auth-worker/src/sleeper-connect-handlers.ts
+++ b/workers/auth-worker/src/sleeper-connect-handlers.ts
@@ -1,8 +1,9 @@
-import { SleeperStorage } from './sleeper-storage';
+import { SleeperStorage, type SleeperLeague } from './sleeper-storage';
 import { getDefaultSeasonYear } from './season-utils';
 
 const SLEEPER_API = 'https://api.sleeper.app/v1';
 const MAX_HISTORY_YEARS = 5;
+const MAX_RECURRING_CHAIN_DEPTH = 25;
 
 export interface SleeperConnectEnv {
   SUPABASE_URL: string;
@@ -28,6 +29,16 @@ interface SleeperApiRoster {
   owner_id: string;
 }
 
+interface SleeperLeagueResponse {
+  id: string;
+  sport: string;
+  leagueId: string;
+  leagueName: string;
+  rosterId: number | null;
+  seasonYear: number;
+  recurringLeagueId: string;
+}
+
 function mapSport(sleeperSport: string): string {
   if (sleeperSport === 'nfl') return 'football';
   if (sleeperSport === 'nba') return 'basketball';
@@ -40,6 +51,60 @@ async function sleeperGet<T>(path: string): Promise<T> {
   });
   if (!res.ok) throw new Error(`Sleeper API ${res.status}: ${path}`);
   return res.json() as Promise<T>;
+}
+
+async function resolveRecurringLeagueId(
+  leagueId: string,
+  cache: Map<string, string>,
+  depth = 0,
+  visited = new Set<string>()
+): Promise<string> {
+  const cached = cache.get(leagueId);
+  if (cached) return cached;
+
+  if (depth >= MAX_RECURRING_CHAIN_DEPTH || visited.has(leagueId)) {
+    cache.set(leagueId, leagueId);
+    return leagueId;
+  }
+
+  visited.add(leagueId);
+
+  try {
+    const league = await sleeperGet<SleeperApiLeague>(`/league/${leagueId}`);
+    if (!league.previous_league_id) {
+      cache.set(leagueId, leagueId);
+      return leagueId;
+    }
+
+    const recurringLeagueId = await resolveRecurringLeagueId(league.previous_league_id, cache, depth + 1, visited);
+    cache.set(leagueId, recurringLeagueId);
+    return recurringLeagueId;
+  } catch (error) {
+    console.warn(`[sleeper-connect] Failed to resolve recurring league for ${leagueId}:`, error);
+    cache.set(leagueId, leagueId);
+    return leagueId;
+  }
+}
+
+async function buildSleeperLeagueResponse(leagues: SleeperLeague[]): Promise<SleeperLeagueResponse[]> {
+  const recurringIdCache = new Map<string, string>();
+  const responseLeagues: SleeperLeagueResponse[] = [];
+
+  // Process sequentially so chain resolution can reuse cached roots from newer seasons.
+  for (const league of leagues) {
+    const recurringLeagueId = await resolveRecurringLeagueId(league.leagueId, recurringIdCache);
+    responseLeagues.push({
+      id: league.id,
+      sport: league.sport,
+      leagueId: league.leagueId,
+      leagueName: league.leagueName,
+      rosterId: league.rosterId,
+      seasonYear: league.seasonYear,
+      recurringLeagueId,
+    });
+  }
+
+  return responseLeagues;
 }
 
 export async function handleSleeperDiscover(
@@ -211,16 +276,10 @@ export async function handleSleeperLeagues(
   try {
     const storage = SleeperStorage.fromEnvironment(env);
     const leagues = await storage.getSleeperLeagues(userId);
+    const responseLeagues = await buildSleeperLeagueResponse(leagues);
     return new Response(
       JSON.stringify({
-        leagues: leagues.map((l) => ({
-          id: l.id,
-          sport: l.sport,
-          leagueId: l.leagueId,
-          leagueName: l.leagueName,
-          rosterId: l.rosterId,
-          seasonYear: l.seasonYear,
-        })),
+        leagues: responseLeagues,
       }),
       { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
@@ -243,17 +302,11 @@ export async function handleSleeperLeagueDelete(
     const storage = SleeperStorage.fromEnvironment(env);
     await storage.deleteSleeperLeague(userId, leagueId);
     const leagues = await storage.getSleeperLeagues(userId);
+    const responseLeagues = await buildSleeperLeagueResponse(leagues);
     return new Response(
       JSON.stringify({
         success: true,
-        leagues: leagues.map((l) => ({
-          id: l.id,
-          sport: l.sport,
-          leagueId: l.leagueId,
-          leagueName: l.leagueName,
-          rosterId: l.rosterId,
-          seasonYear: l.seasonYear,
-        })),
+        leagues: responseLeagues,
       }),
       { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );

--- a/workers/auth-worker/src/sleeper-connect-handlers.ts
+++ b/workers/auth-worker/src/sleeper-connect-handlers.ts
@@ -3,7 +3,6 @@ import { getDefaultSeasonYear } from './season-utils';
 
 const SLEEPER_API = 'https://api.sleeper.app/v1';
 const MAX_HISTORY_YEARS = 5;
-const MAX_RECURRING_CHAIN_DEPTH = 25;
 
 export interface SleeperConnectEnv {
   SUPABASE_URL: string;
@@ -92,45 +91,60 @@ function describeSleeperResolutionFailure(leagueId: string, error: unknown): str
 
 async function tryResolveRecurringLeagueId(
   leagueId: string,
-  cache: Map<string, string>,
-  leagueCache: Map<string, Promise<SleeperApiLeague>>,
-  depth = 0,
-  visited = new Set<string>()
+  cache: Map<string, string | null>,
+  leagueCache: Map<string, Promise<SleeperApiLeague>>
 ): Promise<RecurringLeagueResolutionResult> {
-  const cached = cache.get(leagueId);
-  if (cached) return { recurringLeagueId: cached };
+  const path: string[] = [];
+  const visited = new Set<string>();
+  let currentLeagueId: string | null = leagueId;
 
-  if (depth >= MAX_RECURRING_CHAIN_DEPTH || visited.has(leagueId)) {
-    return {
-      failureReason: depth >= MAX_RECURRING_CHAIN_DEPTH
-        ? `exceeded recurring chain depth ${MAX_RECURRING_CHAIN_DEPTH} at ${leagueId}`
-        : `detected recurring league cycle at ${leagueId}`,
-    };
-  }
+  while (currentLeagueId) {
+    if (cache.has(currentLeagueId)) {
+      const cached = cache.get(currentLeagueId) ?? null;
+      for (const pathLeagueId of path) {
+        cache.set(pathLeagueId, cached);
+      }
 
-  visited.add(leagueId);
-
-  try {
-    const league = await getSleeperLeague(leagueId, leagueCache);
-    if (!league.previous_league_id) {
-      cache.set(leagueId, leagueId);
-      return { recurringLeagueId: leagueId };
+      return cached
+        ? { recurringLeagueId: cached }
+        : { failureReason: `unresolved recurring chain at ${currentLeagueId}` };
     }
 
-    const resolution = await tryResolveRecurringLeagueId(league.previous_league_id, cache, leagueCache, depth + 1, visited);
-    if (!resolution.recurringLeagueId) {
-      return resolution;
+    if (visited.has(currentLeagueId)) {
+      for (const pathLeagueId of path) {
+        cache.set(pathLeagueId, null);
+      }
+      return { failureReason: `detected recurring league cycle at ${currentLeagueId}` };
     }
-    cache.set(leagueId, resolution.recurringLeagueId);
-    return { recurringLeagueId: resolution.recurringLeagueId };
-  } catch (error) {
-    return { failureReason: describeSleeperResolutionFailure(leagueId, error) };
+
+    visited.add(currentLeagueId);
+    path.push(currentLeagueId);
+
+    try {
+      const league = await getSleeperLeague(currentLeagueId, leagueCache);
+      if (!league.previous_league_id) {
+        for (const pathLeagueId of path) {
+          cache.set(pathLeagueId, league.league_id);
+        }
+        return { recurringLeagueId: league.league_id };
+      }
+
+      currentLeagueId = league.previous_league_id;
+    } catch (error) {
+      const failureReason = describeSleeperResolutionFailure(currentLeagueId, error);
+      for (const pathLeagueId of path) {
+        cache.set(pathLeagueId, null);
+      }
+      return { failureReason };
+    }
   }
+
+  return { failureReason: `unresolved recurring chain at ${leagueId}` };
 }
 
 async function resolveRecurringLeagueId(
   leagueId: string,
-  cache: Map<string, string>,
+  cache: Map<string, string | null>,
   leagueCache: Map<string, Promise<SleeperApiLeague>>
 ): Promise<string> {
   const resolution = await tryResolveRecurringLeagueId(leagueId, cache, leagueCache);
@@ -141,12 +155,11 @@ async function resolveRecurringLeagueId(
   console.warn(
     `[sleeper-connect] Falling back to season-scoped leagueId ${leagueId} for recurring grouping: ${resolution.failureReason ?? 'unresolved recurring chain'}`
   );
-  cache.set(leagueId, leagueId);
   return leagueId;
 }
 
 async function buildSleeperLeagueResponse(leagues: SleeperLeague[]): Promise<SleeperLeagueResponse[]> {
-  const recurringIdCache = new Map<string, string>();
+  const recurringIdCache = new Map<string, string | null>();
   const leagueCache = new Map<string, Promise<SleeperApiLeague>>();
   for (const league of leagues) {
     if (league.recurringLeagueId) {
@@ -217,7 +230,7 @@ export async function handleSleeperDiscover(
     const currentLeagues = [...(nflLeagues ?? []), ...(nbaLeagues ?? [])];
     let totalSaved = 0;
     const seasonsDiscovered = new Set<string>();
-    const recurringIdCache = new Map<string, string>();
+    const recurringIdCache = new Map<string, string | null>();
     const leagueCache = new Map<string, Promise<SleeperApiLeague>>();
     const processedLeagueIds = new Set<string>();
 

--- a/workers/auth-worker/src/sleeper-connect-handlers.ts
+++ b/workers/auth-worker/src/sleeper-connect-handlers.ts
@@ -39,6 +39,11 @@ interface SleeperLeagueResponse {
   recurringLeagueId: string;
 }
 
+interface RecurringLeagueResolutionResult {
+  recurringLeagueId?: string;
+  failureReason?: string;
+}
+
 function mapSport(sleeperSport: string): string {
   if (sleeperSport === 'nfl') return 'football';
   if (sleeperSport === 'nba') return 'basketball';
@@ -74,18 +79,33 @@ async function getSleeperLeague(
   return request;
 }
 
+function describeSleeperResolutionFailure(leagueId: string, error: unknown): string {
+  if (error instanceof Error) {
+    const statusMatch = error.message.match(/Sleeper API (\d{3}):/);
+    if (statusMatch) {
+      return `Sleeper API ${statusMatch[1]} while resolving ${leagueId}`;
+    }
+    return `${error.message} while resolving ${leagueId}`;
+  }
+  return `unknown error while resolving ${leagueId}`;
+}
+
 async function tryResolveRecurringLeagueId(
   leagueId: string,
   cache: Map<string, string>,
   leagueCache: Map<string, Promise<SleeperApiLeague>>,
   depth = 0,
   visited = new Set<string>()
-): Promise<string | undefined> {
+): Promise<RecurringLeagueResolutionResult> {
   const cached = cache.get(leagueId);
-  if (cached) return cached;
+  if (cached) return { recurringLeagueId: cached };
 
   if (depth >= MAX_RECURRING_CHAIN_DEPTH || visited.has(leagueId)) {
-    return undefined;
+    return {
+      failureReason: depth >= MAX_RECURRING_CHAIN_DEPTH
+        ? `exceeded recurring chain depth ${MAX_RECURRING_CHAIN_DEPTH} at ${leagueId}`
+        : `detected recurring league cycle at ${leagueId}`,
+    };
   }
 
   visited.add(leagueId);
@@ -94,18 +114,17 @@ async function tryResolveRecurringLeagueId(
     const league = await getSleeperLeague(leagueId, leagueCache);
     if (!league.previous_league_id) {
       cache.set(leagueId, leagueId);
-      return leagueId;
+      return { recurringLeagueId: leagueId };
     }
 
-    const recurringLeagueId = await tryResolveRecurringLeagueId(league.previous_league_id, cache, leagueCache, depth + 1, visited);
-    if (!recurringLeagueId) {
-      return undefined;
+    const resolution = await tryResolveRecurringLeagueId(league.previous_league_id, cache, leagueCache, depth + 1, visited);
+    if (!resolution.recurringLeagueId) {
+      return resolution;
     }
-    cache.set(leagueId, recurringLeagueId);
-    return recurringLeagueId;
+    cache.set(leagueId, resolution.recurringLeagueId);
+    return { recurringLeagueId: resolution.recurringLeagueId };
   } catch (error) {
-    console.warn(`[sleeper-connect] Failed to resolve recurring league for ${leagueId}:`, error);
-    return undefined;
+    return { failureReason: describeSleeperResolutionFailure(leagueId, error) };
   }
 }
 
@@ -114,11 +133,14 @@ async function resolveRecurringLeagueId(
   cache: Map<string, string>,
   leagueCache: Map<string, Promise<SleeperApiLeague>>
 ): Promise<string> {
-  const recurringLeagueId = await tryResolveRecurringLeagueId(leagueId, cache, leagueCache);
-  if (recurringLeagueId) {
-    return recurringLeagueId;
+  const resolution = await tryResolveRecurringLeagueId(leagueId, cache, leagueCache);
+  if (resolution.recurringLeagueId) {
+    return resolution.recurringLeagueId;
   }
 
+  console.warn(
+    `[sleeper-connect] Falling back to season-scoped leagueId ${leagueId} for recurring grouping: ${resolution.failureReason ?? 'unresolved recurring chain'}`
+  );
   cache.set(leagueId, leagueId);
   return leagueId;
 }
@@ -212,8 +234,10 @@ export async function handleSleeperDiscover(
         const rosters = await sleeperGet<SleeperApiRoster[]>(`/league/${league.league_id}/rosters`);
         const userRoster = rosters?.find((r) => r.owner_id === sleeperUserId);
         rosterId = userRoster?.roster_id ?? null;
-      } catch {
-        // Non-fatal: save without roster_id
+      } catch (error) {
+        console.warn(
+          `[sleeper-connect] Failed to load rosters for ${league.league_id}; saving without rosterId: ${describeSleeperResolutionFailure(league.league_id, error)}`
+        );
       }
 
       const leagueToSave: Parameters<SleeperStorage['saveSleeperLeague']>[0] = {
@@ -240,16 +264,23 @@ export async function handleSleeperDiscover(
           if (prevLeague?.league_id) {
             await processLeague(prevLeague, recurringLeagueId, depth + 1);
           }
-        } catch {
-          // Non-fatal: history traversal best-effort
+        } catch (error) {
+          console.warn(
+            `[sleeper-connect] Failed to traverse previous league ${league.previous_league_id} from ${league.league_id}: ${describeSleeperResolutionFailure(league.previous_league_id, error)}`
+          );
         }
       }
     }
 
     await Promise.all(currentLeagues.map(async (league) => {
       cacheSleeperLeague(leagueCache, league);
-      const recurringLeagueId = await tryResolveRecurringLeagueId(league.league_id, recurringIdCache, leagueCache);
-      await processLeague(league, recurringLeagueId);
+      const resolution = await tryResolveRecurringLeagueId(league.league_id, recurringIdCache, leagueCache);
+      if (!resolution.recurringLeagueId) {
+        console.warn(
+          `[sleeper-connect] Discovery could not persist recurringLeagueId for ${league.league_id}: ${resolution.failureReason ?? 'unresolved recurring chain'}`
+        );
+      }
+      await processLeague(league, resolution.recurringLeagueId);
     }));
 
     return new Response(

--- a/workers/auth-worker/src/sleeper-connect-handlers.ts
+++ b/workers/auth-worker/src/sleeper-connect-handlers.ts
@@ -3,7 +3,7 @@ import { getDefaultSeasonYear } from './season-utils';
 
 const SLEEPER_API = 'https://api.sleeper.app/v1';
 const MAX_HISTORY_YEARS = 5;
-const MAX_RECURRING_CHAIN_DEPTH = 25;
+const MAX_RECURRING_CHAIN_DEPTH = 12;
 
 export interface SleeperConnectEnv {
   SUPABASE_URL: string;
@@ -53,9 +53,31 @@ async function sleeperGet<T>(path: string): Promise<T> {
   return res.json() as Promise<T>;
 }
 
+function cacheSleeperLeague(
+  leagueCache: Map<string, Promise<SleeperApiLeague>>,
+  league: SleeperApiLeague
+): void {
+  leagueCache.set(league.league_id, Promise.resolve(league));
+}
+
+async function getSleeperLeague(
+  leagueId: string,
+  leagueCache: Map<string, Promise<SleeperApiLeague>>
+): Promise<SleeperApiLeague> {
+  const cached = leagueCache.get(leagueId);
+  if (cached) {
+    return cached;
+  }
+
+  const request = sleeperGet<SleeperApiLeague>(`/league/${leagueId}`);
+  leagueCache.set(leagueId, request);
+  return request;
+}
+
 async function resolveRecurringLeagueId(
   leagueId: string,
   cache: Map<string, string>,
+  leagueCache: Map<string, Promise<SleeperApiLeague>>,
   depth = 0,
   visited = new Set<string>()
 ): Promise<string> {
@@ -70,13 +92,13 @@ async function resolveRecurringLeagueId(
   visited.add(leagueId);
 
   try {
-    const league = await sleeperGet<SleeperApiLeague>(`/league/${leagueId}`);
+    const league = await getSleeperLeague(leagueId, leagueCache);
     if (!league.previous_league_id) {
       cache.set(leagueId, leagueId);
       return leagueId;
     }
 
-    const recurringLeagueId = await resolveRecurringLeagueId(league.previous_league_id, cache, depth + 1, visited);
+    const recurringLeagueId = await resolveRecurringLeagueId(league.previous_league_id, cache, leagueCache, depth + 1, visited);
     cache.set(leagueId, recurringLeagueId);
     return recurringLeagueId;
   } catch (error) {
@@ -88,12 +110,19 @@ async function resolveRecurringLeagueId(
 
 async function buildSleeperLeagueResponse(leagues: SleeperLeague[]): Promise<SleeperLeagueResponse[]> {
   const recurringIdCache = new Map<string, string>();
-  const responseLeagues: SleeperLeagueResponse[] = [];
-
-  // Process sequentially so chain resolution can reuse cached roots from newer seasons.
+  const leagueCache = new Map<string, Promise<SleeperApiLeague>>();
   for (const league of leagues) {
-    const recurringLeagueId = await resolveRecurringLeagueId(league.leagueId, recurringIdCache);
-    responseLeagues.push({
+    if (league.recurringLeagueId) {
+      recurringIdCache.set(league.leagueId, league.recurringLeagueId);
+      recurringIdCache.set(league.recurringLeagueId, league.recurringLeagueId);
+    }
+  }
+
+  return Promise.all(leagues.map(async (league) => {
+    const recurringLeagueId = league.recurringLeagueId
+      ?? await resolveRecurringLeagueId(league.leagueId, recurringIdCache, leagueCache);
+
+    return {
       id: league.id,
       sport: league.sport,
       leagueId: league.leagueId,
@@ -101,10 +130,8 @@ async function buildSleeperLeagueResponse(leagues: SleeperLeague[]): Promise<Sle
       rosterId: league.rosterId,
       seasonYear: league.seasonYear,
       recurringLeagueId,
-    });
-  }
-
-  return responseLeagues;
+    };
+  }));
 }
 
 export async function handleSleeperDiscover(
@@ -153,10 +180,16 @@ export async function handleSleeperDiscover(
     const currentLeagues = [...(nflLeagues ?? []), ...(nbaLeagues ?? [])];
     let totalSaved = 0;
     const seasonsDiscovered = new Set<string>();
+    const recurringIdCache = new Map<string, string>();
+    const leagueCache = new Map<string, Promise<SleeperApiLeague>>();
+    const processedLeagueIds = new Set<string>();
 
     // Process each league and traverse history chain
-    async function processLeague(league: SleeperApiLeague, depth = 0): Promise<void> {
-      if (depth >= MAX_HISTORY_YEARS) return;
+    async function processLeague(league: SleeperApiLeague, recurringLeagueId: string, depth = 0): Promise<void> {
+      if (depth >= MAX_HISTORY_YEARS || processedLeagueIds.has(league.league_id)) return;
+
+      processedLeagueIds.add(league.league_id);
+      cacheSleeperLeague(leagueCache, league);
 
       // Find user's roster_id in this league
       let rosterId: number | null = null;
@@ -175,6 +208,7 @@ export async function handleSleeperDiscover(
         seasonYear: parseInt(league.season, 10) || getDefaultSeasonYear('football'),
         leagueName: league.name,
         rosterId,
+        recurringLeagueId,
         sleeperUserId: sleeperUserId,
       });
       totalSaved++;
@@ -183,9 +217,9 @@ export async function handleSleeperDiscover(
       // Traverse previous season
       if (league.previous_league_id) {
         try {
-          const prevLeague = await sleeperGet<SleeperApiLeague>(`/league/${league.previous_league_id}`);
+          const prevLeague = await getSleeperLeague(league.previous_league_id, leagueCache);
           if (prevLeague?.league_id) {
-            await processLeague(prevLeague, depth + 1);
+            await processLeague(prevLeague, recurringLeagueId, depth + 1);
           }
         } catch {
           // Non-fatal: history traversal best-effort
@@ -193,7 +227,11 @@ export async function handleSleeperDiscover(
       }
     }
 
-    await Promise.all(currentLeagues.map((league) => processLeague(league)));
+    await Promise.all(currentLeagues.map(async (league) => {
+      cacheSleeperLeague(leagueCache, league);
+      const recurringLeagueId = await resolveRecurringLeagueId(league.league_id, recurringIdCache, leagueCache);
+      await processLeague(league, recurringLeagueId);
+    }));
 
     return new Response(
       JSON.stringify({

--- a/workers/auth-worker/src/sleeper-connect-handlers.ts
+++ b/workers/auth-worker/src/sleeper-connect-handlers.ts
@@ -58,7 +58,7 @@ async function sleeperGet<T>(path: string): Promise<T> {
 }
 
 function cacheSleeperLeague(
-  leagueCache: Map<string, Promise<SleeperApiLeague>>,
+  leagueCache: Map<string, Promise<SleeperApiLeague | null>>,
   league: SleeperApiLeague
 ): void {
   leagueCache.set(league.league_id, Promise.resolve(league));
@@ -66,14 +66,14 @@ function cacheSleeperLeague(
 
 async function getSleeperLeague(
   leagueId: string,
-  leagueCache: Map<string, Promise<SleeperApiLeague>>
-): Promise<SleeperApiLeague> {
+  leagueCache: Map<string, Promise<SleeperApiLeague | null>>
+): Promise<SleeperApiLeague | null> {
   const cached = leagueCache.get(leagueId);
   if (cached) {
     return cached;
   }
 
-  const request = sleeperGet<SleeperApiLeague>(`/league/${leagueId}`);
+  const request = sleeperGet<SleeperApiLeague | null>(`/league/${leagueId}`);
   leagueCache.set(leagueId, request);
   return request;
 }
@@ -92,7 +92,7 @@ function describeSleeperResolutionFailure(leagueId: string, error: unknown): str
 async function tryResolveRecurringLeagueId(
   leagueId: string,
   cache: Map<string, string | null>,
-  leagueCache: Map<string, Promise<SleeperApiLeague>>
+  leagueCache: Map<string, Promise<SleeperApiLeague | null>>
 ): Promise<RecurringLeagueResolutionResult> {
   const path: string[] = [];
   const visited = new Set<string>();
@@ -122,6 +122,13 @@ async function tryResolveRecurringLeagueId(
 
     try {
       const league = await getSleeperLeague(currentLeagueId, leagueCache);
+      if (!league) {
+        for (const pathLeagueId of path) {
+          cache.set(pathLeagueId, null);
+        }
+        return { failureReason: `Sleeper returned null while resolving ${currentLeagueId}` };
+      }
+
       if (!league.previous_league_id) {
         for (const pathLeagueId of path) {
           cache.set(pathLeagueId, league.league_id);
@@ -145,7 +152,7 @@ async function tryResolveRecurringLeagueId(
 async function resolveRecurringLeagueId(
   leagueId: string,
   cache: Map<string, string | null>,
-  leagueCache: Map<string, Promise<SleeperApiLeague>>
+  leagueCache: Map<string, Promise<SleeperApiLeague | null>>
 ): Promise<string> {
   const resolution = await tryResolveRecurringLeagueId(leagueId, cache, leagueCache);
   if (resolution.recurringLeagueId) {
@@ -160,7 +167,7 @@ async function resolveRecurringLeagueId(
 
 async function buildSleeperLeagueResponse(leagues: SleeperLeague[]): Promise<SleeperLeagueResponse[]> {
   const recurringIdCache = new Map<string, string | null>();
-  const leagueCache = new Map<string, Promise<SleeperApiLeague>>();
+  const leagueCache = new Map<string, Promise<SleeperApiLeague | null>>();
   for (const league of leagues) {
     if (league.recurringLeagueId) {
       recurringIdCache.set(league.leagueId, league.recurringLeagueId);
@@ -231,7 +238,7 @@ export async function handleSleeperDiscover(
     let totalSaved = 0;
     const seasonsDiscovered = new Set<string>();
     const recurringIdCache = new Map<string, string | null>();
-    const leagueCache = new Map<string, Promise<SleeperApiLeague>>();
+    const leagueCache = new Map<string, Promise<SleeperApiLeague | null>>();
     const processedLeagueIds = new Set<string>();
 
     // Process each league and traverse history chain

--- a/workers/auth-worker/src/sleeper-connect-handlers.ts
+++ b/workers/auth-worker/src/sleeper-connect-handlers.ts
@@ -3,7 +3,7 @@ import { getDefaultSeasonYear } from './season-utils';
 
 const SLEEPER_API = 'https://api.sleeper.app/v1';
 const MAX_HISTORY_YEARS = 5;
-const MAX_RECURRING_CHAIN_DEPTH = 12;
+const MAX_RECURRING_CHAIN_DEPTH = 25;
 
 export interface SleeperConnectEnv {
   SUPABASE_URL: string;
@@ -74,19 +74,18 @@ async function getSleeperLeague(
   return request;
 }
 
-async function resolveRecurringLeagueId(
+async function tryResolveRecurringLeagueId(
   leagueId: string,
   cache: Map<string, string>,
   leagueCache: Map<string, Promise<SleeperApiLeague>>,
   depth = 0,
   visited = new Set<string>()
-): Promise<string> {
+): Promise<string | undefined> {
   const cached = cache.get(leagueId);
   if (cached) return cached;
 
   if (depth >= MAX_RECURRING_CHAIN_DEPTH || visited.has(leagueId)) {
-    cache.set(leagueId, leagueId);
-    return leagueId;
+    return undefined;
   }
 
   visited.add(leagueId);
@@ -98,14 +97,30 @@ async function resolveRecurringLeagueId(
       return leagueId;
     }
 
-    const recurringLeagueId = await resolveRecurringLeagueId(league.previous_league_id, cache, leagueCache, depth + 1, visited);
+    const recurringLeagueId = await tryResolveRecurringLeagueId(league.previous_league_id, cache, leagueCache, depth + 1, visited);
+    if (!recurringLeagueId) {
+      return undefined;
+    }
     cache.set(leagueId, recurringLeagueId);
     return recurringLeagueId;
   } catch (error) {
     console.warn(`[sleeper-connect] Failed to resolve recurring league for ${leagueId}:`, error);
-    cache.set(leagueId, leagueId);
-    return leagueId;
+    return undefined;
   }
+}
+
+async function resolveRecurringLeagueId(
+  leagueId: string,
+  cache: Map<string, string>,
+  leagueCache: Map<string, Promise<SleeperApiLeague>>
+): Promise<string> {
+  const recurringLeagueId = await tryResolveRecurringLeagueId(leagueId, cache, leagueCache);
+  if (recurringLeagueId) {
+    return recurringLeagueId;
+  }
+
+  cache.set(leagueId, leagueId);
+  return leagueId;
 }
 
 async function buildSleeperLeagueResponse(leagues: SleeperLeague[]): Promise<SleeperLeagueResponse[]> {
@@ -185,7 +200,7 @@ export async function handleSleeperDiscover(
     const processedLeagueIds = new Set<string>();
 
     // Process each league and traverse history chain
-    async function processLeague(league: SleeperApiLeague, recurringLeagueId: string, depth = 0): Promise<void> {
+    async function processLeague(league: SleeperApiLeague, recurringLeagueId: string | undefined, depth = 0): Promise<void> {
       if (depth >= MAX_HISTORY_YEARS || processedLeagueIds.has(league.league_id)) return;
 
       processedLeagueIds.add(league.league_id);
@@ -201,16 +216,20 @@ export async function handleSleeperDiscover(
         // Non-fatal: save without roster_id
       }
 
-      await storage.saveSleeperLeague({
+      const leagueToSave: Parameters<SleeperStorage['saveSleeperLeague']>[0] = {
         clerkUserId: userId,
         leagueId: league.league_id,
         sport: mapSport(league.sport),
         seasonYear: parseInt(league.season, 10) || getDefaultSeasonYear('football'),
         leagueName: league.name,
         rosterId,
-        recurringLeagueId,
         sleeperUserId: sleeperUserId,
-      });
+      };
+      if (recurringLeagueId) {
+        leagueToSave.recurringLeagueId = recurringLeagueId;
+      }
+
+      await storage.saveSleeperLeague(leagueToSave);
       totalSaved++;
       seasonsDiscovered.add(league.season);
 
@@ -229,7 +248,7 @@ export async function handleSleeperDiscover(
 
     await Promise.all(currentLeagues.map(async (league) => {
       cacheSleeperLeague(leagueCache, league);
-      const recurringLeagueId = await resolveRecurringLeagueId(league.league_id, recurringIdCache, leagueCache);
+      const recurringLeagueId = await tryResolveRecurringLeagueId(league.league_id, recurringIdCache, leagueCache);
       await processLeague(league, recurringLeagueId);
     }));
 

--- a/workers/auth-worker/src/sleeper-storage.ts
+++ b/workers/auth-worker/src/sleeper-storage.ts
@@ -27,9 +27,17 @@ interface SleeperLeagueRow {
   season_year: number;
   league_name: string;
   roster_id: number | null;
+  recurring_league_id?: string | null;
   sleeper_user_id: string;
   created_at: string;
   updated_at: string;
+}
+
+interface SupabaseErrorLike {
+  code?: string;
+  message?: string;
+  details?: string;
+  hint?: string;
 }
 
 export interface SleeperLeague {
@@ -40,11 +48,33 @@ export interface SleeperLeague {
   seasonYear: number;
   leagueName: string;
   rosterId: number | null;
+  recurringLeagueId?: string;
   sleeperUserId: string;
+}
+
+function isMissingRecurringLeagueIdColumnError(error: SupabaseErrorLike | null | undefined): boolean {
+  if (!error) return false;
+
+  const combined = [error.code, error.message, error.details, error.hint]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+
+  if (!combined.includes('recurring_league_id')) {
+    return false;
+  }
+
+  return combined.includes('column')
+    || combined.includes('schema cache')
+    || combined.includes('unknown')
+    || combined.includes('not found')
+    || error.code === '42703'
+    || error.code === 'PGRST204';
 }
 
 export class SleeperStorage {
   private supabase;
+  private recurringLeagueIdColumnStatus: 'unknown' | 'available' | 'missing' = 'unknown';
 
   constructor(supabaseUrl: string, supabaseKey: string) {
     this.supabase = createClient(supabaseUrl, supabaseKey);
@@ -111,6 +141,7 @@ export class SleeperStorage {
       seasonYear: row.season_year,
       leagueName: row.league_name,
       rosterId: row.roster_id,
+      recurringLeagueId: row.recurring_league_id ?? undefined,
       sleeperUserId: row.sleeper_user_id,
     }));
   }
@@ -122,22 +153,41 @@ export class SleeperStorage {
     seasonYear: number;
     leagueName: string;
     rosterId: number | null;
+    recurringLeagueId?: string;
     sleeperUserId: string;
   }): Promise<void> {
-    const { error } = await this.supabase
-      .from('sleeper_leagues')
-      .upsert({
-        clerk_user_id: league.clerkUserId,
-        league_id: league.leagueId,
-        sport: league.sport,
-        season_year: league.seasonYear,
-        league_name: league.leagueName,
-        roster_id: league.rosterId,
-        sleeper_user_id: league.sleeperUserId,
-        updated_at: new Date().toISOString(),
-      }, { onConflict: 'clerk_user_id,league_id,season_year' });
+    const basePayload = {
+      clerk_user_id: league.clerkUserId,
+      league_id: league.leagueId,
+      sport: league.sport,
+      season_year: league.seasonYear,
+      league_name: league.leagueName,
+      roster_id: league.rosterId,
+      sleeper_user_id: league.sleeperUserId,
+      updated_at: new Date().toISOString(),
+    };
 
-    if (error) throw new Error(`Failed to save Sleeper league: ${error.message}`);
+    if (league.recurringLeagueId && this.recurringLeagueIdColumnStatus !== 'missing') {
+      const error = await this.upsertSleeperLeagueRow({
+        ...basePayload,
+        recurring_league_id: league.recurringLeagueId,
+      });
+
+      if (!error) {
+        this.recurringLeagueIdColumnStatus = 'available';
+        return;
+      }
+
+      if (!isMissingRecurringLeagueIdColumnError(error)) {
+        throw new Error(`Failed to save Sleeper league: ${error.message}`);
+      }
+
+      console.warn('[sleeper-storage] recurring_league_id column unavailable; retrying without it');
+      this.recurringLeagueIdColumnStatus = 'missing';
+    }
+
+    const legacyError = await this.upsertSleeperLeagueRow(basePayload);
+    if (legacyError) throw new Error(`Failed to save Sleeper league: ${legacyError.message}`);
   }
 
   async deleteSleeperLeague(clerkUserId: string, leagueId: string): Promise<void> {
@@ -191,5 +241,13 @@ export class SleeperStorage {
     if (result.skipped) {
       console.warn(`[sleeper-storage] clearDefaultsForPlatform skipped for user ${maskUserId(clerkUserId)}: ${result.error ?? 'unknown reason'}`);
     }
+  }
+
+  private async upsertSleeperLeagueRow(payload: Record<string, unknown>): Promise<SupabaseErrorLike | null> {
+    const { error } = await this.supabase
+      .from('sleeper_leagues')
+      .upsert(payload, { onConflict: 'clerk_user_id,league_id,season_year' });
+
+    return (error as SupabaseErrorLike | null) ?? null;
   }
 }

--- a/workers/auth-worker/src/sleeper-storage.ts
+++ b/workers/auth-worker/src/sleeper-storage.ts
@@ -53,23 +53,7 @@ export interface SleeperLeague {
 }
 
 function isMissingRecurringLeagueIdColumnError(error: SupabaseErrorLike | null | undefined): boolean {
-  if (!error) return false;
-
-  const combined = [error.code, error.message, error.details, error.hint]
-    .filter(Boolean)
-    .join(' ')
-    .toLowerCase();
-
-  if (!combined.includes('recurring_league_id')) {
-    return false;
-  }
-
-  return combined.includes('column')
-    || combined.includes('schema cache')
-    || combined.includes('unknown')
-    || combined.includes('not found')
-    || error.code === '42703'
-    || error.code === 'PGRST204';
+  return error?.code === '42703' || error?.code === 'PGRST204';
 }
 
 export class SleeperStorage {
@@ -182,7 +166,9 @@ export class SleeperStorage {
         throw new Error(`Failed to save Sleeper league: ${error.message}`);
       }
 
-      console.warn('[sleeper-storage] recurring_league_id column unavailable; retrying without it');
+      console.warn(
+        `[sleeper-storage] recurring_league_id column unavailable for user ${maskUserId(league.clerkUserId)} league ${league.leagueId}; retrying without it (code=${error.code ?? 'unknown'})`
+      );
       this.recurringLeagueIdColumnStatus = 'missing';
     }
 

--- a/workers/fantasy-mcp/README.md
+++ b/workers/fantasy-mcp/README.md
@@ -54,6 +54,7 @@ All tools take explicit parameters. Call `get_user_session` first in a normal ch
 `get_transactions` uses platform-specific week semantics in v1: ESPN/Sleeper support explicit `week`, while Yahoo ignores explicit `week` and uses a recent 14-day timestamp window. Yahoo `type=waiver` filtering is intentionally unsupported in v1. ESPN responses include a `teams` map (team ID → display name) so the LLM can resolve numeric `team_ids` on each transaction to human-readable names. Player entries are enriched with name, position, and pro team.
 `get_free_agents` returns platform-specific availability context: ESPN/Yahoo include ownership percentages and sort by ownership, while Sleeper returns available-player identities from the public player index without ownership percentages.
 `get_players` always returns identity, but ownership context is platform-specific: ESPN and Yahoo include market/global ownership and may also include league ownership fields (`league_status`, `league_team_name`, `league_owner_name`); Sleeper returns identity with unavailable ownership context. If league ownership fields are absent, null, or unavailable, fall back to `get_league_info` + `get_roster`.
+Recurring seasons are grouped by stable league identity before active/history selection. Yahoo derives that from the stable league ID inside `league_key`; Sleeper uses auth-worker's `recurringLeagueId`, which is computed from Sleeper's `previous_league_id` chain while keeping the season-specific `leagueId` intact for direct calls.
 
 ### Tool Parameters
 

--- a/workers/fantasy-mcp/src/__tests__/tools.test.ts
+++ b/workers/fantasy-mcp/src/__tests__/tools.test.ts
@@ -759,6 +759,51 @@ describe('fantasy-mcp tools', () => {
     });
   });
 
+  it('get_user_session: grouped Sleeper seasons keep only the current season in active leagues', async () => {
+    const tool = getUnifiedTools().find((t) => t.name === 'get_user_session');
+    expect(tool).toBeTruthy();
+
+    const sleeperLeagues = [
+      { sport: 'football', leagueId: 'sleeper-2025', recurringLeagueId: 'sleeper-root', leagueName: 'Dynasty Squad', rosterId: 7, seasonYear: 2025 },
+      { sport: 'football', leagueId: 'sleeper-2024', recurringLeagueId: 'sleeper-root', leagueName: 'Dynasty Squad', rosterId: 7, seasonYear: 2024 },
+    ];
+
+    const env = {
+      INTERNAL_SERVICE_TOKEN: 'internal-secret',
+      AUTH_WORKER: {
+        fetch: async (req: Request) => {
+          const url = new URL(req.url);
+          if (url.pathname === '/internal/leagues/sleeper') {
+            return new Response(JSON.stringify({ leagues: sleeperLeagues }), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          }
+          return new Response(JSON.stringify({ leagues: [] }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        },
+      },
+    } as unknown as Env;
+
+    const result = await tool!.handler({}, env, 'Bearer test-token');
+    const payload = JSON.parse(result.content[0].text) as {
+      allLeagues: Array<{ platform: string; sport: string; leagueId: string; seasonYear: number }>;
+      totalLeaguesFound: number;
+    };
+
+    const sleeperFootball = payload.allLeagues.filter(
+      (l) => l.platform === 'sleeper' && l.sport === 'football'
+    );
+    expect(payload.totalLeaguesFound).toBe(1);
+    expect(sleeperFootball).toHaveLength(1);
+    expect(sleeperFootball[0]).toMatchObject({
+      leagueId: 'sleeper-2025',
+      seasonYear: 2025,
+    });
+  });
+
   it('get_user_session: distinct Yahoo leagues with the same name remain separate', async () => {
     const tool = getUnifiedTools().find((t) => t.name === 'get_user_session');
     expect(tool).toBeTruthy();

--- a/workers/fantasy-mcp/src/__tests__/tools.test.ts
+++ b/workers/fantasy-mcp/src/__tests__/tools.test.ts
@@ -714,6 +714,51 @@ describe('fantasy-mcp tools', () => {
     expect(yahooFootball[0].leagueId).toBe('461.l.1000');
   });
 
+  it('get_user_session: historical Sleeper football season does not leak into active session view', async () => {
+    const tool = getUnifiedTools().find((t) => t.name === 'get_user_session');
+    expect(tool).toBeTruthy();
+
+    const sleeperLeagues = [
+      { sport: 'football', leagueId: 'sleeper-2025', leagueName: 'Dynasty Squad', rosterId: 7, seasonYear: 2025 },
+      { sport: 'football', leagueId: 'sleeper-2024', leagueName: 'Dynasty Squad', rosterId: 7, seasonYear: 2024 },
+    ];
+
+    const env = {
+      INTERNAL_SERVICE_TOKEN: 'internal-secret',
+      AUTH_WORKER: {
+        fetch: async (req: Request) => {
+          const url = new URL(req.url);
+          if (url.pathname === '/internal/leagues/sleeper') {
+            return new Response(JSON.stringify({ leagues: sleeperLeagues }), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          }
+          return new Response(JSON.stringify({ leagues: [] }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        },
+      },
+    } as unknown as Env;
+
+    const result = await tool!.handler({}, env, 'Bearer test-token');
+    const payload = JSON.parse(result.content[0].text) as {
+      allLeagues: Array<{ platform: string; sport: string; leagueId: string; seasonYear: number }>;
+      totalLeaguesFound: number;
+    };
+
+    const sleeperFootball = payload.allLeagues.filter(
+      (l) => l.platform === 'sleeper' && l.sport === 'football'
+    );
+    expect(payload.totalLeaguesFound).toBe(1);
+    expect(sleeperFootball).toHaveLength(1);
+    expect(sleeperFootball[0]).toMatchObject({
+      leagueId: 'sleeper-2025',
+      seasonYear: 2025,
+    });
+  });
+
   it('get_user_session: distinct Yahoo leagues with the same name remain separate', async () => {
     const tool = getUnifiedTools().find((t) => t.name === 'get_user_session');
     expect(tool).toBeTruthy();
@@ -754,6 +799,53 @@ describe('fantasy-mcp tools', () => {
     expect(payload.totalLeaguesFound).toBe(2);
     expect(yahooFootball).toHaveLength(2);
     expect(yahooFootball.map((l) => l.leagueId).sort()).toEqual(['461.l.1000', '461.l.2000']);
+  });
+
+  it('get_ancient_history: recurring Sleeper seasons stay grouped under the active league', async () => {
+    const tool = getUnifiedTools().find((t) => t.name === 'get_ancient_history');
+    expect(tool).toBeTruthy();
+
+    const sleeperLeagues = [
+      { sport: 'football', leagueId: 'sleeper-2025', recurringLeagueId: 'sleeper-root', leagueName: 'Dynasty Squad', rosterId: 7, seasonYear: 2025 },
+      { sport: 'football', leagueId: 'sleeper-2024', recurringLeagueId: 'sleeper-root', leagueName: 'Dynasty Squad', rosterId: 7, seasonYear: 2024 },
+    ];
+
+    const env = {
+      INTERNAL_SERVICE_TOKEN: 'internal-secret',
+      AUTH_WORKER: {
+        fetch: async (req: Request) => {
+          const url = new URL(req.url);
+          if (url.pathname === '/internal/leagues/sleeper') {
+            return new Response(JSON.stringify({ leagues: sleeperLeagues }), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          }
+          return new Response(JSON.stringify({ leagues: [] }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        },
+      },
+    } as unknown as Env;
+
+    const result = await tool!.handler({}, env, 'Bearer test-token');
+    const payload = JSON.parse(result.content[0].text) as {
+      oldLeagues: Array<{ platform: string; leagueId: string; seasonYear: number }>;
+      oldSeasonsFromActiveLeagues: Record<string, Array<{ platform: string; leagueId: string; seasonYear: number }>>;
+      totalOldSeasons: number;
+    };
+
+    expect(payload.oldLeagues).toHaveLength(0);
+    expect(Object.keys(payload.oldSeasonsFromActiveLeagues)).toEqual(['sleeper:football:sleeper-root']);
+    const allOldSeasons = Object.values(payload.oldSeasonsFromActiveLeagues).flat();
+    expect(payload.totalOldSeasons).toBe(1);
+    expect(allOldSeasons).toHaveLength(1);
+    expect(allOldSeasons[0]).toMatchObject({
+      platform: 'sleeper',
+      leagueId: 'sleeper-2024',
+      seasonYear: 2024,
+    });
   });
 
   it('get_players routes unchanged to client', async () => {

--- a/workers/fantasy-mcp/src/mcp/tools.ts
+++ b/workers/fantasy-mcp/src/mcp/tools.ts
@@ -90,6 +90,7 @@ interface UserLeague {
   seasonYear?: number;
   leagueName?: string;
   teamName?: string;
+  recurringLeagueId?: string;
 }
 
 function getYahooStableLeagueId(leagueId: string): string {
@@ -100,6 +101,9 @@ function getYahooStableLeagueId(leagueId: string): string {
 function getActiveLeagueGroupKey(league: UserLeague): string {
   if (league.platform === 'yahoo') {
     return `${league.platform}:${(league.sport || '').toLowerCase()}:${getYahooStableLeagueId(league.leagueId)}`;
+  }
+  if (league.platform === 'sleeper') {
+    return `${league.platform}:${(league.sport || '').toLowerCase()}:${league.recurringLeagueId || league.leagueId}`;
   }
   return `${league.platform}:${league.leagueId}`;
 }
@@ -277,6 +281,7 @@ async function fetchSleeperLeagues(
         leagueName: string;
         rosterId?: number;
         seasonYear: number;
+        recurringLeagueId?: string;
       }>;
     };
 
@@ -287,6 +292,7 @@ async function fetchSleeperLeagues(
       leagueName: league.leagueName,
       teamId: league.rosterId ? String(league.rosterId) : '',
       seasonYear: league.seasonYear,
+      recurringLeagueId: league.recurringLeagueId,
     }));
 
     console.log(`[fantasy-mcp] ${cid} found ${leagues.length} Sleeper leagues`);
@@ -492,6 +498,10 @@ export function getUnifiedTools(): UnifiedTool[] {
               const currentSeason = groupSeasons.find(s => s.seasonYear === currentYear);
               if (currentSeason) {
                 leagues.push(currentSeason);
+              } else if (groupSeasons[0]?.platform === 'sleeper') {
+                // Sleeper league IDs are season-specific, so a fallback here can promote a
+                // past canonical season into the active session view.
+                continue;
               } else {
                 // Fallback: most recent season (e.g., league not yet created for current season)
                 leagues.push(groupSeasons[0]);


### PR DESCRIPTION
## Summary
- compute a best-effort Sleeper `recurringLeagueId` when reading linked leagues from auth-worker
- group Sleeper seasons by `recurringLeagueId ?? leagueId` in fantasy-mcp and the `/leagues` UI
- prevent historical Sleeper seasons from leaking into the active session while preserving recurring-season grouping

## Why
Sleeper seasons for the same recurring league were being treated as unrelated league records in some session/history paths. That could surface an old season in the active session view while also leaving it in history. This PR makes the grouping key explicit and consistent across auth-worker, fantasy-mcp, and web.

## Included issue
- FLA-115

## Verification
- `corepack pnpm --dir workers/auth-worker run type-check`
- `corepack pnpm --dir workers/auth-worker test`
- `corepack pnpm --dir workers/fantasy-mcp run type-check`
- `corepack pnpm --dir workers/fantasy-mcp test`
- `corepack pnpm --dir web exec tsc --noEmit`
- `corepack pnpm --dir web run lint`
- `git diff --check`

## Notes
- checks were rerun after rebasing this branch onto current `origin/main`
- checks in this worktree ran under Node `25.9.0`; the repo declares Node `24.x`