### PR TITLE
[codex] fix Yahoo token refresh handling

### DIFF
--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -60,6 +60,8 @@ Stores Yahoo OAuth credentials for a Clerk user.
 | refresh_token | text | Yahoo OAuth refresh token |
 | expires_at | timestamptz | Access token expiry |
 | yahoo_guid | text | Optional Yahoo user GUID |
+| refresh_lease_owner | text | Short-lived owner ID for single-writer token refresh |
+| refresh_lease_expires_at | timestamptz | Expiry for the refresh lease |
 | created_at | timestamptz | Created timestamp |
 | updated_at | timestamptz | Updated timestamp |
 

--- a/web/app/(site)/leagues/page.tsx
+++ b/web/app/(site)/leagues/page.tsx
@@ -152,6 +152,21 @@ function capitalize(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1);
 }
 
+function getYahooConnectErrorMessage(error: string, description: string | null): string {
+  switch (error) {
+    case 'token_refresh_validation_failed':
+      return 'Yahoo connection did not complete because the refresh token could not be validated. Please connect Yahoo again.';
+    case 'token_refresh_validation_unavailable':
+      return 'Yahoo connection could not be validated because Yahoo was temporarily unavailable. Please try again in a few minutes.';
+    case 'token_exchange_failed':
+      return description || 'Yahoo connection failed while exchanging the authorization code. Please try again.';
+    case 'oauth_denied':
+      return 'Yahoo connection was canceled.';
+    default:
+      return description || 'Yahoo connection failed. Please try again.';
+  }
+}
+
 // Convert ESPN leagues to unified format (isDefault computed from preferences)
 function espnToUnified(leagues: League[], preferences: UserPreferencesState): UnifiedLeague[] {
   return leagues.map((l) => {
@@ -617,6 +632,13 @@ function LeaguesPageContent() {
       }
     };
     loadPreferences();
+
+    const yahooError = searchParams.get('error');
+    if (yahooError) {
+      setLeagueError(getYahooConnectErrorMessage(yahooError, searchParams.get('error_description')));
+      setIsYahooSetupOpen(true);
+      router.replace('/leagues', { scroll: false });
+    }
 
     const yahooParam = searchParams.get('yahoo');
     if (yahooParam === 'connected') {

--- a/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
@@ -206,18 +206,30 @@ describe('yahoo-connect-handlers', () => {
         redirectAfter: undefined,
       });
 
-      // Mock successful token exchange
-      mockFetch.mockResolvedValue(
-        new Response(
-          JSON.stringify({
-            access_token: 'yahoo-access-token',
-            refresh_token: 'yahoo-refresh-token',
-            expires_in: 3600,
-            xoauth_yahoo_guid: 'yahoo-guid-123',
-          }),
-          { status: 200 }
+      // Mock successful token exchange, then the callback's immediate refresh validation
+      mockFetch
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              access_token: 'yahoo-access-token',
+              refresh_token: 'yahoo-refresh-token',
+              expires_in: 3600,
+              xoauth_yahoo_guid: 'yahoo-guid-123',
+            }),
+            { status: 200 }
+          )
         )
-      );
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              access_token: 'validated-access-token',
+              refresh_token: 'validated-refresh-token',
+              expires_in: 3600,
+              xoauth_yahoo_guid: 'yahoo-guid-123',
+            }),
+            { status: 200 }
+          )
+        );
 
       const request = new Request('https://api.flaim.app/connect/yahoo/callback?code=auth_code&state=user_abc123:nonce');
 
