### PR TITLE
test/refactor(FLA-83, FLA-82): harden and extract ESPN standings logic

### DIFF
--- a/workers/espn-client/src/shared/__tests__/standings.test.ts
+++ b/workers/espn-client/src/shared/__tests__/standings.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+import {
+  deriveStandingsOutcome,
+  deriveStandingsSeasonPhase,
+} from '../standings';
+
+describe('deriveStandingsSeasonPhase', () => {
+  it('marks the season complete when ESPN exposes explicit final ranks', () => {
+    expect(deriveStandingsSeasonPhase({
+      requestedSeasonYear: 2026,
+      currentSeasonYear: 2026,
+      scoringPeriodId: 10,
+      regularSeasonMatchupPeriods: 20,
+      teams: [{ id: 1, rankFinal: 1 }],
+    })).toBe('season_complete');
+  });
+
+  it('marks older seasons complete even without explicit final ranks', () => {
+    expect(deriveStandingsSeasonPhase({
+      requestedSeasonYear: 2024,
+      currentSeasonYear: 2026,
+      scoringPeriodId: 10,
+      regularSeasonMatchupPeriods: 20,
+      teams: [{ id: 1 }],
+    })).toBe('season_complete');
+  });
+
+  it('returns playoffs_in_progress for current-season requests after the regular season', () => {
+    expect(deriveStandingsSeasonPhase({
+      requestedSeasonYear: 2026,
+      currentSeasonYear: 2026,
+      scoringPeriodId: 22,
+      regularSeasonMatchupPeriods: 20,
+      teams: [{ id: 1 }],
+    })).toBe('playoffs_in_progress');
+  });
+
+  it('returns regular_season for current-season requests during the regular season', () => {
+    expect(deriveStandingsSeasonPhase({
+      requestedSeasonYear: 2026,
+      currentSeasonYear: 2026,
+      scoringPeriodId: 10,
+      regularSeasonMatchupPeriods: 20,
+      teams: [{ id: 1 }],
+    })).toBe('regular_season');
+  });
+
+  it('returns regular_season for future seasons', () => {
+    expect(deriveStandingsSeasonPhase({
+      requestedSeasonYear: 2027,
+      currentSeasonYear: 2026,
+      scoringPeriodId: 0,
+      regularSeasonMatchupPeriods: 20,
+      teams: [{ id: 1 }],
+    })).toBe('regular_season');
+  });
+});
+
+describe('deriveStandingsOutcome', () => {
+  it('returns champion fields for a completed season winner', () => {
+    expect(deriveStandingsOutcome({
+      rankFinal: 1,
+      playoffSeed: 1,
+      seasonComplete: true,
+    })).toEqual({
+      finalRank: 1,
+      championshipWon: true,
+      playoffOutcome: 'champion',
+      outcomeConfidence: 'explicit',
+      madePlayoffs: true,
+    });
+  });
+
+  it('returns runner-up fields for second place', () => {
+    expect(deriveStandingsOutcome({
+      rankFinal: 2,
+      playoffSeed: 2,
+      seasonComplete: true,
+    })).toEqual({
+      finalRank: 2,
+      championshipWon: false,
+      playoffOutcome: 'runner_up',
+      outcomeConfidence: 'explicit',
+      madePlayoffs: true,
+    });
+  });
+
+  it('returns eliminated for completed playoff teams outside the final', () => {
+    expect(deriveStandingsOutcome({
+      rankFinal: 4,
+      playoffSeed: 4,
+      seasonComplete: true,
+    })).toEqual({
+      finalRank: 4,
+      championshipWon: false,
+      playoffOutcome: 'eliminated',
+      outcomeConfidence: 'explicit',
+      madePlayoffs: true,
+    });
+  });
+
+  it('returns missed_playoffs for completed non-playoff teams', () => {
+    expect(deriveStandingsOutcome({
+      rankFinal: 7,
+      seasonComplete: true,
+    })).toEqual({
+      finalRank: 7,
+      championshipWon: false,
+      playoffOutcome: 'missed_playoffs',
+      outcomeConfidence: 'explicit',
+      madePlayoffs: false,
+    });
+  });
+
+  it('keeps outcome fields null when a completed season has no explicit final rank', () => {
+    expect(deriveStandingsOutcome({
+      seasonComplete: true,
+    })).toEqual({
+      finalRank: null,
+      championshipWon: null,
+      playoffOutcome: null,
+      outcomeConfidence: null,
+      madePlayoffs: null,
+    });
+  });
+
+  it('keeps postseason outcome null but marks madePlayoffs true during active playoffs when playoffSeed exists', () => {
+    expect(deriveStandingsOutcome({
+      playoffSeed: 1,
+      seasonComplete: false,
+    })).toEqual({
+      finalRank: null,
+      championshipWon: null,
+      playoffOutcome: null,
+      outcomeConfidence: null,
+      madePlayoffs: true,
+    });
+  });
+
+  it('preserves current champion semantics for rankCalculatedFinal without playoffSeed', () => {
+    expect(deriveStandingsOutcome({
+      rankCalculatedFinal: 1,
+      seasonComplete: true,
+    })).toEqual({
+      finalRank: 1,
+      championshipWon: true,
+      playoffOutcome: 'champion',
+      outcomeConfidence: 'explicit',
+      madePlayoffs: false,
+    });
+  });
+});

