### PR TITLE
Simplify ESPN refresh UI

### DIFF
--- a/.github/workflows/check-web.yml
+++ b/.github/workflows/check-web.yml
@@ -49,5 +49,5 @@ jobs:
         working-directory: web
 
       - name: Test
-        run: pnpm run test
+        run: corepack pnpm run test
         working-directory: web

--- a/.github/workflows/check-web.yml
+++ b/.github/workflows/check-web.yml
@@ -47,3 +47,7 @@ jobs:
       - name: Type-check
         run: npx tsc --noEmit
         working-directory: web
+
+      - name: Test
+        run: pnpm run test
+        working-directory: web

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -275,7 +275,7 @@ Opening a PR triggers a full preview stack: Vercel preview deploy + all 5 Cloudf
 | Supabase | Shared (same instance) | Shared (same instance) |
 | Worker URLs | Custom domains (`api.flaim.app/*`) | `.workers.dev` URLs |
 
-**Vercel env vars are scoped by environment.** `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, `CLERK_SECRET_KEY`, `AUTH_WORKER_URL`, `NEXT_PUBLIC_AUTH_WORKER_URL`, and `NEXT_PUBLIC_FANTASY_MCP_URL` each have separate Production and Preview values. Preview points to dev Clerk and preview worker URLs. Server-only web routes should use `AUTH_WORKER_URL`; browser-visible configuration uses the `NEXT_PUBLIC_*` names.
+**Vercel env vars are scoped by environment.** `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, `CLERK_SECRET_KEY`, `AUTH_WORKER_URL`, `NEXT_PUBLIC_AUTH_WORKER_URL`, and `NEXT_PUBLIC_FANTASY_MCP_URL` each have separate Production and Preview values. Preview points to dev Clerk and preview worker URLs. Server-only web routes should use `AUTH_WORKER_URL` with the direct `.workers.dev` worker URL; browser-visible configuration uses the `NEXT_PUBLIC_*` names and may point at the public custom gateway.
 
 **Auth-worker resolves frontend redirects dynamically in preview** — no static `FRONTEND_URL` needed. It reads the `Origin` header (OAuth consent) or stored `redirect_after` (Yahoo callback) and accepts any `flaim-*.vercel.app` origin.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -275,7 +275,7 @@ Opening a PR triggers a full preview stack: Vercel preview deploy + all 5 Cloudf
 | Supabase | Shared (same instance) | Shared (same instance) |
 | Worker URLs | Custom domains (`api.flaim.app/*`) | `.workers.dev` URLs |
 
-**Vercel env vars are scoped by environment.** `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, `CLERK_SECRET_KEY`, `NEXT_PUBLIC_AUTH_WORKER_URL`, and `NEXT_PUBLIC_FANTASY_MCP_URL` each have separate Production and Preview values. Preview points to dev Clerk and preview worker URLs.
+**Vercel env vars are scoped by environment.** `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, `CLERK_SECRET_KEY`, `AUTH_WORKER_URL`, `NEXT_PUBLIC_AUTH_WORKER_URL`, and `NEXT_PUBLIC_FANTASY_MCP_URL` each have separate Production and Preview values. Preview points to dev Clerk and preview worker URLs. Server-only web routes should use `AUTH_WORKER_URL`; browser-visible configuration uses the `NEXT_PUBLIC_*` names.
 
 **Auth-worker resolves frontend redirects dynamically in preview** — no static `FRONTEND_URL` needed. It reads the `Origin` header (OAuth consent) or stored `redirect_after` (Yahoo callback) and accepts any `flaim-*.vercel.app` origin.
 

--- a/web/.env.example
+++ b/web/.env.example
@@ -27,6 +27,7 @@ NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL=/
 # ===========================================
 # These point to local wrangler dev servers
 # Run 'npm run dev' from the project root to start all services
+AUTH_WORKER_URL=http://localhost:8786
 NEXT_PUBLIC_AUTH_WORKER_URL=http://localhost:8786
 NEXT_PUBLIC_FANTASY_MCP_URL=http://localhost:8790
 INTERNAL_SERVICE_TOKEN=replace-with-shared-internal-token

--- a/web/README.md
+++ b/web/README.md
@@ -82,7 +82,7 @@ NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_...
 CLERK_SECRET_KEY=sk_...
 
 # Worker URLs (unified gateway is primary)
-AUTH_WORKER_URL=https://api.flaim.app/auth
+AUTH_WORKER_URL=https://auth-worker.gerrygugger.workers.dev
 NEXT_PUBLIC_AUTH_WORKER_URL=https://api.flaim.app/auth
 NEXT_PUBLIC_FANTASY_MCP_URL=https://api.flaim.app/mcp
 # Shared internal token for server-to-worker helper calls

--- a/web/README.md
+++ b/web/README.md
@@ -82,7 +82,7 @@ NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_...
 CLERK_SECRET_KEY=sk_...
 
 # Worker URLs (unified gateway is primary)
-AUTH_WORKER_URL=https://auth-worker.gerrygugger.workers.dev
+AUTH_WORKER_URL=https://<auth-worker-subdomain>.workers.dev
 NEXT_PUBLIC_AUTH_WORKER_URL=https://api.flaim.app/auth
 NEXT_PUBLIC_FANTASY_MCP_URL=https://api.flaim.app/mcp
 # Shared internal token for server-to-worker helper calls

--- a/web/README.md
+++ b/web/README.md
@@ -82,6 +82,7 @@ NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_...
 CLERK_SECRET_KEY=sk_...
 
 # Worker URLs (unified gateway is primary)
+AUTH_WORKER_URL=https://api.flaim.app/auth
 NEXT_PUBLIC_AUTH_WORKER_URL=https://api.flaim.app/auth
 NEXT_PUBLIC_FANTASY_MCP_URL=https://api.flaim.app/mcp
 # Shared internal token for server-to-worker helper calls