@@ -232,11 +244,205 @@ describe('yahoo-connect-handlers', () => {
       expect(mockStorage.saveYahooCredentials).toHaveBeenCalledWith(
         expect.objectContaining({
           clerkUserId: 'user_abc123',
-          accessToken: 'yahoo-access-token',
-          refreshToken: 'yahoo-refresh-token',
+          accessToken: 'validated-access-token',
+          refreshToken: 'validated-refresh-token',
           yahooGuid: 'yahoo-guid-123',
         })
       );
+
+      const exchangeRequest = mockFetch.mock.calls[0][1] as RequestInit;
+      const exchangeBody = new URLSearchParams(exchangeRequest.body as string);
+      expect(exchangeBody.get('grant_type')).toBe('authorization_code');
+      expect(exchangeBody.get('redirect_uri')).toBe('https://api.flaim.app/auth/connect/yahoo/callback');
+
+      const validationRequest = mockFetch.mock.calls[1][1] as RequestInit;
+      const validationBody = new URLSearchParams(validationRequest.body as string);
+      expect(validationBody.get('grant_type')).toBe('refresh_token');
+      expect(validationBody.get('refresh_token')).toBe('yahoo-refresh-token');
+      expect(validationBody.get('redirect_uri')).toBe('https://api.flaim.app/auth/connect/yahoo/callback');
+    });
+
+    it('keeps the original refresh token when callback validation does not rotate it', async () => {
+      mockStorage.consumePlatformOAuthState.mockResolvedValue({
+        clerkUserId: 'user_abc123',
+        platform: 'yahoo',
+        redirectAfter: undefined,
+      });
+
+      mockFetch
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              access_token: 'yahoo-access-token',
+              refresh_token: 'yahoo-refresh-token',
+              expires_in: 3600,
+              xoauth_yahoo_guid: 'yahoo-guid-123',
+            }),
+            { status: 200 }
+          )
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              access_token: 'validated-access-token',
+              expires_in: 3600,
+              xoauth_yahoo_guid: 'yahoo-guid-123',
+            }),
+            { status: 200 }
+          )
+        );
+
+      const request = new Request('https://api.flaim.app/connect/yahoo/callback?code=auth_code&state=user_abc123:nonce');
+
+      const response = await handleYahooCallback(request, env, corsHeaders);
+
+      expect(response.status).toBe(302);
+      expect(mockStorage.saveYahooCredentials).toHaveBeenCalledWith(
+        expect.objectContaining({
+          accessToken: 'validated-access-token',
+          refreshToken: 'yahoo-refresh-token',
+        })
+      );
+    });
+
+    it('returns error redirect when refresh validation fails after token exchange', async () => {
+      mockStorage.consumePlatformOAuthState.mockResolvedValue({
+        clerkUserId: 'user_abc123',
+        platform: 'yahoo',
+      });
+
+      mockFetch
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              access_token: 'yahoo-access-token',
+              refresh_token: 'bad-refresh-token',
+              expires_in: 3600,
+            }),
+            { status: 200 }
+          )
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              error: 'invalid_grant',
+              error_description: 'Refresh token rejected',
+            }),
+            { status: 400 }
+          )
+        );
+
+      const request = new Request('https://api.flaim.app/connect/yahoo/callback?code=auth_code&state=user_abc123:nonce');
+
+      const response = await handleYahooCallback(request, env, corsHeaders);
+
+      expect(response.status).toBe(302);
+      const location = response.headers.get('Location')!;
+      expect(location).toContain('error=token_refresh_validation_failed');
+      expect(mockStorage.saveYahooCredentials).not.toHaveBeenCalled();
+    });
+
+    it('returns temporary error redirect when refresh validation has a transient Yahoo error', async () => {
+      mockStorage.consumePlatformOAuthState.mockResolvedValue({
+        clerkUserId: 'user_abc123',
+        platform: 'yahoo',
+      });
+
+      mockFetch
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              access_token: 'yahoo-access-token',
+              refresh_token: 'yahoo-refresh-token',
+              expires_in: 3600,
+            }),
+            { status: 200 }
+          )
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              error: 'temporarily_unavailable',
+              error_description: 'Try again later',
+            }),
+            { status: 503 }
+          )
+        );
+
+      const request = new Request('https://api.flaim.app/connect/yahoo/callback?code=auth_code&state=user_abc123:nonce');
+
+      const response = await handleYahooCallback(request, env, corsHeaders);
+
+      expect(response.status).toBe(302);
+      const location = response.headers.get('Location')!;
+      expect(location).toContain('error=token_refresh_validation_unavailable');
+      expect(mockStorage.saveYahooCredentials).not.toHaveBeenCalled();
+    });
+
+    it('returns temporary error redirect when refresh validation aborts', async () => {
+      mockStorage.consumePlatformOAuthState.mockResolvedValue({
+        clerkUserId: 'user_abc123',
+        platform: 'yahoo',
+      });
+
+      const abortError = new DOMException('The operation was aborted', 'AbortError');
+      mockFetch
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              access_token: 'yahoo-access-token',
+              refresh_token: 'yahoo-refresh-token',
+              expires_in: 3600,
+            }),
+            { status: 200 }
+          )
+        )
+        .mockRejectedValueOnce(abortError);
+
+      const request = new Request('https://api.flaim.app/connect/yahoo/callback?code=auth_code&state=user_abc123:nonce');
+
+      const response = await handleYahooCallback(request, env, corsHeaders);
+
+      expect(response.status).toBe(302);
+      const location = response.headers.get('Location')!;
+      expect(location).toContain('error=token_refresh_validation_unavailable');
+      expect(mockStorage.saveYahooCredentials).not.toHaveBeenCalled();
+    });
+
+    it('returns error redirect when refresh validation omits expires_in', async () => {
+      mockStorage.consumePlatformOAuthState.mockResolvedValue({
+        clerkUserId: 'user_abc123',
+        platform: 'yahoo',
+      });
+
+      mockFetch
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              access_token: 'yahoo-access-token',
+              refresh_token: 'yahoo-refresh-token',
+              expires_in: 3600,
+            }),
+            { status: 200 }
+          )
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              access_token: 'validated-access-token',
+            }),
+            { status: 200 }
+          )
+        );
+
+      const request = new Request('https://api.flaim.app/connect/yahoo/callback?code=auth_code&state=user_abc123:nonce');
+
+      const response = await handleYahooCallback(request, env, corsHeaders);
+
+      expect(response.status).toBe(302);
+      const location = response.headers.get('Location')!;
+      expect(location).toContain('error=token_refresh_validation_failed');
+      expect(mockStorage.saveYahooCredentials).not.toHaveBeenCalled();
     });
 
     it('returns error redirect when token exchange fails', async () => {
@@ -313,6 +519,17 @@ describe('yahoo-connect-handlers', () => {
       expect(response.status).toBe(200);
       const body = (await response.json()) as Record<string, unknown>;
       expect(body.access_token).toBe('new-access-token');
+
+      const refreshRequest = mockFetch.mock.calls[0][1] as RequestInit;
+      const refreshBody = new URLSearchParams(refreshRequest.body as string);
+      expect(refreshBody.get('grant_type')).toBe('refresh_token');
+      expect(refreshBody.get('redirect_uri')).toBe('https://api.flaim.app/auth/connect/yahoo/callback');
+      expect(mockStorage.acquireRefreshLease).toHaveBeenCalledWith(
+        'user_123',
+        expect.any(String),
+        30_000,
+        'refresh-token'
+      );
 
       // Verify credentials were updated (3rd arg is the lease ownerId)
       expect(mockStorage.updateYahooCredentials).toHaveBeenCalledWith(

--- a/workers/auth-worker/src/__tests__/yahoo-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-storage.test.ts
@@ -224,6 +224,8 @@ describe('YahooStorage', () => {
           access_token: 'yahoo-access-token',
           refresh_token: 'yahoo-refresh-token',
           yahoo_guid: 'yahoo-user-guid',
+          refresh_lease_owner: null,
+          refresh_lease_expires_at: null,
         }),
         expect.objectContaining({ onConflict: 'clerk_user_id' })
       );
@@ -361,7 +363,7 @@ describe('YahooStorage', () => {
     it('returns true when the lease update succeeds', async () => {
       mockSelect.mockResolvedValue({ data: [{ clerk_user_id: 'user_123' }], error: null });
 
-      const result = await storage.acquireRefreshLease('user_123', 'owner-1', 30_000);
+      const result = await storage.acquireRefreshLease('user_123', 'owner-1', 30_000, 'refresh-token');
 
       expect(result).toBe(true);
       expect(mockUpdate).toHaveBeenCalledWith(
@@ -369,23 +371,39 @@ describe('YahooStorage', () => {
           refresh_lease_owner: 'owner-1',
         })
       );
+      expect(mockEq).toHaveBeenCalledWith('refresh_token', 'refresh-token');
       expect(mockOr).toHaveBeenCalledTimes(1);
       expect(mockOr).toHaveBeenCalledWith(expect.stringContaining('refresh_lease_expires_at.is.null'));
+      expect(mockOr).toHaveBeenCalledWith(expect.stringContaining('refresh_lease_expires_at.lt."'));
     });
 
     it('returns false when another owner already holds the lease', async () => {
       mockSelect.mockResolvedValue({ data: [], error: null });
 
-      const result = await storage.acquireRefreshLease('user_123', 'owner-1', 30_000);
+      const result = await storage.acquireRefreshLease('user_123', 'owner-1', 30_000, 'refresh-token');
 
       expect(result).toBe(false);
+    });
+
+    it('guards lease acquisition by the refresh token the caller read', async () => {
+      mockSelect.mockResolvedValue({ data: [{ clerk_user_id: 'user_123' }], error: null });
+
+      const result = await storage.acquireRefreshLease(
+        'user_123',
+        'owner-1',
+        30_000,
+        'expected-refresh-token'
+      );
+
+      expect(result).toBe(true);
+      expect(mockEq).toHaveBeenCalledWith('refresh_token', 'expected-refresh-token');
     });
 
     it('throws when lease acquisition hits a storage error', async () => {
       mockSelect.mockResolvedValue({ data: null, error: { message: 'DB down' } });
 
       await expect(
-        storage.acquireRefreshLease('user_123', 'owner-1', 30_000)
+        storage.acquireRefreshLease('user_123', 'owner-1', 30_000, 'refresh-token')
       ).rejects.toThrow('Failed to acquire Yahoo refresh lease');
     });
   });

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -40,6 +40,7 @@ interface YahooTokenResponse {
   expires_in: number;
   token_type: string;
   xoauth_yahoo_guid?: string;
+  status?: number;
   error?: string;
   error_description?: string;
 }
@@ -103,6 +104,18 @@ function looksLikeNewerCredentials(
 }
 
 const sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
+
+function isUsableTokenResponse(response: YahooTokenResponse): boolean {
+  return typeof response.access_token === 'string'
+    && response.access_token.length > 0
+    && typeof response.expires_in === 'number'
+    && Number.isFinite(response.expires_in)
+    && response.expires_in > 0;
+}
+
+function isTransientYahooTokenError(status?: number): boolean {
+  return status === 429 || (typeof status === 'number' && status >= 500);
+}
 
 // =============================================================================
 // TOKEN ACQUISITION
@@ -187,7 +200,12 @@ async function getValidYahooAccessToken(
     }
 
     const ownerId = crypto.randomUUID();
-    const won = await storage.acquireRefreshLease(userId, ownerId, LEASE_TTL_MS);
+    const won = await storage.acquireRefreshLease(
+      userId,
+      ownerId,
+      LEASE_TTL_MS,
+      credentials.refreshToken
+    );
 
     if (!won) {
       const latest = await storage.getYahooCredentials(userId);
@@ -220,8 +238,12 @@ async function getValidYahooAccessToken(
     let result: YahooTokenResponse;
     try {
       result = await refreshAccessToken(credentials.refreshToken, env, controller.signal);
-    } catch {
+    } catch (error) {
       clearTimeout(timer);
+      console.error(
+        `[yahoo-connect] Yahoo token refresh request failed for user ${maskUserId(userId)}:`,
+        error instanceof Error ? error.message : error
+      );
       try {
         await storage.releaseRefreshLease(userId, ownerId);
       } catch (releaseError) {
@@ -232,6 +254,11 @@ async function getValidYahooAccessToken(
     clearTimeout(timer);
 
     if (result.error) {
+      const statusSuffix = result.status ? ` (HTTP ${result.status})` : '';
+      console.error(
+        `[yahoo-connect] Yahoo token refresh failed for user ${maskUserId(userId)}: ${result.error}${statusSuffix}` +
+          (result.error_description ? ` - ${result.error_description}` : '')
+      );
       try {
         await storage.releaseRefreshLease(userId, ownerId);
       } catch (releaseError) {
@@ -246,6 +273,16 @@ async function getValidYahooAccessToken(
         error: 'refresh_failed',
         errorDescription: result.error_description || 'Failed to refresh access token',
       };
+    }
+
+    if (!isUsableTokenResponse(result)) {
+      console.error(`[yahoo-connect] Yahoo token refresh returned an invalid token response for user ${maskUserId(userId)}`);
+      try {
+        await storage.releaseRefreshLease(userId, ownerId);
+      } catch (releaseError) {
+        console.warn('[yahoo-connect] Failed to release Yahoo refresh lease after invalid Yahoo refresh response:', releaseError);
+      }
+      return { error: 'refresh_failed', errorDescription: 'Failed to refresh access token' };
     }
 
     const expiresAt = new Date(Date.now() + result.expires_in * 1000);
@@ -425,16 +462,66 @@ export async function handleYahooCallback(
       return errorRedirect('token_exchange_failed', 'Yahoo did not provide a refresh token');
     }
 
-    // Calculate token expiration
-    const expiresAt = new Date(Date.now() + tokenResponse.expires_in * 1000);
+    // This intentional second Yahoo call proves the refresh path works now,
+    // so reconnect cannot look successful and then fail after access-token expiry.
+    const validationController = new AbortController();
+    const validationTimer = setTimeout(() => validationController.abort(), REFRESH_TIMEOUT_MS);
+    let validatedTokenResponse: YahooTokenResponse;
+    try {
+      validatedTokenResponse = await refreshAccessToken(
+        tokenResponse.refresh_token,
+        env,
+        validationController.signal
+      );
+    } catch (error) {
+      clearTimeout(validationTimer);
+      console.error(
+        '[yahoo-connect] Refresh token validation failed after Yahoo callback:',
+        error instanceof Error ? error.message : error
+      );
+      return errorRedirect(
+        'token_refresh_validation_unavailable',
+        'Yahoo refresh token validation is temporarily unavailable. Please try again.'
+      );
+    }
+    clearTimeout(validationTimer);
+
+    if (validatedTokenResponse.error) {
+      const statusSuffix = validatedTokenResponse.status ? ` (HTTP ${validatedTokenResponse.status})` : '';
+      const isTransient = isTransientYahooTokenError(validatedTokenResponse.status);
+      console.error(
+        `[yahoo-connect] Refresh token validation failed after Yahoo callback: ${validatedTokenResponse.error}${statusSuffix}` +
+          (validatedTokenResponse.error_description ? ` - ${validatedTokenResponse.error_description}` : '')
+      );
+      return errorRedirect(
+        isTransient ? 'token_refresh_validation_unavailable' : 'token_refresh_validation_failed',
+        isTransient
+          ? 'Yahoo refresh token validation is temporarily unavailable. Please try again.'
+          : 'Yahoo refresh token validation failed'
+      );
+    }
+
+    if (!isUsableTokenResponse(validatedTokenResponse)) {
+      console.error('[yahoo-connect] Refresh token validation returned an invalid token response after Yahoo callback');
+      return errorRedirect(
+        'token_refresh_validation_failed',
+        'Yahoo refresh token validation failed'
+      );
+    }
+
+    const refreshToken = validatedTokenResponse.refresh_token || tokenResponse.refresh_token;
+    const yahooGuid = validatedTokenResponse.xoauth_yahoo_guid || tokenResponse.xoauth_yahoo_guid;
+
+    // Calculate token expiration from the validated refresh response.
+    const expiresAt = new Date(Date.now() + validatedTokenResponse.expires_in * 1000);
 
     // Save credentials
     await storage.saveYahooCredentials({
       clerkUserId,
-      accessToken: tokenResponse.access_token,
-      refreshToken: tokenResponse.refresh_token,
+      accessToken: validatedTokenResponse.access_token,
+      refreshToken,
       expiresAt,
-      yahooGuid: tokenResponse.xoauth_yahoo_guid,
+      yahooGuid,
     });
 
     console.log(`[yahoo-connect] Successfully connected user ${maskUserId(clerkUserId)} to Yahoo`);
@@ -647,6 +734,7 @@ async function exchangeCodeForTokens(
       token_type: 'bearer',
       error: data.error || 'token_error',
       error_description: data.error_description || 'Failed to exchange code for tokens',
+      status: response.status,
     };
   }
 
@@ -671,6 +759,7 @@ async function refreshAccessToken(
     },
     body: new URLSearchParams({
       grant_type: 'refresh_token',
+      redirect_uri: getCallbackUrl(env),
       refresh_token: refreshToken,
     }).toString(),
     signal,
@@ -685,6 +774,7 @@ async function refreshAccessToken(
       token_type: 'bearer',
       error: data.error || 'refresh_error',
       error_description: data.error_description || 'Failed to refresh access token',
+      status: response.status,
     };
   }
 

--- a/workers/auth-worker/src/yahoo-storage.ts
+++ b/workers/auth-worker/src/yahoo-storage.ts
@@ -192,6 +192,9 @@ export class YahooStorage {
         expires_at: params.expiresAt.toISOString(),
         yahoo_guid: params.yahooGuid || null,
         updated_at: new Date().toISOString(),
+        // Reconnect replaces the token set, so any outstanding refresh winner is stale.
+        refresh_lease_owner: null,
+        refresh_lease_expires_at: null,
       },
       { onConflict: 'clerk_user_id' }
     );
@@ -290,23 +293,29 @@ export class YahooStorage {
    *
    * The update only succeeds if no other owner holds an unexpired lease
    * (refresh_lease_owner IS NULL OR refresh_lease_expires_at < now).
+   * The token row must still match the credentials the caller read before
+   * trying to refresh.
    * Returns true if this caller won the lease, false if another holder beat them.
    */
   async acquireRefreshLease(
     clerkUserId: string,
     ownerId: string,
-    ttlMs: number
+    ttlMs: number,
+    expectedRefreshToken: string
   ): Promise<boolean> {
     const expiresAt = new Date(Date.now() + ttlMs).toISOString();
     const now = new Date().toISOString();
-    const { data, error } = await this.supabase
+    const query = this.supabase
       .from('yahoo_credentials')
       .update({
         refresh_lease_owner: ownerId,
         refresh_lease_expires_at: expiresAt,
       })
       .eq('clerk_user_id', clerkUserId)
-      .or(`refresh_lease_owner.is.null,refresh_lease_expires_at.lt.${now},refresh_lease_expires_at.is.null`)
+      .eq('refresh_token', expectedRefreshToken);
+
+    const { data, error } = await query
+      .or(`refresh_lease_owner.is.null,refresh_lease_expires_at.lt."${now}",refresh_lease_expires_at.is.null`)
       .select('clerk_user_id');
 
     if (error) {

--- a/workers/yahoo-client/src/shared/__tests__/auth.test.ts
+++ b/workers/yahoo-client/src/shared/__tests__/auth.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi, type MockedFunction } from 'vitest';
+import { authWorkerFetch } from '@flaim/worker-shared';
+import type { Env } from '../../types';
+import { getYahooCredentials, resolveUserTeamKey } from '../auth';
+
+vi.mock('@flaim/worker-shared', () => ({
+  authWorkerFetch: vi.fn(),
+}));
+
+const mockAuthWorkerFetch = authWorkerFetch as MockedFunction<typeof authWorkerFetch>;
+
+describe('getYahooCredentials', () => {
+  const env = {} as Env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('includes auth-worker error descriptions in thrown errors', async () => {
+    mockAuthWorkerFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: 'refresh_failed',
+          error_description: 'Refresh token expired',
+        }),
+        { status: 401 }
+      )
+    );
+
+    await expect(getYahooCredentials(env, 'Bearer token')).rejects.toThrow(
+      'YAHOO_AUTH_ERROR: refresh_failed: Refresh token expired'
+    );
+  });
+
+  it('classifies auth-worker failures while resolving Yahoo team keys', async () => {
+    mockAuthWorkerFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: 'refresh_failed',
+          error_description: 'Refresh token expired',
+        }),
+        { status: 401 }
+      )
+    );
+
+    await expect(resolveUserTeamKey(env, '461.l.12345', 'Bearer token')).rejects.toThrow(
+      'YAHOO_AUTH_ERROR: refresh_failed: Refresh token expired'
+    );
+  });
+
+  it('returns null when Yahoo team key resolution receives a 404', async () => {
+    mockAuthWorkerFetch.mockResolvedValue(new Response(null, { status: 404 }));
+
+    await expect(resolveUserTeamKey(env, '461.l.12345', 'Bearer token')).resolves.toBeNull();
+  });
+});

--- a/workers/yahoo-client/src/shared/auth.ts
+++ b/workers/yahoo-client/src/shared/auth.ts
@@ -5,6 +5,18 @@ export interface YahooCredentials {
   accessToken: string;
 }
 
+async function throwYahooAuthWorkerError(response: Response): Promise<never> {
+  const errorData = await response.json().catch(() => ({})) as {
+    error?: string;
+    error_description?: string;
+  };
+  const errorSummary = errorData.error || response.statusText;
+  const errorDetail = errorData.error_description
+    ? `${errorSummary}: ${errorData.error_description}`
+    : errorSummary;
+  throw new Error(`YAHOO_AUTH_ERROR: ${errorDetail}`);
+}
+
 export async function getYahooCredentials(
   env: Env,
   authHeader?: string,
@@ -32,8 +44,7 @@ export async function getYahooCredentials(
   }
 
   if (!response.ok) {
-    const errorData = await response.json().catch(() => ({})) as { error?: string };
-    throw new Error(`Auth-worker error: ${errorData.error || response.statusText}`);
+    await throwYahooAuthWorkerError(response);
   }
 
   // auth-worker returns snake_case, we normalize to camelCase
@@ -67,9 +78,12 @@ export async function resolveUserTeamKey(
     headers,
   });
 
+  if (response.status === 404) {
+    return null;
+  }
+
   if (!response.ok) {
-    const errorData = await response.json().catch(() => ({})) as { error?: string };
-    throw new Error(`Auth-worker error: ${errorData.error || response.statusText}`);
+    await throwYahooAuthWorkerError(response);
   }
 
   const data = (await response.json()) as { leagues?: YahooLeagueEntry[] };


### PR DESCRIPTION
## Summary
- include Yahoo documented redirect_uri parameter on refresh-token requests
- validate Yahoo refresh-token usability during reconnect before showing connected
- distinguish temporary Yahoo validation failures from permanent refresh-token rejection during reconnect
- guard refresh leases by the originally-read refresh token, clear stale leases on reconnect, and quote PostgREST timestamp filters for expired leases
- propagate Yahoo auth failures as YAHOO_AUTH_ERROR instead of INTERNAL_ERROR
- document Yahoo refresh lease columns

## Root cause
Yahoo access tokens expire after about one hour. The reconnect path stored a fresh access token and refresh token, but the later refresh request omitted redirect_uri, which Yahoo documents as part of the refresh-token request. That made reconnect appear successful until the access token expired and the next roster pull had to refresh.

## Review notes addressed
- validated refresh responses now require a usable access_token and finite positive expires_in before storage
- callback validation maps Yahoo 429/5xx or timeout/network failures to a temporary retry message instead of telling the user the token is invalid
- both authorization-code exchange and refresh validation assert redirect_uri in tests
- acquireRefreshLease requires expectedRefreshToken and uses quoted PostgREST timestamp syntax
- /leagues renders Yahoo callback errors, including token_refresh_validation_failed and token_refresh_validation_unavailable

## Validation
- corepack pnpm --dir workers/auth-worker exec vitest run src/__tests__/yahoo-connect-handlers.test.ts src/__tests__/yahoo-storage.test.ts
- corepack pnpm --dir workers/yahoo-client exec vitest run src/shared/__tests__/auth.test.ts
- corepack pnpm --dir workers/auth-worker run type-check
- corepack pnpm --dir workers/yahoo-client run type-check
- corepack pnpm --dir web exec tsc --noEmit