--- a/workers/espn-client/src/shared/__tests__/standings.test.ts
+++ b/workers/espn-client/src/shared/__tests__/standings.test.ts
@@ -146,7 +146,20 @@ describe('deriveStandingsOutcome', () => {
       championshipWon: true,
       playoffOutcome: 'champion',
       outcomeConfidence: 'explicit',
-      madePlayoffs: false,
+      madePlayoffs: true,
+    });
+  });
+
+  it('treats a runner-up without playoffSeed as having made the playoffs', () => {
+    expect(deriveStandingsOutcome({
+      rankCalculatedFinal: 2,
+      seasonComplete: true,
+    })).toEqual({
+      finalRank: 2,
+      championshipWon: false,
+      playoffOutcome: 'runner_up',
+      outcomeConfidence: 'explicit',
+      madePlayoffs: true,
     });
   });
 });

--- a/workers/espn-client/src/shared/standings.ts
+++ b/workers/espn-client/src/shared/standings.ts
@@ -69,7 +69,9 @@ export function deriveStandingsOutcome({
       : null;
   const outcomeConfidence = finalRank !== null ? 'explicit' : null;
   const madePlayoffs =
-    playoffSeed != null ? true : (seasonComplete && resolvedFinalRank !== null ? false : null);
+    playoffSeed != null || (finalRank !== null && finalRank <= 2)
+      ? true
+      : (seasonComplete && resolvedFinalRank !== null ? false : null);
 
   return {
     finalRank,

--- a/workers/espn-client/src/shared/standings.ts
+++ b/workers/espn-client/src/shared/standings.ts
@@ -1,0 +1,81 @@
+import type { EspnTeam } from '../types';
+
+export type EspnSeasonPhase = 'regular_season' | 'playoffs_in_progress' | 'season_complete';
+
+export type EspnPlayoffOutcome = 'champion' | 'runner_up' | 'eliminated' | 'missed_playoffs';
+
+export interface EspnStandingsOutcome {
+  finalRank: number | null;
+  championshipWon: boolean | null;
+  playoffOutcome: EspnPlayoffOutcome | null;
+  outcomeConfidence: 'explicit' | null;
+  madePlayoffs: boolean | null;
+}
+
+interface DeriveSeasonPhaseInput {
+  requestedSeasonYear: number;
+  currentSeasonYear: number;
+  scoringPeriodId?: number;
+  regularSeasonMatchupPeriods?: number;
+  teams: EspnTeam[];
+}
+
+interface DeriveStandingsOutcomeInput {
+  rankFinal?: number;
+  rankCalculatedFinal?: number;
+  playoffSeed?: number;
+  seasonComplete: boolean;
+}
+
+function hasExplicitCompletionData(teams: EspnTeam[]): boolean {
+  return teams.some((team) => team.rankFinal != null || team.rankCalculatedFinal != null);
+}
+
+export function deriveStandingsSeasonPhase({
+  requestedSeasonYear,
+  currentSeasonYear,
+  scoringPeriodId,
+  regularSeasonMatchupPeriods,
+  teams,
+}: DeriveSeasonPhaseInput): EspnSeasonPhase {
+  if (hasExplicitCompletionData(teams) || requestedSeasonYear < currentSeasonYear) {
+    return 'season_complete';
+  }
+
+  if (requestedSeasonYear === currentSeasonYear) {
+    const regularPeriods = regularSeasonMatchupPeriods ?? 0;
+    const scoringPeriod = scoringPeriodId ?? 0;
+    return scoringPeriod > regularPeriods ? 'playoffs_in_progress' : 'regular_season';
+  }
+
+  return 'regular_season';
+}
+
+export function deriveStandingsOutcome({
+  rankFinal,
+  rankCalculatedFinal,
+  playoffSeed,
+  seasonComplete,
+}: DeriveStandingsOutcomeInput): EspnStandingsOutcome {
+  const resolvedFinalRank = rankFinal ?? rankCalculatedFinal ?? null;
+  const finalRank = seasonComplete && resolvedFinalRank !== null ? resolvedFinalRank : null;
+  const championshipWon = finalRank !== null ? finalRank === 1 : null;
+  const playoffOutcome =
+    finalRank !== null
+      ? finalRank === 1 ? 'champion'
+      : finalRank === 2 ? 'runner_up'
+      : playoffSeed != null ? 'eliminated'
+      : 'missed_playoffs'
+      : null;
+  const outcomeConfidence = finalRank !== null ? 'explicit' : null;
+  const madePlayoffs =
+    playoffSeed != null ? true : (seasonComplete && resolvedFinalRank !== null ? false : null);
+
+  return {
+    finalRank,
+    championshipWon,
+    playoffOutcome,
+    outcomeConfidence,
+    madePlayoffs,
+  };
+}

--- a/workers/espn-client/src/sports/baseball/__tests__/standings.test.ts
+++ b/workers/espn-client/src/sports/baseball/__tests__/standings.test.ts
@@ -1,0 +1,226 @@
+import { beforeEach, describe, expect, it, vi, type MockedFunction } from 'vitest';
+import { baseballHandlers } from '../handlers';
+import type { RoutedToolParams } from '../../../types';
+import { getCredentials } from '../../../shared/auth';
+import { espnFetch } from '../../../shared/espn-api';
+import { getCurrentSeasonYear, withSeasonContext } from '../../../shared/season';
+
+vi.mock('../../../shared/auth', () => ({
+  getCredentials: vi.fn(),
+}));
+
+vi.mock('../../../shared/espn-api', async () => {
+  const actual = await vi.importActual('../../../shared/espn-api') as Record<string, unknown>;
+  return {
+    ...actual,
+    espnFetch: vi.fn(),
+  };
+});
+
+const HISTORICAL_YEAR = 2022;
+const CURRENT_SEASON_YEAR = getCurrentSeasonYear('baseball');
+
+function makeParams(season_year: number): RoutedToolParams {
+  return withSeasonContext({ sport: 'baseball', league_id: '789', season_year });
+}
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('baseball get_standings handler — outcome fields', () => {
+  const getCredentialsMock = getCredentials as MockedFunction<typeof getCredentials>;
+  const espnFetchMock = espnFetch as MockedFunction<typeof espnFetch>;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    getCredentialsMock.mockResolvedValue({ s2: 'token', swid: '{swid}' });
+  });
+
+  it('returns explicit completed-season outcomes for champion, runner-up, eliminated, and missed-playoffs teams', async () => {
+    espnFetchMock.mockResolvedValue(jsonResponse({
+      scoringPeriodId: 22,
+      settings: { regularSeasonMatchupPeriods: 18 },
+      teams: [
+        {
+          id: 1,
+          location: 'Alpha', nickname: 'Aces',
+          rankFinal: 1,
+          playoffSeed: 1,
+          record: { overall: { wins: 14, losses: 4, ties: 0, pointsFor: 1200, pointsAgainst: 980 } },
+        },
+        {
+          id: 2,
+          location: 'Beta', nickname: 'Bats',
+          rankFinal: 2,
+          playoffSeed: 2,
+          record: { overall: { wins: 13, losses: 5, ties: 0, pointsFor: 1175, pointsAgainst: 1000 } },
+        },
+        {
+          id: 3,
+          location: 'Gamma', nickname: 'Gloves',
+          rankFinal: 4,
+          playoffSeed: 4,
+          record: { overall: { wins: 11, losses: 7, ties: 0, pointsFor: 1110, pointsAgainst: 1040 } },
+        },
+        {
+          id: 4,
+          location: 'Delta', nickname: 'Dugout',
+          rankFinal: 7,
+          record: { overall: { wins: 7, losses: 11, ties: 0, pointsFor: 980, pointsAgainst: 1130 } },
+        },
+      ],
+    }));
+
+    const result = await baseballHandlers.get_standings({} as never, makeParams(HISTORICAL_YEAR), 'Bearer x', 'cid');
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.seasonPhase).toBe('season_complete');
+    expect(data.seasonComplete).toBe(true);
+    expect(data.seasonYear).toBe(HISTORICAL_YEAR);
+
+    const standings = data.standings as Array<Record<string, unknown>>;
+
+    const champion = standings.find((team) => team.teamId === 1);
+    expect(champion?.finalRank).toBe(1);
+    expect(champion?.championshipWon).toBe(true);
+    expect(champion?.playoffOutcome).toBe('champion');
+    expect(champion?.outcomeConfidence).toBe('explicit');
+    expect(champion?.madePlayoffs).toBe(true);
+
+    const runnerUp = standings.find((team) => team.teamId === 2);
+    expect(runnerUp?.finalRank).toBe(2);
+    expect(runnerUp?.championshipWon).toBe(false);
+    expect(runnerUp?.playoffOutcome).toBe('runner_up');
+    expect(runnerUp?.outcomeConfidence).toBe('explicit');
+    expect(runnerUp?.madePlayoffs).toBe(true);
+
+    const eliminated = standings.find((team) => team.teamId === 3);
+    expect(eliminated?.finalRank).toBe(4);
+    expect(eliminated?.championshipWon).toBe(false);
+    expect(eliminated?.playoffOutcome).toBe('eliminated');
+    expect(eliminated?.outcomeConfidence).toBe('explicit');
+    expect(eliminated?.madePlayoffs).toBe(true);
+
+    const nonPlayoff = standings.find((team) => team.teamId === 4);
+    expect(nonPlayoff?.finalRank).toBe(7);
+    expect(nonPlayoff?.championshipWon).toBe(false);
+    expect(nonPlayoff?.playoffOutcome).toBe('missed_playoffs');
+    expect(nonPlayoff?.outcomeConfidence).toBe('explicit');
+    expect(nonPlayoff?.madePlayoffs).toBe(false);
+  });
+
+  it('returns season_complete but null outcome fields when a historical season has no explicit final rank', async () => {
+    espnFetchMock.mockResolvedValue(jsonResponse({
+      scoringPeriodId: 22,
+      settings: { regularSeasonMatchupPeriods: 18 },
+      teams: [
+        {
+          id: 1,
+          location: 'Alpha', nickname: 'Aces',
+          record: { overall: { wins: 14, losses: 4, ties: 0, pointsFor: 1200, pointsAgainst: 980 } },
+        },
+      ],
+    }));
+
+    const result = await baseballHandlers.get_standings({} as never, makeParams(HISTORICAL_YEAR), 'Bearer x', 'cid');
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.seasonPhase).toBe('season_complete');
+    expect(data.seasonComplete).toBe(true);
+
+    const standings = data.standings as Array<Record<string, unknown>>;
+    expect(standings[0].finalRank).toBeNull();
+    expect(standings[0].championshipWon).toBeNull();
+    expect(standings[0].playoffOutcome).toBeNull();
+    expect(standings[0].outcomeConfidence).toBeNull();
+    expect(standings[0].madePlayoffs).toBeNull();
+  });
+
+  it('returns playoffs_in_progress with null outcome fields for the current season after regular-season periods', async () => {
+    espnFetchMock.mockResolvedValue(jsonResponse({
+      scoringPeriodId: 20,
+      settings: { regularSeasonMatchupPeriods: 18 },
+      teams: [
+        {
+          id: 1,
+          location: 'Alpha', nickname: 'Aces',
+          record: { overall: { wins: 14, losses: 4, ties: 0, pointsFor: 1200, pointsAgainst: 980 } },
+        },
+      ],
+    }));
+
+    const result = await baseballHandlers.get_standings({} as never, makeParams(CURRENT_SEASON_YEAR), 'Bearer x', 'cid');
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.seasonPhase).toBe('playoffs_in_progress');
+    expect(data.seasonComplete).toBe(false);
+
+    const standings = data.standings as Array<Record<string, unknown>>;
+    expect(standings[0].finalRank).toBeNull();
+    expect(standings[0].championshipWon).toBeNull();
+    expect(standings[0].playoffOutcome).toBeNull();
+    expect(standings[0].outcomeConfidence).toBeNull();
+    expect(standings[0].madePlayoffs).toBeNull();
+  });
+
+  it('returns regular_season with null outcome fields during current regular season', async () => {
+    espnFetchMock.mockResolvedValue(jsonResponse({
+      scoringPeriodId: 10,
+      settings: { regularSeasonMatchupPeriods: 18 },
+      teams: [
+        {
+          id: 1,
+          location: 'Alpha', nickname: 'Aces',
+          record: { overall: { wins: 8, losses: 2, ties: 0, pointsFor: 780, pointsAgainst: 640 } },
+        },
+      ],
+    }));
+
+    const result = await baseballHandlers.get_standings({} as never, makeParams(CURRENT_SEASON_YEAR), 'Bearer x', 'cid');
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.seasonPhase).toBe('regular_season');
+    expect(data.seasonComplete).toBe(false);
+
+    const standings = data.standings as Array<Record<string, unknown>>;
+    expect(standings[0].rank).toBe(1);
+    expect(standings[0].finalRank).toBeNull();
+    expect(standings[0].championshipWon).toBeNull();
+    expect(standings[0].playoffOutcome).toBeNull();
+    expect(standings[0].outcomeConfidence).toBeNull();
+    expect(standings[0].madePlayoffs).toBeNull();
+  });
+
+  it('uses rankCalculatedFinal when rankFinal is absent', async () => {
+    espnFetchMock.mockResolvedValue(jsonResponse({
+      scoringPeriodId: 22,
+      settings: { regularSeasonMatchupPeriods: 18 },
+      teams: [
+        {
+          id: 1,
+          location: 'Alpha', nickname: 'Aces',
+          rankCalculatedFinal: 1,
+          record: { overall: { wins: 14, losses: 4, ties: 0, pointsFor: 1200, pointsAgainst: 980 } },
+        },
+      ],
+    }));
+
+    const result = await baseballHandlers.get_standings({} as never, makeParams(HISTORICAL_YEAR), 'Bearer x', 'cid');
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    const standings = data.standings as Array<Record<string, unknown>>;
+    expect(standings[0].finalRank).toBe(1);
+    expect(standings[0].championshipWon).toBe(true);
+    expect(standings[0].playoffOutcome).toBe('champion');
+    expect(standings[0].outcomeConfidence).toBe('explicit');
+  });
+});

