### PR TITLE
[codex] make Yahoo refresh reauthorize

### DIFF
--- a/web/app/(site)/leagues/page.tsx
+++ b/web/app/(site)/leagues/page.tsx
@@ -167,6 +167,23 @@ function getYahooConnectErrorMessage(error: string, description: string | null):
   }
 }
 
+interface YahooDiscoverErrorResponse {
+  error?: string;
+  error_description?: string;
+}
+
+function parseYahooDiscoverErrorResponse(data: unknown): YahooDiscoverErrorResponse {
+  if (!data || typeof data !== 'object') {
+    return {};
+  }
+
+  const record = data as Record<string, unknown>;
+  return {
+    error: typeof record.error === 'string' ? record.error : undefined,
+    error_description: typeof record.error_description === 'string' ? record.error_description : undefined,
+  };
+}
+
 // Convert ESPN leagues to unified format (isDefault computed from preferences)
 function espnToUnified(leagues: League[], preferences: UserPreferencesState): UnifiedLeague[] {
   return leagues.map((l) => {
@@ -577,10 +594,7 @@ function LeaguesPageContent() {
     setLeagueError(null);
     try {
       const res = await fetch('/api/connect/yahoo/discover', { method: 'POST' });
-      const data = await res.json().catch(() => ({})) as {
-        error?: string;
-        error_description?: string;
-      };
+      const data = parseYahooDiscoverErrorResponse(await res.json().catch(() => null));
       if (!res.ok) {
         if (
           res.status === 401 ||
@@ -598,10 +612,10 @@ function LeaguesPageContent() {
       console.error('Failed to discover Yahoo leagues:', err);
       setLeagueError(err instanceof Error ? err.message : 'Failed to refresh Yahoo leagues');
     } finally {
-      await checkYahooStatus().catch((err: unknown) => {
+      setIsDiscoveringYahoo(false);
+      void checkYahooStatus().catch((err: unknown) => {
         console.error('Failed to refresh Yahoo status:', err);
       });
-      setIsDiscoveringYahoo(false);
     }
   };
 
@@ -609,6 +623,14 @@ function LeaguesPageContent() {
     setLeagueError(null);
     setLeagueNotice(null);
     setIsRefreshingYahooAuth(true);
+    function handlePageHide() {
+      window.clearTimeout(resetTimer);
+    }
+    const resetTimer = window.setTimeout(() => {
+      window.removeEventListener('pagehide', handlePageHide);
+      setIsRefreshingYahooAuth(false);
+    }, 10_000);
+    window.addEventListener('pagehide', handlePageHide, { once: true });
     window.location.href = '/api/connect/yahoo/authorize';
   };
 

--- a/web/app/(site)/leagues/page.tsx
+++ b/web/app/(site)/leagues/page.tsx
@@ -596,6 +596,7 @@ function LeaguesPageContent() {
     let shouldCheckYahooStatus = true;
     try {
       const res = await fetch('/api/connect/yahoo/discover', { method: 'POST' });
+      // Auth-worker error bodies carry reconnect codes even when the response is not ok.
       const data = parseYahooDiscoverErrorResponse(await res.json().catch(() => null));
       if (!res.ok) {
         if (
@@ -604,6 +605,7 @@ function LeaguesPageContent() {
           data.error === 'not_connected' ||
           data.error === 'refresh_failed'
         ) {
+          // The opened panel and notice are the reconnect prompt, so skip the error banner.
           setIsYahooSetupOpen(true);
           setLeagueNotice('Your Yahoo session has expired. Click Refresh to sign in again and pull your latest leagues.');
           shouldCheckYahooStatus = false;
@@ -638,7 +640,7 @@ function LeaguesPageContent() {
     }
 
     const resetRefreshState = () => setIsRefreshingYahooAuth(false);
-    const resetTimer = window.setTimeout(resetRefreshState, 10_000);
+    const resetTimer = window.setTimeout(resetRefreshState, 60_000);
     const handlePageHide = () => {
       window.clearTimeout(resetTimer);
     };
@@ -649,7 +651,7 @@ function LeaguesPageContent() {
     };
 
     window.addEventListener('pagehide', handlePageHide, { once: true });
-    window.addEventListener('pageshow', handlePageShow);
+    window.addEventListener('pageshow', handlePageShow, { once: true });
 
     return () => {
       window.clearTimeout(resetTimer);

--- a/web/app/(site)/leagues/page.tsx
+++ b/web/app/(site)/leagues/page.tsx
@@ -589,6 +589,7 @@ function LeaguesPageContent() {
           data.error === 'refresh_failed'
         ) {
           setIsYahooSetupOpen(true);
+          return;
         }
         throw new Error(data.error_description || data.error || 'Failed to refresh Yahoo leagues');
       }
@@ -597,7 +598,9 @@ function LeaguesPageContent() {
       console.error('Failed to discover Yahoo leagues:', err);
       setLeagueError(err instanceof Error ? err.message : 'Failed to refresh Yahoo leagues');
     } finally {
-      await checkYahooStatus();
+      await checkYahooStatus().catch((err: unknown) => {
+        console.error('Failed to refresh Yahoo status:', err);
+      });
       setIsDiscoveringYahoo(false);
     }
   };
@@ -606,7 +609,6 @@ function LeaguesPageContent() {
     setLeagueError(null);
     setLeagueNotice(null);
     setIsRefreshingYahooAuth(true);
-    window.setTimeout(() => setIsRefreshingYahooAuth(false), 10_000);
     window.location.href = '/api/connect/yahoo/authorize';
   };
 

--- a/web/app/(site)/leagues/page.tsx
+++ b/web/app/(site)/leagues/page.tsx
@@ -279,6 +279,7 @@ function LeaguesPageContent() {
   const [isYahooDisconnecting, setIsYahooDisconnecting] = useState(false);
   const [yahooLeagues, setYahooLeagues] = useState<YahooLeague[]>([]);
   const [isDiscoveringYahoo, setIsDiscoveringYahoo] = useState(false);
+  const [isRefreshingYahooAuth, setIsRefreshingYahooAuth] = useState(false);
   const [sleeperLeagues, setSleeperLeagues] = useState<SleeperLeague[]>([]);
   const [deletingSleeperKey, setDeletingSleeperKey] = useState<string | null>(null);
   const [isSleeperSetupOpen, setIsSleeperSetupOpen] = useState(false);
@@ -571,18 +572,36 @@ function LeaguesPageContent() {
     }
   };
 
-  const discoverYahooLeagues = async () => {
+  const discoverYahooLeagues = async (): Promise<boolean> => {
     setIsDiscoveringYahoo(true);
+    setLeagueError(null);
     try {
       const res = await fetch('/api/connect/yahoo/discover', { method: 'POST' });
-      if (res.ok) {
-        await loadYahooLeagues();
+      const data = await res.json().catch(() => ({})) as {
+        error?: string;
+        error_description?: string;
+      };
+      if (!res.ok) {
+        throw new Error(data.error_description || data.error || 'Failed to refresh Yahoo leagues');
       }
+      await loadYahooLeagues();
+      return true;
     } catch (err) {
       console.error('Failed to discover Yahoo leagues:', err);
+      setIsYahooSetupOpen(true);
+      setLeagueError(err instanceof Error ? err.message : 'Failed to refresh Yahoo leagues');
+      return false;
     } finally {
+      await checkYahooStatus();
       setIsDiscoveringYahoo(false);
     }
+  };
+
+  const refreshYahooAuth = () => {
+    setLeagueError(null);
+    setLeagueNotice(null);
+    setIsRefreshingYahooAuth(true);
+    window.location.href = '/api/connect/yahoo/authorize';
   };
 
   const disconnectYahoo = async () => {
@@ -645,7 +664,7 @@ function LeaguesPageContent() {
       // Just came from OAuth — trust the param, skip status check
       setIsYahooConnected(true);
       setIsCheckingYahoo(false);
-      discoverYahooLeagues();
+      void discoverYahooLeagues();
       router.replace('/leagues', { scroll: false });
     } else {
       // Normal page load — check status from backend
@@ -1996,7 +2015,7 @@ function LeaguesPageContent() {
                 <div id="yahoo-setup-content" className="px-4 pb-4 space-y-3">
                   <p className="text-sm text-muted-foreground">
                     {isYahooConnected
-                      ? 'Use the Refresh Leagues button to trigger a fresh pull of your leagues, teams, and seasons from Yahoo.'
+                      ? 'Refresh signs in with Yahoo again, validates access, then pulls your latest leagues.'
                       : 'Connect your Yahoo account to add leagues.'}
                   </p>
                   {isCheckingYahoo ? (
@@ -2015,16 +2034,21 @@ function LeaguesPageContent() {
                         <Button
                           variant="outline"
                           size="sm"
-                          onClick={discoverYahooLeagues}
-                          disabled={isDiscoveringYahoo}
+                          onClick={refreshYahooAuth}
+                          disabled={isDiscoveringYahoo || isRefreshingYahooAuth}
                         >
-                          {isDiscoveringYahoo ? (
+                          {isRefreshingYahooAuth ? (
                             <>
                               <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                              Discovering...
+                              Opening Yahoo...
+                            </>
+                          ) : isDiscoveringYahoo ? (
+                            <>
+                              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                              Refreshing...
                             </>
                           ) : (
-                            'Refresh Leagues'
+                            'Refresh'
                           )}
                         </Button>
                         <Button
@@ -2050,9 +2074,17 @@ function LeaguesPageContent() {
                       <Button
                         variant="outline"
                         className="w-full"
-                        onClick={() => { window.location.href = '/api/connect/yahoo/authorize'; }}
+                        onClick={refreshYahooAuth}
+                        disabled={isRefreshingYahooAuth}
                       >
-                        Connect Yahoo
+                        {isRefreshingYahooAuth ? (
+                          <>
+                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                            Opening Yahoo...
+                          </>
+                        ) : (
+                          'Connect Yahoo'
+                        )}
                       </Button>
                     </div>
                   )}

--- a/web/app/(site)/leagues/page.tsx
+++ b/web/app/(site)/leagues/page.tsx
@@ -596,9 +596,9 @@ function LeaguesPageContent() {
     let shouldCheckYahooStatus = true;
     try {
       const res = await fetch('/api/connect/yahoo/discover', { method: 'POST' });
-      // Auth-worker error bodies carry reconnect codes even when the response is not ok.
-      const data = parseYahooDiscoverErrorResponse(await res.json().catch(() => null));
       if (!res.ok) {
+        // Auth-worker error bodies carry reconnect codes even when the response is not ok.
+        const data = parseYahooDiscoverErrorResponse(await res.json().catch(() => null));
         if (
           res.status === 401 ||
           res.status === 403 ||
@@ -640,7 +640,7 @@ function LeaguesPageContent() {
     }
 
     const resetRefreshState = () => setIsRefreshingYahooAuth(false);
-    const resetTimer = window.setTimeout(resetRefreshState, 60_000);
+    const resetTimer = window.setTimeout(resetRefreshState, 15_000);
     const handlePageHide = () => {
       window.clearTimeout(resetTimer);
     };

--- a/web/app/(site)/leagues/page.tsx
+++ b/web/app/(site)/leagues/page.tsx
@@ -572,7 +572,7 @@ function LeaguesPageContent() {
     }
   };
 
-  const discoverYahooLeagues = async (): Promise<boolean> => {
+  const discoverYahooLeagues = async (): Promise<void> => {
     setIsDiscoveringYahoo(true);
     setLeagueError(null);
     try {
@@ -582,15 +582,20 @@ function LeaguesPageContent() {
         error_description?: string;
       };
       if (!res.ok) {
+        if (
+          res.status === 401 ||
+          res.status === 403 ||
+          data.error === 'not_connected' ||
+          data.error === 'refresh_failed'
+        ) {
+          setIsYahooSetupOpen(true);
+        }
         throw new Error(data.error_description || data.error || 'Failed to refresh Yahoo leagues');
       }
       await loadYahooLeagues();
-      return true;
     } catch (err) {
       console.error('Failed to discover Yahoo leagues:', err);
-      setIsYahooSetupOpen(true);
       setLeagueError(err instanceof Error ? err.message : 'Failed to refresh Yahoo leagues');
-      return false;
     } finally {
       await checkYahooStatus();
       setIsDiscoveringYahoo(false);
@@ -601,6 +606,7 @@ function LeaguesPageContent() {
     setLeagueError(null);
     setLeagueNotice(null);
     setIsRefreshingYahooAuth(true);
+    window.setTimeout(() => setIsRefreshingYahooAuth(false), 10_000);
     window.location.href = '/api/connect/yahoo/authorize';
   };
 

--- a/web/app/(site)/leagues/page.tsx
+++ b/web/app/(site)/leagues/page.tsx
@@ -592,6 +592,8 @@ function LeaguesPageContent() {
   const discoverYahooLeagues = async (): Promise<void> => {
     setIsDiscoveringYahoo(true);
     setLeagueError(null);
+    setLeagueNotice(null);
+    let shouldCheckYahooStatus = true;
     try {
       const res = await fetch('/api/connect/yahoo/discover', { method: 'POST' });
       const data = parseYahooDiscoverErrorResponse(await res.json().catch(() => null));
@@ -603,6 +605,8 @@ function LeaguesPageContent() {
           data.error === 'refresh_failed'
         ) {
           setIsYahooSetupOpen(true);
+          setLeagueNotice('Your Yahoo session has expired. Click Refresh to sign in again and pull your latest leagues.');
+          shouldCheckYahooStatus = false;
           return;
         }
         throw new Error(data.error_description || data.error || 'Failed to refresh Yahoo leagues');
@@ -613,9 +617,11 @@ function LeaguesPageContent() {
       setLeagueError(err instanceof Error ? err.message : 'Failed to refresh Yahoo leagues');
     } finally {
       setIsDiscoveringYahoo(false);
-      void checkYahooStatus().catch((err: unknown) => {
-        console.error('Failed to refresh Yahoo status:', err);
-      });
+      if (shouldCheckYahooStatus) {
+        void checkYahooStatus().catch((err: unknown) => {
+          console.error('Failed to refresh Yahoo status:', err);
+        });
+      }
     }
   };
 
@@ -623,16 +629,34 @@ function LeaguesPageContent() {
     setLeagueError(null);
     setLeagueNotice(null);
     setIsRefreshingYahooAuth(true);
-    function handlePageHide() {
-      window.clearTimeout(resetTimer);
-    }
-    const resetTimer = window.setTimeout(() => {
-      window.removeEventListener('pagehide', handlePageHide);
-      setIsRefreshingYahooAuth(false);
-    }, 10_000);
-    window.addEventListener('pagehide', handlePageHide, { once: true });
     window.location.href = '/api/connect/yahoo/authorize';
   };
+
+  useEffect(() => {
+    if (!isRefreshingYahooAuth) {
+      return;
+    }
+
+    const resetRefreshState = () => setIsRefreshingYahooAuth(false);
+    const resetTimer = window.setTimeout(resetRefreshState, 10_000);
+    const handlePageHide = () => {
+      window.clearTimeout(resetTimer);
+    };
+    const handlePageShow = (event: PageTransitionEvent) => {
+      if (event.persisted) {
+        resetRefreshState();
+      }
+    };
+
+    window.addEventListener('pagehide', handlePageHide, { once: true });
+    window.addEventListener('pageshow', handlePageShow);
+
+    return () => {
+      window.clearTimeout(resetTimer);
+      window.removeEventListener('pagehide', handlePageHide);
+      window.removeEventListener('pageshow', handlePageShow);
+    };
+  }, [isRefreshingYahooAuth]);
 
   const disconnectYahoo = async () => {
     setIsYahooDisconnecting(true);


### PR DESCRIPTION
## Summary
- change the connected Yahoo Refresh action on `/leagues` to start Yahoo OAuth instead of discovery-only refresh
- keep post-callback discovery so Refresh performs reauth, status validation, and latest-league pull end to end
- surface discovery failures and refresh Yahoo status after the pull attempt finishes

## Validation
- `corepack pnpm --dir web exec tsc --noEmit`
- `corepack pnpm --dir web run lint`
- `git diff --check`