--- a/web/app/(site)/leagues/page.tsx
+++ b/web/app/(site)/leagues/page.tsx
@@ -42,7 +42,6 @@ import {
   DialogDescription,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from '@/components/ui/dialog';
 import { useEspnCredentials } from '@/lib/use-espn-credentials';
 import { getDefaultSeasonYear, getPreviousSeasonYear, getSeasonYearOptions } from '@/lib/season-utils';
@@ -393,6 +392,7 @@ function LeaguesPageContent() {
   const [isLeaguesSectionOpen, setIsLeaguesSectionOpen] = useState(true);
   const [isAiSectionOpen, setIsAiSectionOpen] = useState(true);
   const [isEspnSetupOpen, setIsEspnSetupOpen] = useState(false);
+  const [espnAdvancedOpen, setEspnAdvancedOpen] = useState(false);
   const [isYahooSetupOpen, setIsYahooSetupOpen] = useState(false);
   const [isYahooConnected, setIsYahooConnected] = useState(false);
   const [yahooLastUpdated, setYahooLastUpdated] = useState<string | null>(null);
@@ -478,6 +478,7 @@ function LeaguesPageContent() {
     setLeagueError(null);
     setLeagueNotice(null);
     setIsRefreshingEspn(false);
+    setEspnAdvancedOpen(false);
     setIsDiscoveringYahoo(false);
     setIsRefreshingYahooAuth(false);
     setIsYahooDisconnecting(false);
@@ -663,6 +664,7 @@ function LeaguesPageContent() {
         method: 'POST',
         headers: {
           'Accept': 'application/json',
+          'Content-Type': 'application/json',
         },
       });
       const data = await res.json().catch(() => ({})) as EspnDiscoveryResponse;
@@ -2040,7 +2042,7 @@ function LeaguesPageContent() {
                             </a>
                           </Button>
                         )}
-                        <Popover>
+                        <Popover open={espnAdvancedOpen} onOpenChange={setEspnAdvancedOpen}>
                           <PopoverTrigger asChild>
                             <Button
                               variant="outline"
@@ -2053,34 +2055,70 @@ function LeaguesPageContent() {
                           </PopoverTrigger>
                           <PopoverContent align="start" className="w-64 p-2">
                             <div className="grid gap-1">
-                            <Button asChild variant="ghost" size="sm" className="w-full justify-start">
-                              <a
-                                href={CHROME_EXTENSION_URL}
-                                target="_blank"
-                                rel="noopener noreferrer"
+                              <Button asChild variant="ghost" size="sm" className="w-full justify-start">
+                                <a
+                                  href={CHROME_EXTENSION_URL}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  onClick={() => setEspnAdvancedOpen(false)}
+                                >
+                                  <Chrome className="h-4 w-4 mr-2" />
+                                  Open Chrome Extension
+                                </a>
+                              </Button>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                className="w-full justify-start"
+                                disabled={discoverableEspnLeagues.length === 0}
+                                aria-label="Discover historical seasons"
+                                title={
+                                  discoverableEspnLeagues.length === 0
+                                    ? 'Add an ESPN football or baseball league first'
+                                    : 'Discover historical seasons'
+                                }
+                                onClick={() => {
+                                  setEspnAdvancedOpen(false);
+                                  setDiscoverDialogOpen(true);
+                                }}
                               >
-                                <Chrome className="h-4 w-4 mr-2" />
-                                Open Chrome Extension
-                              </a>
-                            </Button>
+                                <History className="h-4 w-4 mr-2" />
+                                Discover Seasons
+                              </Button>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                className="w-full justify-start"
+                                aria-label="Add league manually"
+                                title="Add Manually"
+                                onClick={() => {
+                                  setEspnAdvancedOpen(false);
+                                  setManualDialogOpen(true);
+                                }}
+                              >
+                                <Briefcase className="h-4 w-4 mr-2" />
+                                Add League Manually
+                              </Button>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                className="w-full justify-start"
+                                title="Edit ESPN credentials"
+                                aria-label="Edit ESPN credentials"
+                                onClick={() => {
+                                  setEspnAdvancedOpen(false);
+                                  setEspnCredsDialogOpen(true);
+                                  handleCancelEdit();
+                                  handleEditCredentials();
+                                }}
+                              >
+                                <Wrench className="h-4 w-4 mr-2" />
+                                Edit ESPN Credentials
+                              </Button>
+                            </div>
+                          </PopoverContent>
+                        </Popover>
                         <Dialog open={discoverDialogOpen} onOpenChange={setDiscoverDialogOpen}>
-                          <DialogTrigger asChild>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              className="w-full justify-start"
-                              disabled={discoverableEspnLeagues.length === 0}
-                              aria-label="Discover historical seasons"
-                              title={
-                                discoverableEspnLeagues.length === 0
-                                  ? 'Add an ESPN football or baseball league first'
-                                  : 'Discover historical seasons'
-                              }
-                            >
-                              <History className="h-4 w-4 mr-2" />
-                              Discover Seasons
-                            </Button>
-                          </DialogTrigger>
                           <DialogContent>
                             <DialogHeader>
                               <DialogTitle>Discover historical seasons</DialogTitle>
@@ -2155,18 +2193,6 @@ function LeaguesPageContent() {
                           </DialogContent>
                         </Dialog>
                         <Dialog open={manualDialogOpen} onOpenChange={setManualDialogOpen}>
-                          <DialogTrigger asChild>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              className="w-full justify-start"
-                              aria-label="Add league manually"
-                              title="Add Manually"
-                            >
-                              <Briefcase className="h-4 w-4 mr-2" />
-                              Add League Manually
-                            </Button>
-                          </DialogTrigger>
                           <DialogContent>
                           <DialogHeader>
                             <div className="flex items-center gap-2">
@@ -2326,18 +2352,6 @@ function LeaguesPageContent() {
                             }
                           }}
                         >
-                          <DialogTrigger asChild>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              className="w-full justify-start"
-                              title="Edit ESPN credentials"
-                              aria-label="Edit ESPN credentials"
-                            >
-                              <Wrench className="h-4 w-4 mr-2" />
-                              Edit ESPN Credentials
-                            </Button>
-                          </DialogTrigger>
                           <DialogContent>
                             <DialogHeader>
                               <DialogTitle>ESPN Credentials</DialogTitle>
@@ -2401,9 +2415,6 @@ function LeaguesPageContent() {
                             </div>
                           </DialogContent>
                         </Dialog>
-                            </div>
-                          </PopoverContent>
-                        </Popover>
                       </div>
                     </div>
                   )}

--- a/web/app/(site)/leagues/page.tsx
+++ b/web/app/(site)/leagues/page.tsx
@@ -186,6 +186,19 @@ interface YahooDiscoverErrorResponse {
   error_description?: string;
 }
 