--- a/workers/espn-client/src/sports/baseball/handlers.ts
+++ b/workers/espn-client/src/sports/baseball/handlers.ts
@@ -17,6 +17,7 @@ import {
   POSITION_SLOTS,
 } from './mappings';
 import { getCurrentSeasonYear, getSeasonContext, normalizeEspnLeagueStatus } from '../../shared/season';
+import { deriveStandingsOutcome, deriveStandingsSeasonPhase } from '../../shared/standings';
 
 const GAME_ID = 'flb'; // ESPN's game ID for fantasy baseball
 
@@ -205,24 +206,13 @@ async function handleGetStandings(
     const data = await response.json() as EspnLeagueResponse;
     const teams = data.teams || [];
 
-    // Determine seasonPhase using sport-aware season year to handle cross-calendar sports correctly.
-    // getCurrentSeasonYear('baseball') returns 2024 in Jan 2025 (before Feb rollover).
-    // Primary signal: explicit rankFinal/rankCalculatedFinal → ESPN has finalized the season.
-    const currentSeasonYear = getCurrentSeasonYear('baseball');
-    const hasExplicitCompletionData = teams.some(
-      (t) => t.rankFinal != null || t.rankCalculatedFinal != null
-    );
-    let seasonPhase: 'regular_season' | 'playoffs_in_progress' | 'season_complete';
-    if (hasExplicitCompletionData || season_year < currentSeasonYear) {
-      seasonPhase = 'season_complete';
-    } else if (season_year === currentSeasonYear) {
-      const regularPeriods = data.settings?.regularSeasonMatchupPeriods ?? 0;
-      const scoringPeriod = data.scoringPeriodId ?? 0;
-      seasonPhase = scoringPeriod > regularPeriods ? 'playoffs_in_progress' : 'regular_season';
-    } else {
-      // season_year > currentSeasonYear — future season, treat as not yet started
-      seasonPhase = 'regular_season';
-    }
+    const seasonPhase = deriveStandingsSeasonPhase({
+      requestedSeasonYear: season_year,
+      currentSeasonYear: getCurrentSeasonYear('baseball'),
+      scoringPeriodId: data.scoringPeriodId,
+      regularSeasonMatchupPeriods: data.settings?.regularSeasonMatchupPeriods,
+      teams,
+    });
     const seasonComplete = seasonPhase === 'season_complete';
 
     // Transform and sort teams by standings
@@ -234,23 +224,12 @@ async function handleGetStandings(
       const totalGames = wins + losses + ties;
       const winPercentage = totalGames > 0 ? wins / totalGames : 0;
 
-      // Season outcome fields — only populated for completed seasons with explicit ESPN data
-      const rf = team.rankFinal ?? team.rankCalculatedFinal ?? null;
-
-      const finalRank = seasonComplete && rf !== null ? rf : null;
-      const championshipWon = finalRank !== null ? finalRank === 1 : null;
-      const playoffOutcome: 'champion' | 'runner_up' | 'eliminated' | 'missed_playoffs' | null =
-        finalRank !== null
-          ? finalRank === 1 ? 'champion'
-          : finalRank === 2 ? 'runner_up'
-          : team.playoffSeed != null ? 'eliminated'
-          : 'missed_playoffs'
-        : null;
-      const outcomeConfidence: 'explicit' | null = finalRank !== null ? 'explicit' : null;
-      // madePlayoffs: true if playoff seed present; false if season is complete with explicit ranks
-      // but no playoff seed (team missed playoffs); null if unknown
-      const madePlayoffs: boolean | null =
-        team.playoffSeed != null ? true : (seasonComplete && rf !== null ? false : null);
+      const outcome = deriveStandingsOutcome({
+        rankFinal: team.rankFinal,
+        rankCalculatedFinal: team.rankCalculatedFinal,
+        playoffSeed: team.playoffSeed,
+        seasonComplete,
+      });
 
       return {
         teamId: team.id,
@@ -267,11 +246,7 @@ async function handleGetStandings(
         playoffSeed: team.playoffSeed ?? null,
         draftDayProjectedRank: team.draftDayProjectedRank,
         currentProjectedRank: team.currentProjectedRank,
-        madePlayoffs,
-        finalRank,
-        championshipWon,
-        playoffOutcome,
-        outcomeConfidence,
+        ...outcome,
       };
     }).sort((a, b) => {
       // Sort by win percentage descending, then by wins descending

--- a/workers/espn-client/src/sports/basketball/__tests__/standings.test.ts
+++ b/workers/espn-client/src/sports/basketball/__tests__/standings.test.ts
@@ -120,6 +120,12 @@ describe('basketball get_standings handler — seasonPhase and canonical year', 
     const data = result.data as Record<string, unknown>;
     expect(data.seasonPhase).toBe('season_complete');
     expect(data.seasonYear).toBe(HISTORICAL_CANONICAL_YEAR);
+    const standings = data.standings as Array<Record<string, unknown>>;
+    expect(standings[0].finalRank).toBeNull();
+    expect(standings[0].championshipWon).toBeNull();
+    expect(standings[0].playoffOutcome).toBeNull();
+    expect(standings[0].madePlayoffs).toBeNull();
+    expect(standings[0].outcomeConfidence).toBeNull();
   });
 
   it('returns playoffs_in_progress for current season past regular season periods', async () => {
@@ -145,6 +151,12 @@ describe('basketball get_standings handler — seasonPhase and canonical year', 
     expect(data.seasonComplete).toBe(false);
     // Response must echo canonical year, not ESPN year
     expect(data.seasonYear).toBe(CURRENT_CANONICAL_YEAR);
+    const standings = data.standings as Array<Record<string, unknown>>;
+    expect(standings[0].finalRank).toBeNull();
+    expect(standings[0].championshipWon).toBeNull();
+    expect(standings[0].playoffOutcome).toBeNull();
+    expect(standings[0].madePlayoffs).toBe(true);
+    expect(standings[0].outcomeConfidence).toBeNull();
   });
 
   it('returns regular_season for current season within regular season periods', async () => {
@@ -167,6 +179,12 @@ describe('basketball get_standings handler — seasonPhase and canonical year', 
     expect(data.seasonPhase).toBe('regular_season');
     expect(data.seasonComplete).toBe(false);
     expect(data.seasonYear).toBe(CURRENT_CANONICAL_YEAR);
+    const standings = data.standings as Array<Record<string, unknown>>;
+    expect(standings[0].finalRank).toBeNull();
+    expect(standings[0].championshipWon).toBeNull();
+    expect(standings[0].playoffOutcome).toBeNull();
+    expect(standings[0].madePlayoffs).toBeNull();
+    expect(standings[0].outcomeConfidence).toBeNull();
   });
 
   it('uses rankCalculatedFinal when rankFinal is absent', async () => {

--- a/workers/espn-client/src/sports/basketball/handlers.ts
+++ b/workers/espn-client/src/sports/basketball/handlers.ts
@@ -17,6 +17,7 @@ import {
   POSITION_SLOTS,
 } from './mappings';
 import { getCurrentSeasonYear, getSeasonContext, normalizeEspnLeagueStatus } from '../../shared/season';
+import { deriveStandingsOutcome, deriveStandingsSeasonPhase } from '../../shared/standings';
 
 const GAME_ID = 'fba'; // ESPN's game ID for fantasy basketball
 
@@ -207,25 +208,13 @@ async function handleGetStandings(
     const data = await response.json() as EspnLeagueResponse;
     const teams = data.teams || [];
 
-    // Determine seasonPhase using sport-aware season year to handle cross-calendar sports correctly.
-    // getCurrentSeasonYear('basketball') returns 2025 in Jan 2026 (before Aug rollover), so an
-    // NBA 2025 season mid-playoff request in Jan 2026 is not incorrectly marked season_complete.
-    // Primary signal: explicit rankFinal/rankCalculatedFinal → ESPN has finalized the season.
-    const currentSeasonYear = getCurrentSeasonYear('basketball');
-    const hasExplicitCompletionData = teams.some(
-      (t) => t.rankFinal != null || t.rankCalculatedFinal != null
-    );
-    let seasonPhase: 'regular_season' | 'playoffs_in_progress' | 'season_complete';
-    if (hasExplicitCompletionData || canonicalYear < currentSeasonYear) {
-      seasonPhase = 'season_complete';
-    } else if (canonicalYear === currentSeasonYear) {
-      const regularPeriods = data.settings?.regularSeasonMatchupPeriods ?? 0;
-      const scoringPeriod = data.scoringPeriodId ?? 0;
-      seasonPhase = scoringPeriod > regularPeriods ? 'playoffs_in_progress' : 'regular_season';
-    } else {
-      // canonicalYear > currentSeasonYear — future season, treat as not yet started
-      seasonPhase = 'regular_season';
-    }
+    const seasonPhase = deriveStandingsSeasonPhase({
+      requestedSeasonYear: canonicalYear,
+      currentSeasonYear: getCurrentSeasonYear('basketball'),
+      scoringPeriodId: data.scoringPeriodId,
+      regularSeasonMatchupPeriods: data.settings?.regularSeasonMatchupPeriods,
+      teams,
+    });
     const seasonComplete = seasonPhase === 'season_complete';
 
     // Transform and sort teams by standings
@@ -237,23 +226,12 @@ async function handleGetStandings(
       const totalGames = wins + losses + ties;
       const winPercentage = totalGames > 0 ? wins / totalGames : 0;
 
-      // Season outcome fields — only populated for completed seasons with explicit ESPN data
-      const rf = team.rankFinal ?? team.rankCalculatedFinal ?? null;
-
-      const finalRank = seasonComplete && rf !== null ? rf : null;
-      const championshipWon = finalRank !== null ? finalRank === 1 : null;
-      const playoffOutcome: 'champion' | 'runner_up' | 'eliminated' | 'missed_playoffs' | null =
-        finalRank !== null
-          ? finalRank === 1 ? 'champion'
-          : finalRank === 2 ? 'runner_up'
-          : team.playoffSeed != null ? 'eliminated'
-          : 'missed_playoffs'
-        : null;
-      const outcomeConfidence: 'explicit' | null = finalRank !== null ? 'explicit' : null;
-      // madePlayoffs: true if playoff seed present; false if season is complete with explicit ranks
-      // but no playoff seed (team missed playoffs); null if unknown
-      const madePlayoffs: boolean | null =
-        team.playoffSeed != null ? true : (seasonComplete && rf !== null ? false : null);
+      const outcome = deriveStandingsOutcome({
+        rankFinal: team.rankFinal,
+        rankCalculatedFinal: team.rankCalculatedFinal,
+        playoffSeed: team.playoffSeed,
+        seasonComplete,
+      });
 
       return {
         teamId: team.id,
@@ -270,11 +248,7 @@ async function handleGetStandings(
         playoffSeed: team.playoffSeed ?? null,
         draftDayProjectedRank: team.draftDayProjectedRank,
         currentProjectedRank: team.currentProjectedRank,
-        madePlayoffs,
-        finalRank,
-        championshipWon,
-        playoffOutcome,
-        outcomeConfidence,
+        ...outcome,
       };
     }).sort((a, b) => {
       // Sort by win percentage descending, then by wins descending

--- a/workers/espn-client/src/sports/football/handlers.ts
+++ b/workers/espn-client/src/sports/football/handlers.ts
@@ -17,6 +17,7 @@ import {
   POSITION_SLOTS,
 } from './mappings';
 import { getCurrentSeasonYear, getSeasonContext, normalizeEspnLeagueStatus } from '../../shared/season';
+import { deriveStandingsOutcome, deriveStandingsSeasonPhase } from '../../shared/standings';
 
 const GAME_ID = 'ffl'; // ESPN's game ID for fantasy football
 
@@ -144,25 +145,13 @@ async function handleGetStandings(
     const data = await response.json() as EspnLeagueResponse;
     const teams = data.teams || [];
 
-    // Determine seasonPhase using sport-aware season year to handle cross-calendar sports correctly.
-    // getCurrentSeasonYear('football') returns 2024 in Jan 2025 (before Jul rollover), so NFL
-    // January playoffs are not incorrectly marked as season_complete.
-    // Primary signal: explicit rankFinal/rankCalculatedFinal → ESPN has finalized the season.
-    const currentSeasonYear = getCurrentSeasonYear('football');
-    const hasExplicitCompletionData = teams.some(
-      (t) => t.rankFinal != null || t.rankCalculatedFinal != null
-    );
-    let seasonPhase: 'regular_season' | 'playoffs_in_progress' | 'season_complete';
-    if (hasExplicitCompletionData || season_year < currentSeasonYear) {
-      seasonPhase = 'season_complete';
-    } else if (season_year === currentSeasonYear) {
-      const regularPeriods = data.settings?.regularSeasonMatchupPeriods ?? 0;
-      const scoringPeriod = data.scoringPeriodId ?? 0;
-      seasonPhase = scoringPeriod > regularPeriods ? 'playoffs_in_progress' : 'regular_season';
-    } else {
-      // season_year > currentSeasonYear — future season, treat as not yet started
-      seasonPhase = 'regular_season';
-    }
+    const seasonPhase = deriveStandingsSeasonPhase({
+      requestedSeasonYear: season_year,
+      currentSeasonYear: getCurrentSeasonYear('football'),
+      scoringPeriodId: data.scoringPeriodId,
+      regularSeasonMatchupPeriods: data.settings?.regularSeasonMatchupPeriods,
+      teams,
+    });
     const seasonComplete = seasonPhase === 'season_complete';
 
     // Transform and sort teams by standings
@@ -174,23 +163,12 @@ async function handleGetStandings(
       const totalGames = wins + losses + ties;
       const winPercentage = totalGames > 0 ? wins / totalGames : 0;
 
-      // Season outcome fields — only populated for completed seasons with explicit ESPN data
-      const rf = team.rankFinal ?? team.rankCalculatedFinal ?? null;
-
-      const finalRank = seasonComplete && rf !== null ? rf : null;
-      const championshipWon = finalRank !== null ? finalRank === 1 : null;
-      const playoffOutcome: 'champion' | 'runner_up' | 'eliminated' | 'missed_playoffs' | null =
-        finalRank !== null
-          ? finalRank === 1 ? 'champion'
-          : finalRank === 2 ? 'runner_up'
-          : team.playoffSeed != null ? 'eliminated'
-          : 'missed_playoffs'
-        : null;
-      const outcomeConfidence: 'explicit' | null = finalRank !== null ? 'explicit' : null;
-      // madePlayoffs: true if playoff seed present; false if season is complete with explicit ranks
-      // but no playoff seed (team missed playoffs); null if unknown
-      const madePlayoffs: boolean | null =
-        team.playoffSeed != null ? true : (seasonComplete && rf !== null ? false : null);
+      const outcome = deriveStandingsOutcome({
+        rankFinal: team.rankFinal,
+        rankCalculatedFinal: team.rankCalculatedFinal,
+        playoffSeed: team.playoffSeed,
+        seasonComplete,
+      });
 
       return {
         teamId: team.id,
@@ -207,11 +185,7 @@ async function handleGetStandings(
         playoffSeed: team.playoffSeed ?? null,
         draftDayProjectedRank: team.draftDayProjectedRank,
         currentProjectedRank: team.currentProjectedRank,
-        madePlayoffs,
-        finalRank,
-        championshipWon,
-        playoffOutcome,
-        outcomeConfidence,
+        ...outcome,
       };
     }).sort((a, b) => {
       // Sort by win percentage descending, then by wins descending

--- a/workers/espn-client/src/sports/hockey/__tests__/standings.test.ts
+++ b/workers/espn-client/src/sports/hockey/__tests__/standings.test.ts
@@ -120,6 +120,12 @@ describe('hockey get_standings handler — seasonPhase and canonical year', () =
     const data = result.data as Record<string, unknown>;
     expect(data.seasonPhase).toBe('season_complete');
     expect(data.seasonYear).toBe(HISTORICAL_CANONICAL_YEAR);
+    const standings = data.standings as Array<Record<string, unknown>>;
+    expect(standings[0].finalRank).toBeNull();
+    expect(standings[0].championshipWon).toBeNull();
+    expect(standings[0].playoffOutcome).toBeNull();
+    expect(standings[0].madePlayoffs).toBeNull();
+    expect(standings[0].outcomeConfidence).toBeNull();
   });
 
   it('returns playoffs_in_progress for current season past regular season periods', async () => {
@@ -145,6 +151,12 @@ describe('hockey get_standings handler — seasonPhase and canonical year', () =
     expect(data.seasonComplete).toBe(false);
     // Response must echo canonical year, not ESPN year
     expect(data.seasonYear).toBe(CURRENT_CANONICAL_YEAR);
+    const standings = data.standings as Array<Record<string, unknown>>;
+    expect(standings[0].finalRank).toBeNull();
+    expect(standings[0].championshipWon).toBeNull();
+    expect(standings[0].playoffOutcome).toBeNull();
+    expect(standings[0].madePlayoffs).toBe(true);
+    expect(standings[0].outcomeConfidence).toBeNull();
   });
 
   it('returns regular_season for current season within regular season periods', async () => {
@@ -167,6 +179,12 @@ describe('hockey get_standings handler — seasonPhase and canonical year', () =
     expect(data.seasonPhase).toBe('regular_season');
     expect(data.seasonComplete).toBe(false);
     expect(data.seasonYear).toBe(CURRENT_CANONICAL_YEAR);
+    const standings = data.standings as Array<Record<string, unknown>>;
+    expect(standings[0].finalRank).toBeNull();
+    expect(standings[0].championshipWon).toBeNull();
+    expect(standings[0].playoffOutcome).toBeNull();
+    expect(standings[0].madePlayoffs).toBeNull();
+    expect(standings[0].outcomeConfidence).toBeNull();
   });
 
   it('uses rankCalculatedFinal when rankFinal is absent', async () => {

--- a/workers/espn-client/src/sports/hockey/handlers.ts
+++ b/workers/espn-client/src/sports/hockey/handlers.ts
@@ -17,6 +17,7 @@ import {
   POSITION_SLOTS,
 } from './mappings';
 import { getCurrentSeasonYear, getSeasonContext, normalizeEspnLeagueStatus } from '../../shared/season';
+import { deriveStandingsOutcome, deriveStandingsSeasonPhase } from '../../shared/standings';
 
 const GAME_ID = 'fhl'; // ESPN's game ID for fantasy hockey
 
@@ -207,25 +208,13 @@ async function handleGetStandings(
     const data = await response.json() as EspnLeagueResponse;
     const teams = data.teams || [];
 
-    // Determine seasonPhase using sport-aware season year to handle cross-calendar sports correctly.
-    // getCurrentSeasonYear('hockey') returns 2025 in Jan 2026 (before Aug rollover), so an
-    // NHL 2025 season mid-playoff request in Jan 2026 is not incorrectly marked season_complete.
-    // Primary signal: explicit rankFinal/rankCalculatedFinal → ESPN has finalized the season.
-    const currentSeasonYear = getCurrentSeasonYear('hockey');
-    const hasExplicitCompletionData = teams.some(
-      (t) => t.rankFinal != null || t.rankCalculatedFinal != null
-    );
-    let seasonPhase: 'regular_season' | 'playoffs_in_progress' | 'season_complete';
-    if (hasExplicitCompletionData || canonicalYear < currentSeasonYear) {
-      seasonPhase = 'season_complete';
-    } else if (canonicalYear === currentSeasonYear) {
-      const regularPeriods = data.settings?.regularSeasonMatchupPeriods ?? 0;
-      const scoringPeriod = data.scoringPeriodId ?? 0;
-      seasonPhase = scoringPeriod > regularPeriods ? 'playoffs_in_progress' : 'regular_season';
-    } else {
-      // canonicalYear > currentSeasonYear — future season, treat as not yet started
-      seasonPhase = 'regular_season';
-    }
+    const seasonPhase = deriveStandingsSeasonPhase({
+      requestedSeasonYear: canonicalYear,
+      currentSeasonYear: getCurrentSeasonYear('hockey'),
+      scoringPeriodId: data.scoringPeriodId,
+      regularSeasonMatchupPeriods: data.settings?.regularSeasonMatchupPeriods,
+      teams,
+    });
     const seasonComplete = seasonPhase === 'season_complete';
 
     // Transform and sort teams by standings
@@ -237,23 +226,12 @@ async function handleGetStandings(
       const totalGames = wins + losses + ties;
       const winPercentage = totalGames > 0 ? wins / totalGames : 0;
 
-      // Season outcome fields — only populated for completed seasons with explicit ESPN data
-      const rf = team.rankFinal ?? team.rankCalculatedFinal ?? null;
-
-      const finalRank = seasonComplete && rf !== null ? rf : null;
-      const championshipWon = finalRank !== null ? finalRank === 1 : null;
-      const playoffOutcome: 'champion' | 'runner_up' | 'eliminated' | 'missed_playoffs' | null =
-        finalRank !== null
-          ? finalRank === 1 ? 'champion'
-          : finalRank === 2 ? 'runner_up'
-          : team.playoffSeed != null ? 'eliminated'
-          : 'missed_playoffs'
-        : null;
-      const outcomeConfidence: 'explicit' | null = finalRank !== null ? 'explicit' : null;
-      // madePlayoffs: true if playoff seed present; false if season is complete with explicit ranks
-      // but no playoff seed (team missed playoffs); null if unknown
-      const madePlayoffs: boolean | null =
-        team.playoffSeed != null ? true : (seasonComplete && rf !== null ? false : null);
+      const outcome = deriveStandingsOutcome({
+        rankFinal: team.rankFinal,
+        rankCalculatedFinal: team.rankCalculatedFinal,
+        playoffSeed: team.playoffSeed,
+        seasonComplete,
+      });
 
       return {
         teamId: team.id,
@@ -270,11 +248,7 @@ async function handleGetStandings(
         playoffSeed: team.playoffSeed ?? null,
         draftDayProjectedRank: team.draftDayProjectedRank,
         currentProjectedRank: team.currentProjectedRank,
-        madePlayoffs,
-        finalRank,
-        championshipWon,
-        playoffOutcome,
-        outcomeConfidence,
+        ...outcome,
       };
     }).sort((a, b) => {
       // Sort by win percentage descending, then by wins descending


### PR DESCRIPTION
## Summary
- add missing ESPN standings characterization coverage for baseball and strengthen basketball/hockey null-branch assertions
- extract ESPN-only standings season-phase and outcome derivation into a shared espn-client helper
- keep season-year routing and outward response assembly local to each sport handler

## Validation
- corepack pnpm --dir workers/espn-client exec tsc --noEmit
- corepack pnpm --dir workers/espn-client test
- git diff --check