### PR TITLE
[codex] Limit user session widget to current seasons

### DIFF
--- a/workers/fantasy-mcp/src/__tests__/tools.test.ts
+++ b/workers/fantasy-mcp/src/__tests__/tools.test.ts
@@ -760,10 +760,56 @@ describe('fantasy-mcp tools', () => {
     expect(payload.warnings?.some((w) => w.includes('Preserved non-current baseball default'))).toBe(true);
   });
 
+  it('get_user_session: provider-lag seasons are omitted with a current-season message', async () => {
+    const tool = getUnifiedTools().find((t) => t.name === 'get_user_session');
+    expect(tool).toBeTruthy();
+
+    const previousSeasonLeague = {
+      platform: 'espn',
+      sport: 'baseball',
+      leagueId: 'bb-2025',
+      leagueName: 'Diamond',
+      teamId: 't2',
+      seasonYear: 2025,
+    };
+
+    const env = {
+      INTERNAL_SERVICE_TOKEN: 'internal-secret',
+      AUTH_WORKER: {
+        fetch: async (req: Request) => {
+          const url = new URL(req.url);
+          if (url.pathname === '/internal/leagues') {
+            return new Response(JSON.stringify({ leagues: [previousSeasonLeague] }), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          }
+          return new Response(JSON.stringify({ leagues: [] }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        },
+      },
+    } as unknown as Env;
+
+    const result = await tool!.handler({}, env, 'Bearer test-token');
+    const payload = JSON.parse(result.content[0].text) as {
+      allLeagues: Array<{ sport: string; seasonYear: number }>;
+      instructions: string;
+      totalLeaguesFound: number;
+    };
+
+    expect(payload.totalLeaguesFound).toBe(0);
+    expect(payload.allLeagues).toHaveLength(0);
+    expect(payload.instructions).toContain('No current-season leagues found');
+    expect(payload.instructions).not.toContain('No leagues configured');
+  });
+
   it('get_user_session: recurring Yahoo leagues dedup to current season only', async () => {
     const tool = getUnifiedTools().find((t) => t.name === 'get_user_session');
     expect(tool).toBeTruthy();
 
+    // fetchYahooLeagues maps Yahoo's leagueKey field into the normalized leagueId.
     // Same Yahoo league renewed across two seasons — game_key changes, stable league_id does not.
     const yahooLeagues = [
       { sport: 'football', leagueKey: '449.l.1000', leagueName: 'Touchdown League', teamId: 't1', seasonYear: 2024 },
@@ -811,6 +857,7 @@ describe('fantasy-mcp tools', () => {
     // Yahoo can return renewed leagues whose visible lineage is the same even
     // when the stable league_id portion changes. The active session view should
     // still expose only the current baseball season.
+    // fetchYahooLeagues maps Yahoo's leagueKey field into the normalized leagueId.
     const yahooLeagues = [
       { sport: 'baseball', leagueKey: '422.l.1000', leagueName: 'Car Ramrod', teamId: 't1', teamName: "Gerry Gugger's Nice Team", seasonYear: 2024 },
       { sport: 'baseball', leagueKey: '431.l.2000', leagueName: 'Car Ramrod', teamId: 't2', teamName: "Gerry Gugger's Nice Team", seasonYear: 2025 },

--- a/workers/fantasy-mcp/src/__tests__/tools.test.ts
+++ b/workers/fantasy-mcp/src/__tests__/tools.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, type MockedFunction } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi, type MockedFunction } from 'vitest';
 import type { z } from 'zod';
 import { getUnifiedTools, hasRequiredScope, mcpAuthError } from '../mcp/tools';
 import { buildMcpAuthErrorResponse } from '../auth-response';
@@ -14,6 +14,15 @@ vi.mock('../router', () => ({
 }));
 
 describe('fantasy-mcp tools', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-05T12:00:00-05:00'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('exposes the unified tool set', () => {
     const tools = getUnifiedTools();
     const names = tools.map((tool) => tool.name).sort();
@@ -686,6 +695,71 @@ describe('fantasy-mcp tools', () => {
     expect(payload.warnings?.some((w) => w.includes('temporarily unavailable'))).toBe(true);
   });
 
+  it('get_user_session: non-current default present in raw leagues is preserved but not shown active', async () => {
+    const tool = getUnifiedTools().find((t) => t.name === 'get_user_session');
+    expect(tool).toBeTruthy();
+
+    const previousSeasonLeague = {
+      platform: 'espn',
+      sport: 'baseball',
+      leagueId: 'bb-2025',
+      leagueName: 'Diamond',
+      teamId: 't2',
+      seasonYear: 2025,
+    };
+    const prefs = {
+      defaultSport: 'baseball',
+      defaultBaseball: { platform: 'espn', leagueId: 'bb-2025', seasonYear: 2025 },
+    };
+
+    let deleteCalled = false;
+
+    const env = {
+      INTERNAL_SERVICE_TOKEN: 'internal-secret',
+      AUTH_WORKER: {
+        fetch: async (req: Request) => {
+          const url = new URL(req.url);
+          if (url.pathname === '/internal/leagues') {
+            return new Response(JSON.stringify({ leagues: [previousSeasonLeague] }), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          }
+          if (url.pathname === '/internal/user/preferences') {
+            return new Response(JSON.stringify(prefs), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          }
+          if (req.method === 'DELETE' && url.pathname.startsWith('/internal/leagues/default/')) {
+            deleteCalled = true;
+            return new Response(JSON.stringify({ success: true }), { status: 200 });
+          }
+          return new Response(JSON.stringify({ leagues: [] }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        },
+      },
+    } as unknown as Env;
+
+    const result = await tool!.handler({}, env, 'Bearer test-token');
+    const payload = JSON.parse(result.content[0].text) as {
+      allLeagues: Array<{ sport: string; seasonYear: number }>;
+      defaultLeagues: Record<string, unknown>;
+      defaultLeague: unknown;
+      totalLeaguesFound: number;
+      warnings?: string[];
+    };
+
+    expect(deleteCalled).toBe(false);
+    expect(payload.totalLeaguesFound).toBe(0);
+    expect(payload.allLeagues).toHaveLength(0);
+    expect(payload.defaultLeagues.baseball).toBeUndefined();
+    expect(payload.defaultLeague).toBeNull();
+    expect(payload.warnings?.some((w) => w.includes('Preserved non-current baseball default'))).toBe(true);
+  });
+
   it('get_user_session: recurring Yahoo leagues dedup to current season only', async () => {
     const tool = getUnifiedTools().find((t) => t.name === 'get_user_session');
     expect(tool).toBeTruthy();
@@ -728,6 +802,55 @@ describe('fantasy-mcp tools', () => {
     expect(yahooFootball).toHaveLength(1);
     expect(yahooFootball[0].seasonYear).toBe(2025);
     expect(yahooFootball[0].leagueId).toBe('461.l.1000');
+  });
+
+  it('get_user_session: Yahoo seasons with changed stable IDs still hide historical seasons', async () => {
+    const tool = getUnifiedTools().find((t) => t.name === 'get_user_session');
+    expect(tool).toBeTruthy();
+
+    // Yahoo can return renewed leagues whose visible lineage is the same even
+    // when the stable league_id portion changes. The active session view should
+    // still expose only the current baseball season.
+    const yahooLeagues = [
+      { sport: 'baseball', leagueKey: '422.l.1000', leagueName: 'Car Ramrod', teamId: 't1', teamName: "Gerry Gugger's Nice Team", seasonYear: 2024 },
+      { sport: 'baseball', leagueKey: '431.l.2000', leagueName: 'Car Ramrod', teamId: 't2', teamName: "Gerry Gugger's Nice Team", seasonYear: 2025 },
+      { sport: 'baseball', leagueKey: '442.l.3000', leagueName: 'Car Ramrod', teamId: 't3', teamName: "Gerry Gugger's Nice Team", seasonYear: 2026 },
+    ];
+
+    const env = {
+      INTERNAL_SERVICE_TOKEN: 'internal-secret',
+      AUTH_WORKER: {
+        fetch: async (req: Request) => {
+          const url = new URL(req.url);
+          if (url.pathname === '/internal/leagues/yahoo') {
+            return new Response(JSON.stringify({ leagues: yahooLeagues }), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          }
+          return new Response(JSON.stringify({ leagues: [] }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        },
+      },
+    } as unknown as Env;
+
+    const result = await tool!.handler({}, env, 'Bearer test-token');
+    const payload = JSON.parse(result.content[0].text) as {
+      allLeagues: Array<{ platform: string; sport: string; leagueId: string; seasonYear: number }>;
+      totalLeaguesFound: number;
+    };
+
+    const yahooBaseball = payload.allLeagues.filter(
+      (l) => l.platform === 'yahoo' && l.sport === 'baseball'
+    );
+    expect(yahooBaseball).toHaveLength(1);
+    expect(yahooBaseball[0]).toMatchObject({
+      leagueId: '442.l.3000',
+      seasonYear: 2026,
+    });
+    expect(payload.totalLeaguesFound).toBe(1);
   });
 
   it('get_user_session: historical Sleeper football season does not leak into active session view', async () => {

--- a/workers/fantasy-mcp/src/mcp/tools.ts
+++ b/workers/fantasy-mcp/src/mcp/tools.ts
@@ -459,9 +459,6 @@ export function getUnifiedTools(): UnifiedTool[] {
           // Combine all leagues
           const allLeagues = [...espnData.leagues, ...yahooData.leagues, ...sleeperData.leagues];
 
-          // Filter to active leagues (have a season within 2 years) and limit to 2 most recent seasons
-          const thresholdYear = getActiveThresholdYear();
-
           // Track which platforms failed to fetch — used to avoid clearing valid defaults
           // when a platform was temporarily unavailable.
           const failedPlatforms = new Set<string>();
@@ -482,30 +479,20 @@ export function getUnifiedTools(): UnifiedTool[] {
             leagueGroups.get(key)!.push(league);
           }
 
-          // Filter to active leagues and limit seasons
+          // Filter to active leagues. The session view is intentionally strict:
+          // only the sport's current canonical season belongs here. Older seasons
+          // stay discoverable through get_ancient_history.
           const leagues: typeof allLeagues = [];
           for (const [, groupSeasons] of leagueGroups) {
             // Sort by seasonYear descending
             groupSeasons.sort((a, b) => (b.seasonYear || 0) - (a.seasonYear || 0));
-            const mostRecentYear = groupSeasons[0]?.seasonYear || 0;
 
-            // Only include if most recent season is within threshold
-            if (mostRecentYear >= thresholdYear) {
-              // Determine current season for this league's sport
-              const sport = (groupSeasons[0]?.sport || '').toLowerCase();
-              const currentYear = getDefaultSeasonYear(sport as Sport);
-              // Take only the current-season entry (or most recent if no exact match)
-              const currentSeason = groupSeasons.find(s => s.seasonYear === currentYear);
-              if (currentSeason) {
-                leagues.push(currentSeason);
-              } else if (groupSeasons[0]?.platform === 'sleeper') {
-                // Sleeper league IDs are season-specific, so a fallback here can promote a
-                // past canonical season into the active session view.
-                continue;
-              } else {
-                // Fallback: most recent season (e.g., league not yet created for current season)
-                leagues.push(groupSeasons[0]);
-              }
+            // Determine current season for this league's sport
+            const sport = (groupSeasons[0]?.sport || '').toLowerCase();
+            const currentYear = getDefaultSeasonYear(sport as Sport);
+            const currentSeason = groupSeasons.find(s => s.seasonYear === currentYear);
+            if (currentSeason) {
+              leagues.push(currentSeason);
             }
           }
 
@@ -590,38 +577,50 @@ export function getUnifiedTools(): UnifiedTool[] {
                   // Platform fetch failed — the league may still be valid. Preserve
                   // the default and surface a transient warning instead of clearing.
                   warnings.push(`Could not verify ${sport} default: ${defaultInfo.platform} data is temporarily unavailable. Default preserved.`);
+                } else if (
+                  allLeagues.some(
+                    (l) =>
+                      l.platform === defaultInfo.platform &&
+                      l.leagueId === defaultInfo.leagueId &&
+                      l.seasonYear === defaultInfo.seasonYear
+                  )
+                ) {
+                  // The default still exists in the provider payload, but is not
+                  // part of the current-session view. Preserve it so season
+                  // rollover/provider lag does not delete user preferences.
+                  warnings.push(`Preserved non-current ${sport} default: league ${defaultInfo.leagueId} is not shown in active leagues.`);
                 } else {
-                // Platform fetch succeeded but league is missing — it's genuinely stale.
-                // Fire a best-effort clear so future reads don't repeat this lookup.
-                const staleBaseHeaders: Record<string, string> = {
-                  'Content-Type': 'application/json',
-                  ...(authHeader ? { Authorization: authHeader } : {}),
-                };
-                const withStaleCorrelation = correlationId ? withCorrelationId(staleBaseHeaders, correlationId) : new Headers(staleBaseHeaders);
-                const withStaleInternal = withInternalServiceToken(withStaleCorrelation, env, `auth-worker /internal/leagues/default/${sport}`);
-                const staleHeaders = withEvalHeaders(withStaleInternal, evalRunId, evalTraceId);
-                const staleUrl = new URL(`https://internal/internal/leagues/default/${sport}`);
-                staleUrl.searchParams.set('platform', defaultInfo.platform);
-                staleUrl.searchParams.set('leagueId', defaultInfo.leagueId);
-                staleUrl.searchParams.set('seasonYear', String(defaultInfo.seasonYear));
-                let cleared = false;
-                try {
-                  const clearResp = await env.AUTH_WORKER.fetch(
-                    new Request(staleUrl.toString(), { method: 'DELETE', headers: staleHeaders })
-                  );
-                  cleared = clearResp.ok;
-                  if (!clearResp.ok) {
-                    console.error(`[get_user_session] Stale ${sport} default DELETE returned ${clearResp.status}`);
+                  // Platform fetch succeeded but league is missing — it's genuinely stale.
+                  // Fire a best-effort clear so future reads don't repeat this lookup.
+                  const staleBaseHeaders: Record<string, string> = {
+                    'Content-Type': 'application/json',
+                    ...(authHeader ? { Authorization: authHeader } : {}),
+                  };
+                  const withStaleCorrelation = correlationId ? withCorrelationId(staleBaseHeaders, correlationId) : new Headers(staleBaseHeaders);
+                  const withStaleInternal = withInternalServiceToken(withStaleCorrelation, env, `auth-worker /internal/leagues/default/${sport}`);
+                  const staleHeaders = withEvalHeaders(withStaleInternal, evalRunId, evalTraceId);
+                  const staleUrl = new URL(`https://internal/internal/leagues/default/${sport}`);
+                  staleUrl.searchParams.set('platform', defaultInfo.platform);
+                  staleUrl.searchParams.set('leagueId', defaultInfo.leagueId);
+                  staleUrl.searchParams.set('seasonYear', String(defaultInfo.seasonYear));
+                  let cleared = false;
+                  try {
+                    const clearResp = await env.AUTH_WORKER.fetch(
+                      new Request(staleUrl.toString(), { method: 'DELETE', headers: staleHeaders })
+                    );
+                    cleared = clearResp.ok;
+                    if (!clearResp.ok) {
+                      console.error(`[get_user_session] Stale ${sport} default DELETE returned ${clearResp.status}`);
+                    }
+                  } catch (e) {
+                    console.error(`[get_user_session] Network error clearing stale ${sport} default:`, e);
                   }
-                } catch (e) {
-                  console.error(`[get_user_session] Network error clearing stale ${sport} default:`, e);
+                  warnings.push(
+                    cleared
+                      ? `Cleared stale ${sport} default: league ${defaultInfo.leagueId} is no longer in your active leagues.`
+                      : `Stale ${sport} default detected (league ${defaultInfo.leagueId} is no longer active) — automatic cleanup failed, will retry next session.`
+                  );
                 }
-                warnings.push(
-                  cleared
-                    ? `Cleared stale ${sport} default: league ${defaultInfo.leagueId} is no longer in your active leagues.`
-                    : `Stale ${sport} default detected (league ${defaultInfo.leagueId} is no longer active) — automatic cleanup failed, will retry next session.`
-                );
-                } // end: platform fetch succeeded (stale default)
               }
             }
           }

--- a/workers/fantasy-mcp/src/mcp/tools.ts
+++ b/workers/fantasy-mcp/src/mcp/tools.ts
@@ -494,9 +494,14 @@ export function getUnifiedTools(): UnifiedTool[] {
             if (currentSeason) {
               leagues.push(currentSeason);
             }
+            // No fallback to the most recent historical season: showing stale
+            // leagues in get_user_session causes agents and widgets to treat
+            // old seasons as active. Provider-lag cases get a distinct message
+            // below and remain available through get_ancient_history.
           }
 
           const hasLeagues = leagues.length > 0;
+          const hasRawLeagues = allLeagues.length > 0;
           const sportCounts = leagues.reduce(
             (acc, l) => {
               const sport = l.sport?.toLowerCase() || 'unknown';
@@ -508,8 +513,9 @@ export function getUnifiedTools(): UnifiedTool[] {
 
           let sessionMessage: string;
           if (!hasLeagues) {
-            sessionMessage =
-              'No leagues configured. Please go to flaim.app/settings to add your fantasy platform credentials.';
+            sessionMessage = hasRawLeagues
+              ? 'No current-season leagues found. Provider data exists, but every returned league is for a non-current season. Do not treat historical leagues as active; use get_ancient_history only when the user asks about past seasons.'
+              : 'No leagues configured. Please go to flaim.app/settings to add your fantasy platform credentials.';
           } else if (leagues.length === 1) {
             const league = leagues[0];
             sessionMessage = `Use platform="${league.platform}", sport="${league.sport}", leagueId="${league.leagueId}", teamId="${league.teamId || 'none'}", seasonYear=${league.seasonYear} for all tool calls.`;
@@ -560,6 +566,9 @@ export function getUnifiedTools(): UnifiedTool[] {
             basketball: preferences.defaultBasketball,
             hockey: preferences.defaultHockey,
           };
+          const rawLeagueKeys = new Set(
+            allLeagues.map((l) => `${l.platform}:${l.leagueId}:${l.seasonYear}`)
+          );
 
           for (const [sport, defaultInfo] of Object.entries(sportDefaultMap)) {
             if (defaultInfo) {
@@ -577,14 +586,7 @@ export function getUnifiedTools(): UnifiedTool[] {
                   // Platform fetch failed — the league may still be valid. Preserve
                   // the default and surface a transient warning instead of clearing.
                   warnings.push(`Could not verify ${sport} default: ${defaultInfo.platform} data is temporarily unavailable. Default preserved.`);
-                } else if (
-                  allLeagues.some(
-                    (l) =>
-                      l.platform === defaultInfo.platform &&
-                      l.leagueId === defaultInfo.leagueId &&
-                      l.seasonYear === defaultInfo.seasonYear
-                  )
-                ) {
+                } else if (rawLeagueKeys.has(`${defaultInfo.platform}:${defaultInfo.leagueId}:${defaultInfo.seasonYear}`)) {
                   // The default still exists in the provider payload, but is not
                   // part of the current-session view. Preserve it so season
                   // rollover/provider lag does not delete user preferences.


### PR DESCRIPTION
## Summary
- keep get_user_session strict to current canonical sport seasons so the widget does not render historical leagues
- preserve non-current defaults when the raw provider payload still contains them, avoiding season-rollover cleanup damage
- freeze tool tests to a known date and add regression coverage for Yahoo renewed seasons with changed IDs

## Verification
- corepack pnpm --dir workers/fantasy-mcp run type-check
- corepack pnpm --dir workers/fantasy-mcp exec vitest run src/__tests__/tools.test.ts
- corepack pnpm --dir workers/fantasy-mcp exec vitest run -c vitest.integration.config.ts tests/integration/index.integration.test.ts
- corepack pnpm --dir workers/fantasy-mcp run test