+interface EspnDiscoveryCounts {
+  found?: number;
+  added?: number;
+  alreadySaved?: number;
+}
+
+interface EspnDiscoveryResponse {
+  error?: string;
+  error_description?: string;
+  currentSeason?: EspnDiscoveryCounts;
+  pastSeasons?: EspnDiscoveryCounts;
+}
+
 function parseYahooDiscoverErrorResponse(data: unknown): YahooDiscoverErrorResponse {
   if (!data || typeof data !== 'object') {
     return {};
@@ -196,6 +209,37 @@ function parseYahooDiscoverErrorResponse(data: unknown): YahooDiscoverErrorRespo
     error: typeof record.error === 'string' ? record.error : undefined,
     error_description: typeof record.error_description === 'string' ? record.error_description : undefined,
   };
+}
+
+function getEspnDiscoverErrorMessage(status: number, data: EspnDiscoveryResponse): string {
+  if (data.error === 'credentials_not_found') {
+    return 'Add ESPN credentials with the Chrome extension or manual entry, then refresh again.';
+  }
+
+  if (status === 401 || status === 403 || data.error === 'espn_auth_failed') {
+    return 'ESPN credentials look expired or invalid. Update them, then refresh again.';
+  }
+
+  return data.error_description || data.error || 'Failed to refresh ESPN leagues';
+}
+
+function formatEspnRefreshNotice(data: EspnDiscoveryResponse): string {
+  const currentAdded = data.currentSeason?.added ?? 0;
+  const historicalAdded = data.pastSeasons?.added ?? 0;
+  const currentFound = data.currentSeason?.found ?? 0;
+  const historicalFound = data.pastSeasons?.found ?? 0;
+  const added = currentAdded + historicalAdded;
+  const found = currentFound + historicalFound;
+
+  if (added > 0) {
+    return `ESPN refresh complete. Added ${added} new league season${added === 1 ? '' : 's'}.`;
+  }
+
+  if (found > 0) {
+    return 'ESPN refresh complete. No new ESPN league seasons found.';
+  }
+
+  return 'ESPN refresh complete. No ESPN leagues found for these credentials.';
 }
 
 function formatLastUpdated(value: string): string {
@@ -353,6 +397,7 @@ function LeaguesPageContent() {
   const [isYahooDisconnecting, setIsYahooDisconnecting] = useState(false);
   const [yahooLeagues, setYahooLeagues] = useState<YahooLeague[]>([]);
   const [isLoadingYahooLeagues, setIsLoadingYahooLeagues] = useState(true);
+  const [isRefreshingEspn, setIsRefreshingEspn] = useState(false);
   const [isDiscoveringYahoo, setIsDiscoveringYahoo] = useState(false);
   const [isRefreshingYahooAuth, setIsRefreshingYahooAuth] = useState(false);
   const [sleeperLeagues, setSleeperLeagues] = useState<SleeperLeague[]>([]);
@@ -429,6 +474,7 @@ function LeaguesPageContent() {
     setSleeperError(null);
     setLeagueError(null);
     setLeagueNotice(null);
+    setIsRefreshingEspn(false);
     setIsDiscoveringYahoo(false);
     setIsRefreshingYahooAuth(false);
     setIsYahooDisconnecting(false);
@@ -595,6 +641,57 @@ function LeaguesPageContent() {
       if (showSpinner && canApplyState(shouldApply)) setIsLoadingLeagues(false);
     }
   }, []);
+
+  const refreshEspnLeagues = useCallback(async (): Promise<void> => {
+    const shouldApply = createAccountGuard();
+    if (!shouldApply()) return;
+
+    if (!hasCredentials) {
+      setIsEspnSetupOpen(true);
+      setLeagueNotice(null);
+      setLeagueError('Add ESPN credentials with the Chrome extension or manual entry, then refresh again.');
+      return;
+    }
+
+    setIsRefreshingEspn(true);
+    setLeagueError(null);
+    setLeagueNotice(null);
+    try {
+      const res = await fetch('/api/espn/refresh', {
+        method: 'POST',
+        headers: {
+          'Accept': 'application/json',
+        },
+      });
+      const data = await res.json().catch(() => ({})) as EspnDiscoveryResponse;
+      if (!shouldApply()) return;
+
+      if (!res.ok) {
+        if (
+          res.status === 401 ||
+          res.status === 403 ||
+          data.error === 'credentials_not_found' ||
+          data.error === 'espn_auth_failed'
+        ) {
+          setIsEspnSetupOpen(true);
+        }
+        throw new Error(getEspnDiscoverErrorMessage(res.status, data));
+      }
+
+      await loadLeagues({ showSpinner: false, shouldApply });
+      if (!shouldApply()) return;
+      setLeagueNotice(formatEspnRefreshNotice(data));
+    } catch (err) {
+      if (shouldApply()) {
+        console.error('Failed to refresh ESPN leagues:', err);
+        setLeagueError(err instanceof Error ? err.message : 'Failed to refresh ESPN leagues');
+      }
+    } finally {
+      if (shouldApply()) {
+        setIsRefreshingEspn(false);
+      }
+    }
+  }, [createAccountGuard, hasCredentials, loadLeagues]);
 
   const checkYahooStatus = useCallback(async (shouldApply?: () => boolean): Promise<ConnectionStatusResult> => {
     try {
@@ -1360,6 +1457,9 @@ function LeaguesPageContent() {
   const hasAnyLeagueGroups = leaguesBySport.active.length > 0 || leaguesBySport.old.length > 0;
   const displayLeagueError = isAccountStateCurrent ? leagueError : null;
   const displayLeagueNotice = isAccountStateCurrent ? leagueNotice : null;
+  const displayEspnConnected = isAccountStateCurrent && hasCredentials;
+  const displayEspnLastUpdated = isAccountStateCurrent ? espnLastUpdated : null;
+  const isEspnStatusChecking = !isAccountStateCurrent || isCheckingCreds;
   const displayYahooConnected = isAccountStateCurrent && isYahooConnected;
   const displayYahooLastUpdated = isAccountStateCurrent ? yahooLastUpdated : null;
   const isYahooStatusChecking = !isAccountStateCurrent || isCheckingYahoo;
@@ -1882,7 +1982,7 @@ function LeaguesPageContent() {
               >
                 <div className="flex items-center gap-2">
                   <span className="text-lg">ESPN</span>
-                  <ConnectionBadge isChecking={isCheckingCreds} isConnected={hasCredentials} />
+                  <ConnectionBadge isChecking={isEspnStatusChecking} isConnected={displayEspnConnected} />
                 </div>
                 <ChevronDown
                   className={`h-5 w-5 text-muted-foreground transition-transform ${
@@ -1893,32 +1993,73 @@ function LeaguesPageContent() {
               {isEspnSetupOpen && (
                 <div id="espn-setup-content" className="px-4 pb-4 space-y-3">
                   <p className="text-sm text-muted-foreground">
-                    Use the extension to update credentials and discover leagues, or add one manually.
+                    {displayEspnConnected
+                      ? 'Refresh uses your stored ESPN credentials to discover leagues and reload the ESPN list.'
+                      : 'Add ESPN credentials with the extension or manual entry, then refresh.'}
                   </p>
-                  {espnLastUpdated && (
+                  {displayEspnLastUpdated && (
                     <p className="text-xs text-muted-foreground">
-                      Last updated: {formatLastUpdated(espnLastUpdated)}
+                      Credentials updated: {formatLastUpdated(displayEspnLastUpdated)}
                     </p>
                   )}
-                  {!verifiedLeague && (
+                  {isEspnStatusChecking ? (
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      Checking ESPN connection...
+                    </div>
+                  ) : !verifiedLeague && (
                     <div className="space-y-3">
-                      <div className="flex gap-2">
-                        <a
-                          href={CHROME_EXTENSION_URL}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                        >
-                          <Button variant="outline" size="sm">
-                            <Chrome className="h-4 w-4 mr-2" />
-                            Chrome Extension
+                      <div className="flex flex-col gap-2 sm:flex-row">
+                        {displayEspnConnected ? (
+                          <Button
+                            size="sm"
+                            onClick={refreshEspnLeagues}
+                            disabled={isRefreshingEspn}
+                            className="w-full sm:w-auto"
+                          >
+                            {isRefreshingEspn ? (
+                              <>
+                                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                Refreshing...
+                              </>
+                            ) : (
+                              'Refresh'
+                            )}
                           </Button>
-                        </a>
+                        ) : (
+                          <Button asChild size="sm" className="w-full sm:w-auto">
+                            <a
+                              href={CHROME_EXTENSION_URL}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              <Chrome className="h-4 w-4 mr-2" />
+                              Open Extension
+                            </a>
+                          </Button>
+                        )}
+                        <details className="group w-full sm:w-auto">
+                          <summary className="flex h-8 w-full cursor-pointer list-none items-center justify-center gap-2 rounded-md border border-input bg-background px-3 text-xs font-medium shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground sm:w-auto [&::-webkit-details-marker]:hidden">
+                            Advanced
+                            <ChevronDown className="h-4 w-4 text-muted-foreground transition-transform group-open:rotate-180" />
+                          </summary>
+                          <div className="mt-2 grid gap-1 rounded-md border bg-background p-2 shadow-sm sm:w-64">
+                            <Button asChild variant="ghost" size="sm" className="w-full justify-start">
+                              <a
+                                href={CHROME_EXTENSION_URL}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                              >
+                                <Chrome className="h-4 w-4 mr-2" />
+                                Open Chrome Extension
+                              </a>
+                            </Button>
                         <Dialog open={discoverDialogOpen} onOpenChange={setDiscoverDialogOpen}>
                           <DialogTrigger asChild>
                             <Button
-                              variant="outline"
-                              size="icon"
-                              className="h-8 w-8"
+                              variant="ghost"
+                              size="sm"
+                              className="w-full justify-start"
                               disabled={discoverableEspnLeagues.length === 0}
                               aria-label="Discover historical seasons"
                               title={
@@ -1927,7 +2068,8 @@ function LeaguesPageContent() {
                                   : 'Discover historical seasons'
                               }
                             >
-                              <History className="h-4 w-4" />
+                              <History className="h-4 w-4 mr-2" />
+                              Discover Seasons
                             </Button>
                           </DialogTrigger>
                           <DialogContent>
@@ -2006,13 +2148,14 @@ function LeaguesPageContent() {
                         <Dialog open={manualDialogOpen} onOpenChange={setManualDialogOpen}>
                           <DialogTrigger asChild>
                             <Button
-                              variant="outline"
-                              size="icon"
-                              className="h-8 w-8"
+                              variant="ghost"
+                              size="sm"
+                              className="w-full justify-start"
                               aria-label="Add league manually"
                               title="Add Manually"
                             >
-                              <Briefcase className="h-4 w-4" />
+                              <Briefcase className="h-4 w-4 mr-2" />
+                              Add League Manually
                             </Button>
                           </DialogTrigger>
                           <DialogContent>
@@ -2176,13 +2319,14 @@ function LeaguesPageContent() {
                         >
                           <DialogTrigger asChild>
                             <Button
-                              variant="outline"
-                              size="icon"
-                              className="h-8 w-8 shrink-0"
-                              title="Add manually"
-                              aria-label="Add ESPN credentials manually"
+                              variant="ghost"
+                              size="sm"
+                              className="w-full justify-start"
+                              title="Edit ESPN credentials"
+                              aria-label="Edit ESPN credentials"
                             >
-                              <Wrench className="h-4 w-4" />
+                              <Wrench className="h-4 w-4 mr-2" />
+                              Edit ESPN Credentials
                             </Button>
                           </DialogTrigger>
                           <DialogContent>
@@ -2248,6 +2392,8 @@ function LeaguesPageContent() {
                             </div>
                           </DialogContent>
                         </Dialog>
+                          </div>
+                        </details>
                       </div>
                     </div>
                   )}

--- a/web/app/(site)/leagues/page.tsx
+++ b/web/app/(site)/leagues/page.tsx
@@ -443,6 +443,7 @@ function LeaguesPageContent() {
   const [seasonManuallySet, setSeasonManuallySet] = useState(false);
   const [isVerifying, setIsVerifying] = useState(false);
   const [verifiedLeague, setVerifiedLeague] = useState<VerifiedLeague | null>(null);
+  const isManualVerificationPending = verifiedLeague !== null;
   const [selectedTeamId, setSelectedTeamId] = useState<string>('');
   const [isAddingLeague, setIsAddingLeague] = useState(false);
   const [discoverLeagueKey, setDiscoverLeagueKey] = useState<string>('');
@@ -2011,7 +2012,7 @@ function LeaguesPageContent() {
                       <Loader2 className="h-4 w-4 animate-spin" />
                       Checking ESPN connection...
                     </div>
-                  ) : !verifiedLeague && (
+                  ) : !isManualVerificationPending && (
                     <div className="space-y-3">
                       <div className="flex flex-col gap-2 sm:flex-row">
                         {displayEspnConnected ? (
@@ -2111,6 +2112,7 @@ function LeaguesPageContent() {
                                 onClick={() => {
                                   setEspnAdvancedOpen(false);
                                   setEspnCredsDialogOpen(true);
+                                  // Clear stale form state before loading the saved credentials into the dialog.
                                   handleCancelEdit();
                                   handleEditCredentials();
                                 }}

--- a/web/app/(site)/leagues/page.tsx
+++ b/web/app/(site)/leagues/page.tsx
@@ -236,7 +236,7 @@ function formatEspnRefreshNotice(data: EspnDiscoveryResponse): string {
   }
 
   if (found > 0) {
-    return 'ESPN refresh complete. No new ESPN league seasons found.';
+    return `ESPN refresh complete. All ${found} league season${found === 1 ? '' : 's'} already up to date.`;
   }
 
   return 'ESPN refresh complete. No ESPN leagues found for these credentials.';
@@ -649,7 +649,6 @@ function LeaguesPageContent() {
     if (!hasCredentials) {
       setIsEspnSetupOpen(true);
       setLeagueNotice(null);
-      setLeagueError('Add ESPN credentials with the Chrome extension or manual entry, then refresh again.');
       return;
     }
 
@@ -2038,12 +2037,19 @@ function LeaguesPageContent() {
                             </a>
                           </Button>
                         )}
-                        <details className="group w-full sm:w-auto">
-                          <summary className="flex h-8 w-full cursor-pointer list-none items-center justify-center gap-2 rounded-md border border-input bg-background px-3 text-xs font-medium shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground sm:w-auto [&::-webkit-details-marker]:hidden">
-                            Advanced
-                            <ChevronDown className="h-4 w-4 text-muted-foreground transition-transform group-open:rotate-180" />
-                          </summary>
-                          <div className="mt-2 grid gap-1 rounded-md border bg-background p-2 shadow-sm sm:w-64">
+                        <Popover>
+                          <PopoverTrigger asChild>
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              className="w-full sm:w-auto"
+                            >
+                              Advanced
+                              <ChevronDown className="ml-2 h-4 w-4 text-muted-foreground" />
+                            </Button>
+                          </PopoverTrigger>
+                          <PopoverContent align="start" className="w-64 p-2">
+                            <div className="grid gap-1">
                             <Button asChild variant="ghost" size="sm" className="w-full justify-start">
                               <a
                                 href={CHROME_EXTENSION_URL}
@@ -2392,8 +2398,9 @@ function LeaguesPageContent() {
                             </div>
                           </DialogContent>
                         </Dialog>
-                          </div>
-                        </details>
+                            </div>
+                          </PopoverContent>
+                        </Popover>
                       </div>
                     </div>
                   )}

--- a/web/app/(site)/leagues/page.tsx
+++ b/web/app/(site)/leagues/page.tsx
@@ -199,6 +199,9 @@ interface EspnDiscoveryResponse {
   pastSeasons?: EspnDiscoveryCounts;
 }
 
+const ESPN_ERROR_CREDENTIALS_NOT_FOUND = 'credentials_not_found';
+const ESPN_ERROR_AUTH_FAILED = 'espn_auth_failed';
+
 function parseYahooDiscoverErrorResponse(data: unknown): YahooDiscoverErrorResponse {
   if (!data || typeof data !== 'object') {
     return {};
@@ -212,11 +215,11 @@ function parseYahooDiscoverErrorResponse(data: unknown): YahooDiscoverErrorRespo
 }
 
 function getEspnDiscoverErrorMessage(status: number, data: EspnDiscoveryResponse): string {
-  if (data.error === 'credentials_not_found') {
+  if (data.error === ESPN_ERROR_CREDENTIALS_NOT_FOUND) {
     return 'Add ESPN credentials with the Chrome extension or manual entry, then refresh again.';
   }
 
-  if (status === 401 || status === 403 || data.error === 'espn_auth_failed') {
+  if (status === 401 || status === 403 || data.error === ESPN_ERROR_AUTH_FAILED) {
     return 'ESPN credentials look expired or invalid. Update them, then refresh again.';
   }
 
@@ -669,8 +672,8 @@ function LeaguesPageContent() {
         if (
           res.status === 401 ||
           res.status === 403 ||
-          data.error === 'credentials_not_found' ||
-          data.error === 'espn_auth_failed'
+          data.error === ESPN_ERROR_CREDENTIALS_NOT_FOUND ||
+          data.error === ESPN_ERROR_AUTH_FAILED
         ) {
           setIsEspnSetupOpen(true);
         }

--- a/web/app/(site)/leagues/page.tsx
+++ b/web/app/(site)/leagues/page.tsx
@@ -2112,7 +2112,7 @@ function LeaguesPageContent() {
                                 onClick={() => {
                                   setEspnAdvancedOpen(false);
                                   setEspnCredsDialogOpen(true);
-                                  // Clear stale form state before loading the saved credentials into the dialog.
+                                  // Avoid stale form values flashing before the dialog re-populates.
                                   handleCancelEdit();
                                   handleEditCredentials();
                                 }}

--- a/web/app/(site)/leagues/page.tsx
+++ b/web/app/(site)/leagues/page.tsx
@@ -33,6 +33,7 @@ import {
   Briefcase,
   Chrome,
   Info,
+  RefreshCw,
 } from 'lucide-react';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
@@ -664,7 +665,6 @@ function LeaguesPageContent() {
         method: 'POST',
         headers: {
           'Accept': 'application/json',
-          'Content-Type': 'application/json',
         },
       });
       const data = await res.json().catch(() => ({})) as EspnDiscoveryResponse;
@@ -2027,7 +2027,10 @@ function LeaguesPageContent() {
                                 Refreshing...
                               </>
                             ) : (
-                              'Refresh'
+                              <>
+                                <RefreshCw className="mr-2 h-4 w-4" />
+                                Refresh
+                              </>
                             )}
                           </Button>
                         ) : (

--- a/web/app/api/espn/refresh/route.ts
+++ b/web/app/api/espn/refresh/route.ts
@@ -1,0 +1,93 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@clerk/nextjs/server';
+
+interface SeasonCounts {
+  found: number;
+  added: number;
+  alreadySaved: number;
+}
+
+function isSeasonCounts(value: unknown): value is SeasonCounts {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as Record<string, unknown>).found === 'number' &&
+    typeof (value as Record<string, unknown>).added === 'number' &&
+    typeof (value as Record<string, unknown>).alreadySaved === 'number'
+  );
+}
+
+/**
+ * POST /api/espn/refresh
+ * Discover and save ESPN leagues using the user's stored ESPN credentials.
+ */
+export async function POST() {
+  try {
+    const { userId, getToken } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+    }
+
+    const authWorkerUrl = process.env.NEXT_PUBLIC_AUTH_WORKER_URL;
+    if (!authWorkerUrl) {
+      return NextResponse.json({ error: 'AUTH_WORKER_URL not configured' }, { status: 500 });
+    }
+
+    const bearer = await getToken?.();
+    if (!bearer) {
+      return NextResponse.json({ error: 'Authentication token unavailable' }, { status: 401 });
+    }
+
+    const workerRes = await fetch(`${authWorkerUrl}/extension/discover`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${bearer}`,
+      },
+    });
+
+    if (!workerRes.ok) {
+      const error = await workerRes.json().catch(() => ({ error: 'Unknown error' })) as {
+        error?: string;
+        error_description?: string;
+      };
+      return NextResponse.json(
+        {
+          error: error.error || 'Failed to refresh ESPN leagues',
+          error_description: error.error_description,
+        },
+        { status: workerRes.status }
+      );
+    }
+
+    const data = await workerRes.json().catch(() => null) as {
+      discovered?: unknown[];
+      currentSeason?: unknown;
+      pastSeasons?: unknown;
+    } | null;
+
+    if (
+      !data ||
+      !Array.isArray(data.discovered) ||
+      !isSeasonCounts(data.currentSeason) ||
+      !isSeasonCounts(data.pastSeasons)
+    ) {
+      return NextResponse.json(
+        { error: 'server_error', error_description: 'Unexpected response from ESPN refresh service' },
+        { status: 502 }
+      );
+    }
+
+    return NextResponse.json({
+      discovered: data.discovered,
+      currentSeason: data.currentSeason,
+      pastSeasons: data.pastSeasons,
+    });
+  } catch (error) {
+    console.error('ESPN refresh route error:', error);
+    return NextResponse.json(
+      { error: 'server_error', error_description: 'Failed to refresh ESPN leagues' },
+      { status: 500 }
+    );
+  }
+}

--- a/web/app/api/espn/refresh/route.ts
+++ b/web/app/api/espn/refresh/route.ts
@@ -7,14 +7,30 @@ interface SeasonCounts {
   alreadySaved: number;
 }
 
-function isSeasonCounts(value: unknown): value is SeasonCounts {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    typeof (value as Record<string, unknown>).found === 'number' &&
-    typeof (value as Record<string, unknown>).added === 'number' &&
-    typeof (value as Record<string, unknown>).alreadySaved === 'number'
-  );
+function parseOptionalCount(value: unknown): number | null {
+  if (value === undefined || value === null) return 0;
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function normalizeSeasonCounts(value: unknown): SeasonCounts | null {
+  if (value === undefined || value === null) {
+    return { found: 0, added: 0, alreadySaved: 0 };
+  }
+
+  if (typeof value !== 'object') return null;
+
+  const record = value as Record<string, unknown>;
+  const found = parseOptionalCount(record.found);
+  const added = parseOptionalCount(record.added);
+  const alreadySaved = parseOptionalCount(record.alreadySaved);
+
+  if (found === null || added === null || alreadySaved === null) return null;
+
+  return { found, added, alreadySaved };
+}
+
+function normalizeAuthWorkerUrl(value: string): string {
+  return value.replace(/\/+$/, '');
 }
 
 export async function POST() {
@@ -34,7 +50,7 @@ export async function POST() {
       return NextResponse.json({ error: 'Authentication token unavailable' }, { status: 401 });
     }
 
-    const workerRes = await fetch(`${authWorkerUrl}/extension/discover`, {
+    const workerRes = await fetch(`${normalizeAuthWorkerUrl(authWorkerUrl)}/extension/discover`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -61,20 +77,26 @@ export async function POST() {
       pastSeasons?: unknown;
     } | null;
 
-    if (
-      !data ||
-      !isSeasonCounts(data.currentSeason) ||
-      !isSeasonCounts(data.pastSeasons)
-    ) {
+    if (!data) {
       return NextResponse.json(
         { error: 'server_error', error_description: 'Unexpected response from ESPN refresh service' },
         { status: 502 }
       );
     }
 
+    const currentSeason = normalizeSeasonCounts(data.currentSeason);
+    const pastSeasons = normalizeSeasonCounts(data.pastSeasons);
+
+    if (!currentSeason || !pastSeasons) {
+      return NextResponse.json(
+        { error: 'server_error', error_description: 'Unexpected season counts from ESPN refresh service' },
+        { status: 502 }
+      );
+    }
+
     return NextResponse.json({
-      currentSeason: data.currentSeason,
-      pastSeasons: data.pastSeasons,
+      currentSeason,
+      pastSeasons,
     });
   } catch (error) {
     console.error('ESPN refresh route error:', error);

--- a/web/app/api/espn/refresh/route.ts
+++ b/web/app/api/espn/refresh/route.ts
@@ -28,7 +28,7 @@ export async function POST() {
       return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
     }
 
-    const authWorkerUrl = process.env.NEXT_PUBLIC_AUTH_WORKER_URL;
+    const authWorkerUrl = process.env.AUTH_WORKER_URL || process.env.NEXT_PUBLIC_AUTH_WORKER_URL;
     if (!authWorkerUrl) {
       return NextResponse.json({ error: 'AUTH_WORKER_URL not configured' }, { status: 500 });
     }
@@ -44,6 +44,7 @@ export async function POST() {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${bearer}`,
       },
+      // The auth-worker discovers all ESPN leagues from stored credentials; no request body is required.
     });
 
     if (!workerRes.ok) {
@@ -61,14 +62,12 @@ export async function POST() {
     }
 
     const data = await workerRes.json().catch(() => null) as {
-      discovered?: unknown[];
       currentSeason?: unknown;
       pastSeasons?: unknown;
     } | null;
 
     if (
       !data ||
-      !Array.isArray(data.discovered) ||
       !isSeasonCounts(data.currentSeason) ||
       !isSeasonCounts(data.pastSeasons)
     ) {
@@ -79,7 +78,6 @@ export async function POST() {
     }
 
     return NextResponse.json({
-      discovered: data.discovered,
       currentSeason: data.currentSeason,
       pastSeasons: data.pastSeasons,
     });

--- a/web/app/api/espn/refresh/route.ts
+++ b/web/app/api/espn/refresh/route.ts
@@ -7,7 +7,7 @@ interface SeasonCounts {
   alreadySaved: number;
 }
 
-function parseOptionalCount(value: unknown): number | null {
+function normalizeSeasonCountValue(value: unknown): number | null {
   if (value === undefined || value === null) return 0;
   return typeof value === 'number' && Number.isFinite(value) ? value : null;
 }
@@ -20,9 +20,9 @@ function normalizeSeasonCounts(value: unknown): SeasonCounts | null {
   if (typeof value !== 'object') return null;
 
   const record = value as Record<string, unknown>;
-  const found = parseOptionalCount(record.found);
-  const added = parseOptionalCount(record.added);
-  const alreadySaved = parseOptionalCount(record.alreadySaved);
+  const found = normalizeSeasonCountValue(record.found);
+  const added = normalizeSeasonCountValue(record.added);
+  const alreadySaved = normalizeSeasonCountValue(record.alreadySaved);
 
   if (found === null || added === null || alreadySaved === null) return null;
 

--- a/web/app/api/espn/refresh/route.ts
+++ b/web/app/api/espn/refresh/route.ts
@@ -1,50 +1,12 @@
 import { NextResponse } from 'next/server';
 import { auth } from '@clerk/nextjs/server';
+import { normalizeSeasonCounts, normalizeWorkerErrorStatus } from '@/lib/server/espn-refresh';
 
-interface SeasonCounts {
-  found: number;
-  added: number;
-  alreadySaved: number;
-}
-
-// Fail before the platform timeout so the client gets a structured 504.
-const ESPN_REFRESH_WORKER_TIMEOUT_MS = 10_000;
-
-function normalizeSeasonCountValue(value: unknown): number | null {
-  // Missing count fields mean zero; present-but-invalid fields make the worker response malformed.
-  if (value === undefined || value === null) return 0;
-  return typeof value === 'number' && Number.isFinite(value) ? value : null;
-}
-
-function normalizeSeasonCounts(value: unknown): SeasonCounts | null {
-  if (value === undefined || value === null) {
-    return { found: 0, added: 0, alreadySaved: 0 };
-  }
-
-  if (typeof value !== 'object') return null;
-
-  const record = value as Record<string, unknown>;
-  const found = normalizeSeasonCountValue(record.found);
-  const added = normalizeSeasonCountValue(record.added);
-  const alreadySaved = normalizeSeasonCountValue(record.alreadySaved);
-
-  if (found === null || added === null || alreadySaved === null) return null;
-
-  return { found, added, alreadySaved };
-}
+// ESPN discovery can include Fan API calls plus historical season discovery.
+export const maxDuration = 60;
 
 function normalizeAuthWorkerUrl(value: string): string {
   return value.replace(/\/+$/, '');
-}
-
-function isFetchTimeoutError(error: unknown): boolean {
-  return error instanceof Error && (error.name === 'AbortError' || error.name === 'TimeoutError');
-}
-
-function normalizeWorkerErrorStatus(status: number): number {
-  if (status === 401 || status === 403 || status === 429) return status;
-  if (status >= 500) return 502;
-  return status >= 400 ? status : 502;
 }
 
 export async function POST() {
@@ -64,24 +26,12 @@ export async function POST() {
       return NextResponse.json({ error: 'Authentication token unavailable' }, { status: 401 });
     }
 
-    let workerRes: Response;
-    try {
-      workerRes = await fetch(`${normalizeAuthWorkerUrl(authWorkerUrl)}/extension/discover`, {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${bearer}`,
-        },
-        signal: AbortSignal.timeout(ESPN_REFRESH_WORKER_TIMEOUT_MS),
-      });
-    } catch (error) {
-      if (isFetchTimeoutError(error)) {
-        return NextResponse.json(
-          { error: 'server_timeout', error_description: 'ESPN refresh service timed out' },
-          { status: 504 }
-        );
-      }
-      throw error;
-    }
+    const workerRes = await fetch(`${normalizeAuthWorkerUrl(authWorkerUrl)}/extension/discover`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${bearer}`,
+      },
+    });
 
     if (!workerRes.ok) {
       const error = await workerRes.json().catch(() => ({ error: 'Unknown error' })) as {

--- a/web/app/api/espn/refresh/route.ts
+++ b/web/app/api/espn/refresh/route.ts
@@ -7,6 +7,9 @@ interface SeasonCounts {
   alreadySaved: number;
 }
 
+// Fail before the platform timeout so the client gets a structured 504.
+const ESPN_REFRESH_WORKER_TIMEOUT_MS = 10_000;
+
 function normalizeSeasonCountValue(value: unknown): number | null {
   // Missing count fields mean zero; present-but-invalid fields make the worker response malformed.
   if (value === undefined || value === null) return 0;
@@ -38,6 +41,12 @@ function isFetchTimeoutError(error: unknown): boolean {
   return error instanceof Error && (error.name === 'AbortError' || error.name === 'TimeoutError');
 }
 
+function normalizeWorkerErrorStatus(status: number): number {
+  if (status === 401 || status === 403 || status === 429) return status;
+  if (status >= 500) return 502;
+  return status >= 400 ? status : 502;
+}
+
 export async function POST() {
   try {
     const { userId, getToken } = await auth();
@@ -62,7 +71,7 @@ export async function POST() {
         headers: {
           Authorization: `Bearer ${bearer}`,
         },
-        signal: AbortSignal.timeout(10_000),
+        signal: AbortSignal.timeout(ESPN_REFRESH_WORKER_TIMEOUT_MS),
       });
     } catch (error) {
       if (isFetchTimeoutError(error)) {
@@ -84,7 +93,7 @@ export async function POST() {
           error: error.error || 'Failed to refresh ESPN leagues',
           error_description: error.error_description,
         },
-        { status: workerRes.status }
+        { status: normalizeWorkerErrorStatus(workerRes.status) }
       );
     }
 

--- a/web/app/api/espn/refresh/route.ts
+++ b/web/app/api/espn/refresh/route.ts
@@ -34,6 +34,10 @@ function normalizeAuthWorkerUrl(value: string): string {
   return value.replace(/\/+$/, '');
 }
 
+function isFetchTimeoutError(error: unknown): boolean {
+  return error instanceof Error && (error.name === 'AbortError' || error.name === 'TimeoutError');
+}
+
 export async function POST() {
   try {
     const { userId, getToken } = await auth();
@@ -51,12 +55,24 @@ export async function POST() {
       return NextResponse.json({ error: 'Authentication token unavailable' }, { status: 401 });
     }
 
-    const workerRes = await fetch(`${normalizeAuthWorkerUrl(authWorkerUrl)}/extension/discover`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${bearer}`,
-      },
-    });
+    let workerRes: Response;
+    try {
+      workerRes = await fetch(`${normalizeAuthWorkerUrl(authWorkerUrl)}/extension/discover`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${bearer}`,
+        },
+        signal: AbortSignal.timeout(10_000),
+      });
+    } catch (error) {
+      if (isFetchTimeoutError(error)) {
+        return NextResponse.json(
+          { error: 'server_timeout', error_description: 'ESPN refresh service timed out' },
+          { status: 504 }
+        );
+      }
+      throw error;
+    }
 
     if (!workerRes.ok) {
       const error = await workerRes.json().catch(() => ({ error: 'Unknown error' })) as {

--- a/web/app/api/espn/refresh/route.ts
+++ b/web/app/api/espn/refresh/route.ts
@@ -17,10 +17,6 @@ function isSeasonCounts(value: unknown): value is SeasonCounts {
   );
 }
 
-/**
- * POST /api/espn/refresh
- * Discover and save ESPN leagues using the user's stored ESPN credentials.
- */
 export async function POST() {
   try {
     const { userId, getToken } = await auth();
@@ -28,12 +24,12 @@ export async function POST() {
       return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
     }
 
-    const authWorkerUrl = process.env.AUTH_WORKER_URL || process.env.NEXT_PUBLIC_AUTH_WORKER_URL;
+    const authWorkerUrl = process.env.AUTH_WORKER_URL;
     if (!authWorkerUrl) {
       return NextResponse.json({ error: 'AUTH_WORKER_URL not configured' }, { status: 500 });
     }
 
-    const bearer = await getToken?.();
+    const bearer = await getToken();
     if (!bearer) {
       return NextResponse.json({ error: 'Authentication token unavailable' }, { status: 401 });
     }
@@ -44,7 +40,6 @@ export async function POST() {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${bearer}`,
       },
-      // The auth-worker discovers all ESPN leagues from stored credentials; no request body is required.
     });
 
     if (!workerRes.ok) {

--- a/web/app/api/espn/refresh/route.ts
+++ b/web/app/api/espn/refresh/route.ts
@@ -8,6 +8,7 @@ interface SeasonCounts {
 }
 
 function normalizeSeasonCountValue(value: unknown): number | null {
+  // Missing count fields mean zero; present-but-invalid fields make the worker response malformed.
   if (value === undefined || value === null) return 0;
   return typeof value === 'number' && Number.isFinite(value) ? value : null;
 }
@@ -53,7 +54,6 @@ export async function POST() {
     const workerRes = await fetch(`${normalizeAuthWorkerUrl(authWorkerUrl)}/extension/discover`, {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/json',
         Authorization: `Bearer ${bearer}`,
       },
     });

--- a/web/lib/server/__tests__/espn-refresh-route.test.ts
+++ b/web/lib/server/__tests__/espn-refresh-route.test.ts
@@ -63,6 +63,7 @@ describe('ESPN refresh normalization helpers', () => {
   });
 
   it('rejects present-but-invalid season count fields', () => {
+    expect(normalizeSeasonCounts([])).toBeNull();
     expect(normalizeSeasonCounts({ found: '3', added: 1, alreadySaved: 0 })).toBeNull();
     expect(normalizeSeasonCounts({ found: Number.NaN, added: 1, alreadySaved: 0 })).toBeNull();
     expect(normalizeSeasonCounts({ found: -1, added: 1, alreadySaved: 0 })).toBeNull();
@@ -209,6 +210,26 @@ describe('POST /api/espn/refresh', () => {
     expect(body).toEqual({
       error: 'server_error',
       error_description: 'Unexpected response from ESPN refresh service',
+    });
+  });
+
+  it('returns bad gateway when the auth worker returns malformed season counts', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({
+      currentSeason: {
+        found: 'three',
+        added: 0,
+        alreadySaved: 0,
+      },
+      pastSeasons: [],
+    })));
+
+    const response = await POST();
+    const body = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(body).toEqual({
+      error: 'server_error',
+      error_description: 'Unexpected season counts from ESPN refresh service',
     });
   });
 });

