### PR TITLE
[codex] Make user session widget MCP Apps compatible

### DIFF
--- a/workers/fantasy-mcp/src/__tests__/tools.test.ts
+++ b/workers/fantasy-mcp/src/__tests__/tools.test.ts
@@ -4,6 +4,7 @@ import { getUnifiedTools, hasRequiredScope, mcpAuthError } from '../mcp/tools';
 import { buildMcpAuthErrorResponse } from '../auth-response';
 import type { Env } from '../types';
 import { routeToClient } from '../router';
+import { USER_SESSION_WIDGET_HTML } from '../widgets/user-session-widget';
 
 /** Helper to cast an AnySchema value to z3 ZodTypeAny for .parse() in tests. */
 const asZod = (schema: unknown) => schema as z.ZodTypeAny;
@@ -73,6 +74,10 @@ describe('fantasy-mcp tools', () => {
     // structuredContent mirrors the text payload
     expect(result.structuredContent).toBeDefined();
     expect((result.structuredContent as Record<string, unknown>).totalLeaguesFound).toBe(0);
+    expect(result._meta?.ui).toEqual({ resourceUri: 'ui://widget/user-session.html' });
+    expect(result._meta?.['openai/outputTemplate']).toBe('ui://widget/user-session.html');
+    expect(result._meta?.['openai/widgetAccessible']).toBe(true);
+    expect(result._meta?.['openai/resultCanProduceWidget']).toBe(true);
   });
 
   it('get_user_session keeps canonical current-season labels in the session payload', async () => {
@@ -108,6 +113,14 @@ describe('fantasy-mcp tools', () => {
   it('get_user_session includes widgetUri in tool definition', () => {
     const tool = getUnifiedTools().find((t) => t.name === 'get_user_session');
     expect(tool?.widgetUri).toBe('ui://widget/user-session.html');
+  });
+
+  it('user session widget declares the MCP Apps lifecycle messages', () => {
+    expect(USER_SESSION_WIDGET_HTML).toContain("method: 'ui/initialize'");
+    expect(USER_SESSION_WIDGET_HTML).toContain("protocolVersion: '2026-01-26'");
+    expect(USER_SESSION_WIDGET_HTML).toContain("method: 'ui/notifications/initialized'");
+    expect(USER_SESSION_WIDGET_HTML).toContain("msg.method === 'ui/notifications/tool-result'");
+    expect(USER_SESSION_WIDGET_HTML).toContain("msg.method === 'ui/resource-teardown'");
   });
 
   it('get_user_session returns only current-season leagues', async () => {

--- a/workers/fantasy-mcp/src/__tests__/tools.test.ts
+++ b/workers/fantasy-mcp/src/__tests__/tools.test.ts
@@ -116,11 +116,14 @@ describe('fantasy-mcp tools', () => {
   });
 
   it('user session widget declares the MCP Apps lifecycle messages', () => {
+    // The widget is shipped as serialized HTML, so these assertions guard the
+    // protocol strings that MCP Apps hosts need to see at runtime.
     expect(USER_SESSION_WIDGET_HTML).toContain("method: 'ui/initialize'");
     expect(USER_SESSION_WIDGET_HTML).toContain("protocolVersion: '2026-01-26'");
     expect(USER_SESSION_WIDGET_HTML).toContain("method: 'ui/notifications/initialized'");
     expect(USER_SESSION_WIDGET_HTML).toContain("msg.method === 'ui/notifications/tool-result'");
     expect(USER_SESSION_WIDGET_HTML).toContain("msg.method === 'ui/resource-teardown'");
+    expect(USER_SESSION_WIDGET_HTML).toContain('isTrustedMessageEvent(event)');
   });
 
   it('get_user_session returns only current-season leagues', async () => {

--- a/workers/fantasy-mcp/src/mcp/server.ts
+++ b/workers/fantasy-mcp/src/mcp/server.ts
@@ -57,6 +57,7 @@ export function createFantasyMcpServer(ctx: McpContext): McpServer {
           'openai/widgetCSP': {
             connect_domains: [],
             resource_domains: [],
+            // Keep external-link allowlisting without reintroducing a stable widget domain.
             redirect_domains: ['https://flaim.app'],
           },
         },

--- a/workers/fantasy-mcp/src/mcp/server.ts
+++ b/workers/fantasy-mcp/src/mcp/server.ts
@@ -39,17 +39,25 @@ export function createFantasyMcpServer(ctx: McpContext): McpServer {
   server.registerResource(
     'user-session-widget',
     'ui://widget/user-session.html',
-    {},
+    {
+      mimeType: 'text/html;profile=mcp-app',
+    },
     async () => ({
       contents: [{
         uri: 'ui://widget/user-session.html',
-        mimeType: 'text/html+skybridge',
+        mimeType: 'text/html;profile=mcp-app',
         text: USER_SESSION_WIDGET_HTML,
         _meta: {
-          'openai/widgetDomain': 'https://flaim.app',
+          ui: {
+            csp: {
+              connectDomains: [],
+              resourceDomains: [],
+            },
+          },
           'openai/widgetCSP': {
             connect_domains: [],
             resource_domains: [],
+            redirect_domains: ['https://flaim.app'],
           },
         },
       }],
@@ -73,6 +81,9 @@ export function createFantasyMcpServer(ctx: McpContext): McpServer {
             'openai/toolInvocation/invoked': tool.openaiMeta.invoked,
           }),
           ...(tool.widgetUri && {
+            ui: {
+              resourceUri: tool.widgetUri,
+            },
             'openai/outputTemplate': tool.widgetUri,
             'openai/widgetAccessible': true,
             'openai/resultCanProduceWidget': true,

--- a/workers/fantasy-mcp/src/mcp/tools.ts
+++ b/workers/fantasy-mcp/src/mcp/tools.ts
@@ -683,6 +683,9 @@ export function getUnifiedTools(): UnifiedTool[] {
             content: [{ type: 'text' as const, text: JSON.stringify(sessionData, null, 2) }],
             structuredContent: sessionData as unknown as Record<string, unknown>,
             _meta: {
+              ui: {
+                resourceUri: 'ui://widget/user-session.html',
+              },
               'openai/outputTemplate': 'ui://widget/user-session.html',
               'openai/widgetAccessible': true,
               'openai/resultCanProduceWidget': true,

--- a/workers/fantasy-mcp/src/widgets/user-session-widget.ts
+++ b/workers/fantasy-mcp/src/widgets/user-session-widget.ts
@@ -213,7 +213,7 @@ export const USER_SESSION_WIDGET_HTML = `<!DOCTYPE html>
   }
 
   function isTrustedMessageEvent(event) {
-    if (event.source && window.parent && event.source !== window.parent) return false;
+    if (!event.source || !window.parent || event.source !== window.parent) return false;
     // Claude Desktop and other sandboxed MCP Apps hosts can emit "null"
     // origins. Accept them only after the parent-frame source check above.
     if (!event.origin || event.origin === 'null') return true;
@@ -271,6 +271,14 @@ export const USER_SESSION_WIDGET_HTML = `<!DOCTYPE html>
     });
   }
 
+  function queueSizeChanged() {
+    if (typeof requestAnimationFrame === 'function') {
+      requestAnimationFrame(sendSizeChanged);
+      return;
+    }
+    setTimeout(sendSizeChanged, 0);
+  }
+
   function openLegacyLeagues() {
     try {
       if (window.openai && typeof window.openai.openUrl === 'function') {
@@ -298,6 +306,7 @@ export const USER_SESSION_WIDGET_HTML = `<!DOCTYPE html>
           // rejection is the only observable signal where fallback is useful.
           result.catch(function() { openLegacyLeagues(); });
         }
+        if (result === false) return openLegacyLeagues();
         return false;
       }
     } catch (_) {}
@@ -314,7 +323,7 @@ export const USER_SESSION_WIDGET_HTML = `<!DOCTYPE html>
         '<a href="https://flaim.app/leagues" target="_blank" rel="noopener">Connect a league</a>' +
         '</div>';
       rendered = true;
-      sendSizeChanged();
+      queueSizeChanged();
       return;
     }
 
@@ -382,7 +391,7 @@ export const USER_SESSION_WIDGET_HTML = `<!DOCTYPE html>
 
     container.innerHTML = html;
     rendered = true;
-    sendSizeChanged();
+    queueSizeChanged();
   }
 
   function esc(s) {
@@ -442,9 +451,7 @@ export const USER_SESSION_WIDGET_HTML = `<!DOCTYPE html>
     var msg = event.data;
 
     if (msg.jsonrpc === '2.0' && msg.id === initId) {
-      if (Object.prototype.hasOwnProperty.call(msg, 'result')) {
-        sendInitialized();
-      }
+      sendInitialized();
       return;
     }
 

--- a/workers/fantasy-mcp/src/widgets/user-session-widget.ts
+++ b/workers/fantasy-mcp/src/widgets/user-session-widget.ts
@@ -214,6 +214,8 @@ export const USER_SESSION_WIDGET_HTML = `<!DOCTYPE html>
 
   function isTrustedMessageEvent(event) {
     if (event.source && window.parent && event.source !== window.parent) return false;
+    // Claude Desktop and other sandboxed MCP Apps hosts can emit "null"
+    // origins. Accept them only after the parent-frame source check above.
     if (!event.origin || event.origin === 'null') return true;
     try {
       var url = new URL(event.origin);
@@ -462,6 +464,8 @@ export const USER_SESSION_WIDGET_HTML = `<!DOCTYPE html>
     var data = extract(msg);
     if (data) render(data);
   });
+  // Safe in non-MCP hosts: postToParent no-ops when the widget is top-level,
+  // and ChatGPT window.openai data paths remain independent of initialization.
   startMcpAppsLifecycle();
 })();
 </script>

--- a/workers/fantasy-mcp/src/widgets/user-session-widget.ts
+++ b/workers/fantasy-mcp/src/widgets/user-session-widget.ts
@@ -221,6 +221,7 @@ export const USER_SESSION_WIDGET_HTML = `<!DOCTYPE html>
       var url = new URL(event.origin);
       var host = url.hostname;
       if (url.protocol !== 'https:') return false;
+      // Extend this allowlist when a new MCP Apps host origin is certified.
       return host === 'chatgpt.com' ||
         host === 'chat.openai.com' ||
         host === 'claude.ai' ||
@@ -263,6 +264,7 @@ export const USER_SESSION_WIDGET_HTML = `<!DOCTYPE html>
       jsonrpc: '2.0',
       method: 'ui/notifications/size-changed',
       params: {
+        // Matches the ChatGPT text-response widget width declared above.
         width: document.documentElement.scrollWidth || 353,
         height: document.documentElement.scrollHeight || document.body.scrollHeight || 0,
       },
@@ -294,7 +296,7 @@ export const USER_SESSION_WIDGET_HTML = `<!DOCTYPE html>
         if (result && typeof result.catch === 'function') {
           // A resolved promise only tells us the host accepted the request;
           // rejection is the only observable signal where fallback is useful.
-          result.catch(openLegacyLeagues);
+          result.catch(function() { openLegacyLeagues(); });
         }
         return false;
       }

--- a/workers/fantasy-mcp/src/widgets/user-session-widget.ts
+++ b/workers/fantasy-mcp/src/widgets/user-session-widget.ts
@@ -205,9 +205,29 @@ export const USER_SESSION_WIDGET_HTML = `<!DOCTYPE html>
   function postToParent(message) {
     try {
       if (window.parent && window.parent !== window) {
+        // Sandboxed MCP Apps hosts do not always expose a stable target origin.
+        // These lifecycle messages contain no secrets, so '*' is intentional.
         window.parent.postMessage(message, '*');
       }
     } catch (_) {}
+  }
+
+  function isTrustedMessageEvent(event) {
+    if (event.source && window.parent && event.source !== window.parent) return false;
+    if (!event.origin || event.origin === 'null') return true;
+    try {
+      var url = new URL(event.origin);
+      var host = url.hostname;
+      if (url.protocol !== 'https:') return false;
+      return host === 'chatgpt.com' ||
+        host === 'chat.openai.com' ||
+        host === 'claude.ai' ||
+        host.endsWith('.claude.ai') ||
+        host.endsWith('.claudemcpcontent.com') ||
+        host.endsWith('.oaiusercontent.com');
+    } catch (_) {
+      return false;
+    }
   }
 
   function sendInitialized() {
@@ -237,16 +257,14 @@ export const USER_SESSION_WIDGET_HTML = `<!DOCTYPE html>
   }
 
   function sendSizeChanged() {
-    try {
-      postToParent({
-        jsonrpc: '2.0',
-        method: 'ui/notifications/size-changed',
-        params: {
-          width: document.documentElement.scrollWidth || 353,
-          height: document.documentElement.scrollHeight || document.body.scrollHeight || 0,
-        },
-      });
-    } catch (_) {}
+    postToParent({
+      jsonrpc: '2.0',
+      method: 'ui/notifications/size-changed',
+      params: {
+        width: document.documentElement.scrollWidth || 353,
+        height: document.documentElement.scrollHeight || document.body.scrollHeight || 0,
+      },
+    });
   }
 
   function openLegacyLeagues() {
@@ -272,6 +290,8 @@ export const USER_SESSION_WIDGET_HTML = `<!DOCTYPE html>
       if (window.openai && typeof window.openai.openExternal === 'function') {
         var result = window.openai.openExternal({ href: LEAGUES_URL });
         if (result && typeof result.catch === 'function') {
+          // A resolved promise only tells us the host accepted the request;
+          // rejection is the only observable signal where fallback is useful.
           result.catch(openLegacyLeagues);
         }
         return false;
@@ -414,10 +434,13 @@ export const USER_SESSION_WIDGET_HTML = `<!DOCTYPE html>
   // MCP Apps bridge: receive lifecycle messages and tool-result notifications.
   window.addEventListener('message', function(event) {
     if (!event.data) return;
+    if (!isTrustedMessageEvent(event)) return;
     var msg = event.data;
 
-    if (msg.jsonrpc === '2.0' && msg.id === initId && Object.prototype.hasOwnProperty.call(msg, 'result')) {
-      sendInitialized();
+    if (msg.jsonrpc === '2.0' && msg.id === initId) {
+      if (Object.prototype.hasOwnProperty.call(msg, 'result')) {
+        sendInitialized();
+      }
       return;
     }
 

--- a/workers/fantasy-mcp/src/widgets/user-session-widget.ts
+++ b/workers/fantasy-mcp/src/widgets/user-session-widget.ts
@@ -2,7 +2,8 @@
 
 /**
  * Self-contained HTML widget for the get_user_session tool.
- * Renders the user's fantasy leagues inline in ChatGPT via the Apps SDK widget protocol.
+ * Renders the user's fantasy leagues inline through the MCP Apps bridge, with
+ * ChatGPT window.openai compatibility as a fallback.
  *
  * Design constraints:
  * - No external scripts, fonts, images, or stylesheets (CSP-safe for iframe sandbox)
@@ -10,10 +11,10 @@
  * - System fonts only
  * - Aligns with flaim.app branding
  *
- * Data access — in order of priority:
- * 1. openai:set_globals CustomEvent → window.openai.toolOutput (primary, async)
- * 2. window.openai.toolOutput on immediate/DOMContentLoaded (may already be set)
- * 3. postMessage JSON-RPC ui/notifications/tool-result (fallback)
+ * Data access - in order of priority:
+ * 1. MCP Apps postMessage JSON-RPC ui/notifications/tool-result
+ * 2. openai:set_globals CustomEvent -> window.openai.toolOutput
+ * 3. window.openai.toolOutput on immediate/DOMContentLoaded (may already be set)
  *
  * References:
  * - https://developers.openai.com/apps-sdk/build/chatgpt-ui/
@@ -197,10 +198,58 @@ export const USER_SESSION_WIDGET_HTML = `<!DOCTYPE html>
   var SPORT_ORDER = { baseball: 0, football: 1, basketball: 2, hockey: 3 };
   var SPORT_EMOJI = { baseball: '⚾', football: '🏈', basketball: '🏀', hockey: '🏒' };
   var LEAGUES_URL = 'https://flaim.app/leagues';
+  var initId = 'flaim-init-' + Math.random().toString(36).slice(2);
+  var initializedSent = false;
   var rendered = false;
 
-  function openLeagues(e) {
-    if (e && e.preventDefault) e.preventDefault();
+  function postToParent(message) {
+    try {
+      if (window.parent && window.parent !== window) {
+        window.parent.postMessage(message, '*');
+      }
+    } catch (_) {}
+  }
+
+  function sendInitialized() {
+    if (initializedSent) return;
+    initializedSent = true;
+    postToParent({
+      jsonrpc: '2.0',
+      method: 'ui/notifications/initialized',
+      params: {},
+    });
+  }
+
+  function startMcpAppsLifecycle() {
+    postToParent({
+      jsonrpc: '2.0',
+      id: initId,
+      method: 'ui/initialize',
+      params: {
+        protocolVersion: '2026-01-26',
+        appInfo: {
+          name: 'Flaim',
+          version: '1.0.0',
+        },
+        appCapabilities: {},
+      },
+    });
+  }
+
+  function sendSizeChanged() {
+    try {
+      postToParent({
+        jsonrpc: '2.0',
+        method: 'ui/notifications/size-changed',
+        params: {
+          width: document.documentElement.scrollWidth || 353,
+          height: document.documentElement.scrollHeight || document.body.scrollHeight || 0,
+        },
+      });
+    } catch (_) {}
+  }
+
+  function openLegacyLeagues() {
     try {
       if (window.openai && typeof window.openai.openUrl === 'function') {
         window.openai.openUrl(LEAGUES_URL);
@@ -217,6 +266,20 @@ export const USER_SESSION_WIDGET_HTML = `<!DOCTYPE html>
     return false;
   }
 
+  function openLeagues(e) {
+    if (e && e.preventDefault) e.preventDefault();
+    try {
+      if (window.openai && typeof window.openai.openExternal === 'function') {
+        var result = window.openai.openExternal({ href: LEAGUES_URL });
+        if (result && typeof result.catch === 'function') {
+          result.catch(openLegacyLeagues);
+        }
+        return false;
+      }
+    } catch (_) {}
+    return openLegacyLeagues();
+  }
+
   function render(data) {
     if (rendered) return;
     var container = document.getElementById('content');
@@ -227,6 +290,7 @@ export const USER_SESSION_WIDGET_HTML = `<!DOCTYPE html>
         '<a href="https://flaim.app/leagues" target="_blank" rel="noopener">Connect a league</a>' +
         '</div>';
       rendered = true;
+      sendSizeChanged();
       return;
     }
 
@@ -294,6 +358,7 @@ export const USER_SESSION_WIDGET_HTML = `<!DOCTYPE html>
 
     container.innerHTML = html;
     rendered = true;
+    sendSizeChanged();
   }
 
   function esc(s) {
@@ -333,7 +398,7 @@ export const USER_SESSION_WIDGET_HTML = `<!DOCTYPE html>
     }
   }
 
-  // 1. Primary: listen for openai:set_globals CustomEvent (fires when SDK populates toolOutput)
+  // ChatGPT compatibility: listen for openai:set_globals CustomEvent.
   window.addEventListener('openai:set_globals', function(event) {
     if (rendered) return;
     var globals = event.detail && event.detail.globals;
@@ -342,16 +407,29 @@ export const USER_SESSION_WIDGET_HTML = `<!DOCTYPE html>
     }
   });
 
-  // 2. Check immediately and on DOMContentLoaded (toolOutput may already be set)
+  // ChatGPT compatibility: toolOutput may already be set.
   tryToolOutput();
   document.addEventListener('DOMContentLoaded', tryToolOutput);
 
-  // 3. Fallback: postMessage JSON-RPC from parent
+  // MCP Apps bridge: receive lifecycle messages and tool-result notifications.
   window.addEventListener('message', function(event) {
-    if (rendered) return;
     if (!event.data) return;
     var msg = event.data;
-    // JSON-RPC tool-result envelope
+
+    if (msg.jsonrpc === '2.0' && msg.id === initId && Object.prototype.hasOwnProperty.call(msg, 'result')) {
+      sendInitialized();
+      return;
+    }
+
+    if (msg.jsonrpc === '2.0' && msg.method === 'ui/resource-teardown') {
+      if (msg.id !== undefined && msg.id !== null) {
+        postToParent({ jsonrpc: '2.0', id: msg.id, result: {} });
+      }
+      return;
+    }
+
+    if (rendered) return;
+
     if (msg.jsonrpc === '2.0' && msg.method === 'ui/notifications/tool-result') {
       var data = extract(msg.params);
       if (data) render(data);
@@ -361,6 +439,7 @@ export const USER_SESSION_WIDGET_HTML = `<!DOCTYPE html>
     var data = extract(msg);
     if (data) render(data);
   });
+  startMcpAppsLifecycle();
 })();
 </script>
 </body>

--- a/workers/fantasy-mcp/tests/integration/index.integration.test.ts
+++ b/workers/fantasy-mcp/tests/integration/index.integration.test.ts
@@ -5,6 +5,15 @@ import { getUnifiedTools } from '../../src/mcp/tools';
 import { INTERNAL_SERVICE_TOKEN_HEADER } from '@flaim/worker-shared';
 
 function buildMcpRequest(pathname: '/mcp' | '/fantasy/mcp'): Request {
+  return buildMcpJsonRpcRequest(pathname, 'tools/list');
+}
+
+function buildMcpJsonRpcRequest(
+  pathname: '/mcp' | '/fantasy/mcp',
+  method: string,
+  params: Record<string, unknown> = {},
+  id = 'wire-test-1'
+): Request {
   return new Request(`https://api.flaim.app${pathname}`, {
     method: 'POST',
     headers: {
@@ -14,9 +23,9 @@ function buildMcpRequest(pathname: '/mcp' | '/fantasy/mcp'): Request {
     },
     body: JSON.stringify({
       jsonrpc: '2.0',
-      id: 'wire-test-1',
-      method: 'tools/list',
-      params: {},
+      id,
+      method,
+      params,
     }),
   });
 }
@@ -30,7 +39,7 @@ function buildMcpGetRequest(pathname: '/mcp' | '/fantasy/mcp'): Request {
   });
 }
 
-async function parseJsonRpcResponse(response: Response): Promise<{
+type JsonRpcTestPayload = {
   result?: {
     tools?: Array<{
       name: string;
@@ -47,34 +56,39 @@ async function parseJsonRpcResponse(response: Response): Promise<{
         destructiveHint?: boolean;
         idempotentHint?: boolean;
       };
-      _meta?: { securitySchemes?: Array<{ type?: string; scopes?: string[] }> };
+      _meta?: Record<string, unknown> & {
+        securitySchemes?: Array<{ type?: string; scopes?: string[] }>;
+        ui?: { resourceUri?: string };
+        'openai/outputTemplate'?: string;
+        'openai/widgetAccessible'?: boolean;
+        'openai/resultCanProduceWidget'?: boolean;
+        'openai/widgetDomain'?: string;
+      };
+    }>;
+    resources?: Array<{
+      uri: string;
+      name?: string;
+      mimeType?: string;
+      _meta?: Record<string, unknown>;
+    }>;
+    contents?: Array<{
+      uri?: string;
+      mimeType?: string;
+      text?: string;
+      _meta?: Record<string, unknown> & {
+        ui?: { csp?: { connectDomains?: unknown[]; resourceDomains?: unknown[] }; domain?: string };
+        'openai/widgetCSP'?: { connect_domains?: unknown[]; resource_domains?: unknown[] };
+        'openai/widgetDomain'?: string;
+      };
     }>;
   };
-}> {
+};
+
+async function parseJsonRpcResponse(response: Response): Promise<JsonRpcTestPayload> {
   const contentType = response.headers.get('Content-Type') || '';
 
   if (contentType.includes('application/json')) {
-    return response.json() as Promise<{
-      result?: {
-        tools?: Array<{
-          name: string;
-          inputSchema?: {
-            properties?: {
-              platform?: {
-                enum?: string[];
-              };
-            };
-          };
-          annotations?: {
-            readOnlyHint?: boolean;
-            openWorldHint?: boolean;
-            destructiveHint?: boolean;
-            idempotentHint?: boolean;
-          };
-          _meta?: { securitySchemes?: Array<{ type?: string; scopes?: string[] }> };
-        }>;
-      };
-    }>;
+    return response.json() as Promise<JsonRpcTestPayload>;
   }
 
   if (contentType.includes('text/event-stream')) {
@@ -85,27 +99,7 @@ async function parseJsonRpcResponse(response: Response): Promise<{
       .map((line) => line.slice(5).trim())
       .join('\n')
       .trim();
-    return JSON.parse(data) as {
-      result?: {
-        tools?: Array<{
-          name: string;
-          inputSchema?: {
-            properties?: {
-              platform?: {
-                enum?: string[];
-              };
-            };
-          };
-          annotations?: {
-            readOnlyHint?: boolean;
-            openWorldHint?: boolean;
-            destructiveHint?: boolean;
-            idempotentHint?: boolean;
-          };
-          _meta?: { securitySchemes?: Array<{ type?: string; scopes?: string[] }> };
-        }>;
-      };
-    };
+    return JSON.parse(data) as JsonRpcTestPayload;
   }
 
   throw new Error(`Unsupported MCP response content type: ${contentType}`);
@@ -216,6 +210,13 @@ describe('fantasy-mcp gateway integration', () => {
     const freeAgentsTool = tools?.find((tool) => tool.name === 'get_free_agents');
     expect(freeAgentsTool).toBeDefined();
     expect(freeAgentsTool?.inputSchema?.properties?.platform?.enum).toContain('sleeper');
+    const userSessionTool = tools?.find((tool) => tool.name === 'get_user_session');
+    expect(userSessionTool).toBeDefined();
+    expect(userSessionTool?._meta?.ui).toEqual({ resourceUri: 'ui://widget/user-session.html' });
+    expect(userSessionTool?._meta?.['openai/outputTemplate']).toBe('ui://widget/user-session.html');
+    expect(userSessionTool?._meta?.['openai/widgetAccessible']).toBe(true);
+    expect(userSessionTool?._meta?.['openai/resultCanProduceWidget']).toBe(true);
+    expect(userSessionTool?._meta?.['openai/widgetDomain']).toBeUndefined();
 
     const scopeByTool = new Map(getUnifiedTools().map((tool) => [tool.name, tool.requiredScope]));
     for (const tool of tools || []) {
@@ -235,6 +236,52 @@ describe('fantasy-mcp gateway integration', () => {
     expect(introspectReq.url).toBe('https://internal/internal/introspect');
     expect(introspectReq.headers.get('X-Flaim-Expected-Resource')).toBe('https://api.flaim.app/mcp');
     expect(introspectReq.headers.get(INTERNAL_SERVICE_TOKEN_HEADER)).toBe('internal-secret');
+  });
+
+  it('exposes the user session MCP Apps resource metadata', async () => {
+    const authFetch = vi.fn(async () =>
+      new Response(JSON.stringify({ valid: true, userId: 'user-123', scope: 'mcp:read mcp:write', authType: 'oauth' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    const env = buildEnv(authFetch);
+
+    const listResponse = await app.fetch(
+      buildMcpJsonRpcRequest('/mcp', 'resources/list', {}, 'resources-list-1'),
+      env,
+      mockExecutionContext()
+    );
+    expect(listResponse.status).toBe(200);
+    const listPayload = await parseJsonRpcResponse(listResponse);
+    const resource = listPayload.result?.resources?.find((item) => item.uri === 'ui://widget/user-session.html');
+    expect(resource).toBeDefined();
+    expect(resource?.mimeType).toBe('text/html;profile=mcp-app');
+
+    const readResponse = await app.fetch(
+      buildMcpJsonRpcRequest(
+        '/mcp',
+        'resources/read',
+        { uri: 'ui://widget/user-session.html' },
+        'resources-read-1'
+      ),
+      env,
+      mockExecutionContext()
+    );
+    expect(readResponse.status).toBe(200);
+    const readPayload = await parseJsonRpcResponse(readResponse);
+    const content = readPayload.result?.contents?.find((item) => item.uri === 'ui://widget/user-session.html');
+    expect(content?.mimeType).toBe('text/html;profile=mcp-app');
+    expect(content?.text).toContain('<title>Flaim</title>');
+    expect(content?._meta?.ui?.csp?.connectDomains).toEqual([]);
+    expect(content?._meta?.ui?.csp?.resourceDomains).toEqual([]);
+    expect(content?._meta?.ui?.domain).toBeUndefined();
+    expect(content?._meta?.['openai/widgetDomain']).toBeUndefined();
+    expect(content?._meta?.['openai/widgetCSP']).toEqual({
+      connect_domains: [],
+      resource_domains: [],
+      redirect_domains: ['https://flaim.app'],
+    });
   });
 
   it('fails closed with 401 when introspection returns non-OK', async () => {


### PR DESCRIPTION
Summary: Refactors the get_user_session widget metadata and iframe lifecycle to be MCP Apps-first while preserving ChatGPT compatibility aliases. Root cause: Claude Desktop treats the legacy openai/widgetDomain value as ui.domain and rejects https://flaim.app because Claude expects either no domain or a claudemcpcontent.com host. Changes: remove stable widget domain metadata, declare text/html;profile=mcp-app for resources/list and resources/read, add _meta.ui.resourceUri and _meta.ui.csp, keep ChatGPT aliases, add manual ui/initialize lifecycle handling, and cover the MCP Apps metadata in tests. Validation: corepack pnpm --dir workers/fantasy-mcp run type-check; corepack pnpm --dir workers/fantasy-mcp exec vitest run src/__tests__/tools.test.ts; corepack pnpm --dir workers/fantasy-mcp exec vitest run -c vitest.integration.config.ts tests/integration/index.integration.test.ts; corepack pnpm --dir workers/fantasy-mcp run test.