--- a/web/lib/server/__tests__/espn-refresh-route.test.ts
+++ b/web/lib/server/__tests__/espn-refresh-route.test.ts
@@ -71,6 +71,53 @@ describe('ESPN refresh normalization helpers', () => {
 });
 
 describe('POST /api/espn/refresh', () => {
+  it('rejects unauthenticated requests without calling the auth worker', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    mocks.auth.mockResolvedValue({
+      userId: null,
+      getToken: vi.fn(),
+    });
+
+    const response = await POST();
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body).toEqual({ error: 'Authentication required' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('fails fast when AUTH_WORKER_URL is not configured', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    delete process.env.AUTH_WORKER_URL;
+
+    const response = await POST();
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body).toEqual({ error: 'AUTH_WORKER_URL not configured' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects requests when Clerk cannot issue a bearer token', async () => {
+    const fetchMock = vi.fn();
+    const getToken = vi.fn(async () => null);
+    vi.stubGlobal('fetch', fetchMock);
+    mocks.auth.mockResolvedValue({
+      userId: 'user_123',
+      getToken,
+    });
+
+    const response = await POST();
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body).toEqual({ error: 'Authentication token unavailable' });
+    expect(getToken).toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('proxies to the auth worker and returns normalized counts', async () => {
     const fetchMock = vi.fn(async () => jsonResponse({
       currentSeason: {
@@ -137,6 +184,19 @@ describe('POST /api/espn/refresh', () => {
     expect(body).toEqual({
       error: 'upstream_unavailable',
       error_description: 'Auth worker unavailable',
+    });
+  });
+
+  it('returns bad gateway when the auth worker returns a null body', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse(null)));
+
+    const response = await POST();
+    const body = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(body).toEqual({
+      error: 'server_error',
+      error_description: 'Unexpected response from ESPN refresh service',
     });
   });
 });

--- a/web/lib/server/__tests__/espn-refresh-route.test.ts
+++ b/web/lib/server/__tests__/espn-refresh-route.test.ts
@@ -55,6 +55,11 @@ describe('ESPN refresh normalization helpers', () => {
       added: 0,
       alreadySaved: 0,
     });
+    expect(normalizeSeasonCounts(null)).toEqual({
+      found: 0,
+      added: 0,
+      alreadySaved: 0,
+    });
     expect(normalizeSeasonCounts({ found: 3 })).toEqual({
       found: 3,
       added: 0,
@@ -67,11 +72,13 @@ describe('ESPN refresh normalization helpers', () => {
     expect(normalizeSeasonCounts({ found: '3', added: 1, alreadySaved: 0 })).toBeNull();
     expect(normalizeSeasonCounts({ found: Number.NaN, added: 1, alreadySaved: 0 })).toBeNull();
     expect(normalizeSeasonCounts({ found: -1, added: 1, alreadySaved: 0 })).toBeNull();
+    expect(normalizeSeasonCounts({ found: 1.7, added: 1, alreadySaved: 0 })).toBeNull();
   });
 
   it('rejects invalid individual season count values', () => {
     expect(normalizeSeasonCountValue(Number.NaN)).toBeNull();
     expect(normalizeSeasonCountValue(-1)).toBeNull();
+    expect(normalizeSeasonCountValue(1.7)).toBeNull();
   });
 
   it('passes expected upstream statuses and maps other worker errors to bad gateway', () => {

--- a/web/lib/server/__tests__/espn-refresh-route.test.ts
+++ b/web/lib/server/__tests__/espn-refresh-route.test.ts
@@ -39,7 +39,11 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  process.env.AUTH_WORKER_URL = ORIGINAL_AUTH_WORKER_URL;
+  if (ORIGINAL_AUTH_WORKER_URL === undefined) {
+    delete process.env.AUTH_WORKER_URL;
+  } else {
+    process.env.AUTH_WORKER_URL = ORIGINAL_AUTH_WORKER_URL;
+  }
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
 });

--- a/web/lib/server/__tests__/espn-refresh-route.test.ts
+++ b/web/lib/server/__tests__/espn-refresh-route.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  normalizeSeasonCountValue,
   normalizeSeasonCounts,
   normalizeWorkerErrorStatus,
 } from '../espn-refresh';
@@ -60,12 +61,19 @@ describe('ESPN refresh normalization helpers', () => {
   it('rejects present-but-invalid season count fields', () => {
     expect(normalizeSeasonCounts({ found: '3', added: 1, alreadySaved: 0 })).toBeNull();
     expect(normalizeSeasonCounts({ found: Number.NaN, added: 1, alreadySaved: 0 })).toBeNull();
+    expect(normalizeSeasonCounts({ found: -1, added: 1, alreadySaved: 0 })).toBeNull();
   });
 
-  it('passes expected upstream statuses and maps worker 5xx responses to bad gateway', () => {
+  it('rejects invalid individual season count values', () => {
+    expect(normalizeSeasonCountValue(Number.NaN)).toBeNull();
+    expect(normalizeSeasonCountValue(-1)).toBeNull();
+  });
+
+  it('passes expected upstream statuses and maps other worker errors to bad gateway', () => {
     expect(normalizeWorkerErrorStatus(401)).toBe(401);
     expect(normalizeWorkerErrorStatus(403)).toBe(403);
     expect(normalizeWorkerErrorStatus(429)).toBe(429);
+    expect(normalizeWorkerErrorStatus(422)).toBe(502);
     expect(normalizeWorkerErrorStatus(503)).toBe(502);
   });
 });

--- a/web/lib/server/__tests__/espn-refresh-route.test.ts
+++ b/web/lib/server/__tests__/espn-refresh-route.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  normalizeSeasonCounts,
+  normalizeWorkerErrorStatus,
+} from '../espn-refresh';
+
+const mocks = vi.hoisted(() => ({
+  auth: vi.fn(),
+}));
+
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: mocks.auth,
+}));
+
+import { POST } from '../../../app/api/espn/refresh/route';
+
+const ORIGINAL_AUTH_WORKER_URL = process.env.AUTH_WORKER_URL;
+
+function mockSignedInUser() {
+  const getToken = vi.fn(async () => 'test-token');
+  mocks.auth.mockResolvedValue({
+    userId: 'user_123',
+    getToken,
+  });
+  return { getToken };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+beforeEach(() => {
+  process.env.AUTH_WORKER_URL = 'https://auth.example/';
+  mockSignedInUser();
+});
+
+afterEach(() => {
+  process.env.AUTH_WORKER_URL = ORIGINAL_AUTH_WORKER_URL;
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('ESPN refresh normalization helpers', () => {
+  it('normalizes missing season counts to zero', () => {
+    expect(normalizeSeasonCounts(undefined)).toEqual({
+      found: 0,
+      added: 0,
+      alreadySaved: 0,
+    });
+    expect(normalizeSeasonCounts({ found: 3 })).toEqual({
+      found: 3,
+      added: 0,
+      alreadySaved: 0,
+    });
+  });
+
+  it('rejects present-but-invalid season count fields', () => {
+    expect(normalizeSeasonCounts({ found: '3', added: 1, alreadySaved: 0 })).toBeNull();
+    expect(normalizeSeasonCounts({ found: Number.NaN, added: 1, alreadySaved: 0 })).toBeNull();
+  });
+
+  it('passes expected upstream statuses and maps worker 5xx responses to bad gateway', () => {
+    expect(normalizeWorkerErrorStatus(401)).toBe(401);
+    expect(normalizeWorkerErrorStatus(403)).toBe(403);
+    expect(normalizeWorkerErrorStatus(429)).toBe(429);
+    expect(normalizeWorkerErrorStatus(503)).toBe(502);
+  });
+});
+
+describe('POST /api/espn/refresh', () => {
+  it('proxies to the auth worker and returns normalized counts', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({
+      currentSeason: {
+        found: 2,
+        added: 1,
+        alreadySaved: 1,
+      },
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await POST();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      currentSeason: {
+        found: 2,
+        added: 1,
+        alreadySaved: 1,
+      },
+      pastSeasons: {
+        found: 0,
+        added: 0,
+        alreadySaved: 0,
+      },
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://auth.example/extension/discover',
+      expect.objectContaining({
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer test-token',
+        },
+      })
+    );
+  });
+
+  it('passes through expected auth-worker credential errors', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({
+      error: 'credentials_not_found',
+      error_description: 'Reconnect ESPN credentials',
+    }, 403)));
+
+    const response = await POST();
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body).toEqual({
+      error: 'credentials_not_found',
+      error_description: 'Reconnect ESPN credentials',
+    });
+  });
+
+  it('normalizes auth-worker 5xx responses to bad gateway', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({
+      error: 'upstream_unavailable',
+      error_description: 'Auth worker unavailable',
+    }, 503)));
+
+    const response = await POST();
+    const body = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(body).toEqual({
+      error: 'upstream_unavailable',
+      error_description: 'Auth worker unavailable',
+    });
+  });
+});

--- a/web/lib/server/espn-refresh.ts
+++ b/web/lib/server/espn-refresh.ts
@@ -1,0 +1,34 @@
+export interface SeasonCounts {
+  found: number;
+  added: number;
+  alreadySaved: number;
+}
+
+export function normalizeSeasonCountValue(value: unknown): number | null {
+  // Missing count fields mean zero; present-but-invalid fields make the worker response malformed.
+  if (value === undefined || value === null) return 0;
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+export function normalizeSeasonCounts(value: unknown): SeasonCounts | null {
+  if (value === undefined || value === null) {
+    return { found: 0, added: 0, alreadySaved: 0 };
+  }
+
+  if (typeof value !== 'object') return null;
+
+  const record = value as Record<string, unknown>;
+  const found = normalizeSeasonCountValue(record.found);
+  const added = normalizeSeasonCountValue(record.added);
+  const alreadySaved = normalizeSeasonCountValue(record.alreadySaved);
+
+  if (found === null || added === null || alreadySaved === null) return null;
+
+  return { found, added, alreadySaved };
+}
+
+export function normalizeWorkerErrorStatus(status: number): number {
+  if (status === 401 || status === 403 || status === 429) return status;
+  if (status >= 500) return 502;
+  return status >= 400 ? status : 502;
+}

--- a/web/lib/server/espn-refresh.ts
+++ b/web/lib/server/espn-refresh.ts
@@ -7,7 +7,7 @@ export interface SeasonCounts {
 export function normalizeSeasonCountValue(value: unknown): number | null {
   // Missing count fields mean zero; present-but-invalid fields make the worker response malformed.
   if (value === undefined || value === null) return 0;
-  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : null;
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0 ? value : null;
 }
 
 export function normalizeSeasonCounts(value: unknown): SeasonCounts | null {

--- a/web/lib/server/espn-refresh.ts
+++ b/web/lib/server/espn-refresh.ts
@@ -7,7 +7,7 @@ export interface SeasonCounts {
 export function normalizeSeasonCountValue(value: unknown): number | null {
   // Missing count fields mean zero; present-but-invalid fields make the worker response malformed.
   if (value === undefined || value === null) return 0;
-  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : null;
 }
 
 export function normalizeSeasonCounts(value: unknown): SeasonCounts | null {
@@ -29,6 +29,5 @@ export function normalizeSeasonCounts(value: unknown): SeasonCounts | null {
 
 export function normalizeWorkerErrorStatus(status: number): number {
   if (status === 401 || status === 403 || status === 429) return status;
-  if (status >= 500) return 502;
-  return status >= 400 ? status : 502;
+  return 502;
 }

--- a/web/lib/server/espn-refresh.ts
+++ b/web/lib/server/espn-refresh.ts
@@ -15,7 +15,7 @@ export function normalizeSeasonCounts(value: unknown): SeasonCounts | null {
     return { found: 0, added: 0, alreadySaved: 0 };
   }
 
-  if (typeof value !== 'object') return null;
+  if (typeof value !== 'object' || Array.isArray(value)) return null;
 
   const record = value as Record<string, unknown>;
   const found = normalizeSeasonCountValue(record.found);


### PR DESCRIPTION
Adds a web-owned ESPN refresh endpoint and updates the leagues page so ESPN has a primary Refresh action when connected, Open Extension when disconnected, and advanced ESPN-only tools grouped behind an Advanced affordance. Validation: web typecheck, web lint, and git diff --check passed. ui:check still fails on known unrelated hero-chat palette warnings tracked as FLA-119.