### PR TITLE
[codex] Fix ESPN standings season phase

### DIFF
--- a/workers/espn-client/src/shared/__tests__/standings.test.ts
+++ b/workers/espn-client/src/shared/__tests__/standings.test.ts
@@ -5,14 +5,26 @@ import {
 } from '../standings';
 
 describe('deriveStandingsSeasonPhase', () => {
-  it('marks the season complete when ESPN exposes explicit final ranks', () => {
+  it('marks the current season complete when explicit final ranks align with postseason matchup context', () => {
     expect(deriveStandingsSeasonPhase({
       requestedSeasonYear: 2026,
       currentSeasonYear: 2026,
-      scoringPeriodId: 10,
+      scoringPeriodId: 150,
+      currentMatchupPeriod: 21,
       regularSeasonMatchupPeriods: 20,
       teams: [{ id: 1, rankFinal: 1 }],
     })).toBe('season_complete');
+  });
+
+  it('ignores explicit final-rank-like fields during the current regular season', () => {
+    expect(deriveStandingsSeasonPhase({
+      requestedSeasonYear: 2026,
+      currentSeasonYear: 2026,
+      scoringPeriodId: 150,
+      currentMatchupPeriod: 10,
+      regularSeasonMatchupPeriods: 20,
+      teams: [{ id: 1, rankCalculatedFinal: 1 }],
+    })).toBe('regular_season');
   });
 
   it('marks older seasons complete even without explicit final ranks', () => {
@@ -29,7 +41,8 @@ describe('deriveStandingsSeasonPhase', () => {
     expect(deriveStandingsSeasonPhase({
       requestedSeasonYear: 2026,
       currentSeasonYear: 2026,
-      scoringPeriodId: 22,
+      scoringPeriodId: 150,
+      currentMatchupPeriod: 22,
       regularSeasonMatchupPeriods: 20,
       teams: [{ id: 1 }],
     })).toBe('playoffs_in_progress');
@@ -39,7 +52,8 @@ describe('deriveStandingsSeasonPhase', () => {
     expect(deriveStandingsSeasonPhase({
       requestedSeasonYear: 2026,
       currentSeasonYear: 2026,
-      scoringPeriodId: 10,
+      scoringPeriodId: 150,
+      currentMatchupPeriod: 10,
       regularSeasonMatchupPeriods: 20,
       teams: [{ id: 1 }],
     })).toBe('regular_season');

--- a/workers/espn-client/src/shared/__tests__/standings.test.ts
+++ b/workers/espn-client/src/shared/__tests__/standings.test.ts
@@ -59,6 +59,16 @@ describe('deriveStandingsSeasonPhase', () => {
     })).toBe('regular_season');
   });
 
+  it('returns regular_season when regular-season length is unavailable', () => {
+    expect(deriveStandingsSeasonPhase({
+      requestedSeasonYear: 2026,
+      currentSeasonYear: 2026,
+      scoringPeriodId: 150,
+      currentMatchupPeriod: 22,
+      teams: [{ id: 1, rankCalculatedFinal: 1 }],
+    })).toBe('regular_season');
+  });
+
   it('returns regular_season for future seasons', () => {
     expect(deriveStandingsSeasonPhase({
       requestedSeasonYear: 2027,

--- a/workers/espn-client/src/shared/standings.ts
+++ b/workers/espn-client/src/shared/standings.ts
@@ -16,6 +16,7 @@ interface DeriveSeasonPhaseInput {
   requestedSeasonYear: number;
   currentSeasonYear: number;
   scoringPeriodId?: number;
+  currentMatchupPeriod?: number;
   regularSeasonMatchupPeriods?: number;
   teams: EspnTeam[];
 }
@@ -35,17 +36,24 @@ export function deriveStandingsSeasonPhase({
   requestedSeasonYear,
   currentSeasonYear,
   scoringPeriodId,
+  currentMatchupPeriod,
   regularSeasonMatchupPeriods,
   teams,
 }: DeriveSeasonPhaseInput): EspnSeasonPhase {
-  if (hasExplicitCompletionData(teams) || requestedSeasonYear < currentSeasonYear) {
+  if (requestedSeasonYear < currentSeasonYear) {
     return 'season_complete';
   }
 
   if (requestedSeasonYear === currentSeasonYear) {
-    const regularPeriods = regularSeasonMatchupPeriods ?? 0;
-    const scoringPeriod = scoringPeriodId ?? 0;
-    return scoringPeriod > regularPeriods ? 'playoffs_in_progress' : 'regular_season';
+    const matchupPeriod = currentMatchupPeriod ?? scoringPeriodId;
+    if (
+      regularSeasonMatchupPeriods != null
+      && matchupPeriod != null
+      && matchupPeriod > regularSeasonMatchupPeriods
+    ) {
+      return hasExplicitCompletionData(teams) ? 'season_complete' : 'playoffs_in_progress';
+    }
+    return 'regular_season';
   }
 
   return 'regular_season';

--- a/workers/espn-client/src/sports/__tests__/matchups-cross-sport.test.ts
+++ b/workers/espn-client/src/sports/__tests__/matchups-cross-sport.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi, type MockedFunction } from 'vitest';
+import { getCredentials } from '../../shared/auth';
+import { espnFetch } from '../../shared/espn-api';
+import { withSeasonContext } from '../../shared/season';
+import { footballHandlers } from '../football/handlers';
+import { basketballHandlers } from '../basketball/handlers';
+import { hockeyHandlers } from '../hockey/handlers';
+
+vi.mock('../../shared/auth', () => ({
+  getCredentials: vi.fn(),
+}));
+
+vi.mock('../../shared/espn-api', async () => {
+  const actual = await vi.importActual('../../shared/espn-api') as Record<string, unknown>;
+  return {
+    ...actual,
+    espnFetch: vi.fn(),
+  };
+});
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('ESPN get_matchups current matchup fallback', () => {
+  const getCredentialsMock = getCredentials as MockedFunction<typeof getCredentials>;
+  const espnFetchMock = espnFetch as MockedFunction<typeof espnFetch>;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    getCredentialsMock.mockResolvedValue({ s2: 'token', swid: '{swid}' });
+  });
+
+  it.each([
+    { sport: 'football' as const, seasonYear: 2026, leagueId: '123', handlers: footballHandlers },
+    { sport: 'basketball' as const, seasonYear: 2025, leagueId: '456', handlers: basketballHandlers },
+    { sport: 'hockey' as const, seasonYear: 2025, leagueId: '789', handlers: hockeyHandlers },
+  ])('defaults $sport matchups to status.currentMatchupPeriod', async ({ sport, seasonYear, leagueId, handlers }) => {
+    espnFetchMock.mockResolvedValue(jsonResponse({
+      scoringPeriodId: 130,
+      status: { currentMatchupPeriod: 10 },
+      schedule: [
+        { matchupPeriodId: 10, home: { teamId: 1, totalPoints: 100 }, away: { teamId: 2, totalPoints: 90 } },
+        { matchupPeriodId: 11, home: { teamId: 3, totalPoints: 80 }, away: { teamId: 4, totalPoints: 70 } },
+      ],
+    }));
+
+    const params = withSeasonContext({ sport, league_id: leagueId, season_year: seasonYear });
+    const result = await handlers.get_matchups({} as never, params, 'Bearer x', 'cid');
+
+    expect(result.success).toBe(true);
+    const data = result.data as { matchupPeriod: number | null; matchups: unknown[] };
+    expect(data.matchupPeriod).toBe(10);
+    expect(data.matchups).toHaveLength(1);
+  });
+});

--- a/workers/espn-client/src/sports/baseball/__tests__/matchups.test.ts
+++ b/workers/espn-client/src/sports/baseball/__tests__/matchups.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi, type MockedFunction } from 'vitest';
+import { baseballHandlers } from '../handlers';
+import { getCredentials } from '../../../shared/auth';
+import { espnFetch } from '../../../shared/espn-api';
+import { withSeasonContext } from '../../../shared/season';
+
+vi.mock('../../../shared/auth', () => ({
+  getCredentials: vi.fn(),
+}));
+
+vi.mock('../../../shared/espn-api', async () => {
+  const actual = await vi.importActual('../../../shared/espn-api') as Record<string, unknown>;
+  return {
+    ...actual,
+    espnFetch: vi.fn(),
+  };
+});
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('baseball get_matchups handler', () => {
+  const getCredentialsMock = getCredentials as MockedFunction<typeof getCredentials>;
+  const espnFetchMock = espnFetch as MockedFunction<typeof espnFetch>;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    getCredentialsMock.mockResolvedValue({ s2: 'token', swid: '{swid}' });
+  });
+
+  it('defaults to currentMatchupPeriod instead of daily scoringPeriodId', async () => {
+    espnFetchMock.mockResolvedValue(jsonResponse({
+      scoringPeriodId: 130,
+      status: { currentMatchupPeriod: 10 },
+      teams: [
+        { id: 1, location: 'Alpha', nickname: 'Aces' },
+        { id: 2, location: 'Beta', nickname: 'Bats' },
+      ],
+      schedule: [
+        {
+          matchupPeriodId: 10,
+          home: { teamId: 1, totalPoints: 100 },
+          away: { teamId: 2, totalPoints: 90 },
+          winner: 'HOME',
+        },
+        {
+          matchupPeriodId: 11,
+          home: { teamId: 2, totalPoints: 80 },
+          away: { teamId: 1, totalPoints: 70 },
+          winner: 'HOME',
+        },
+      ],
+    }));
+
+    const params = withSeasonContext({ sport: 'baseball', league_id: '789', season_year: 2026 });
+    const result = await baseballHandlers.get_matchups({} as never, params, 'Bearer x', 'cid');
+
+    expect(result.success).toBe(true);
+    const data = result.data as { matchupPeriod: number | null; matchups: unknown[] };
+    expect(data.matchupPeriod).toBe(10);
+    expect(data.matchups).toHaveLength(1);
+  });
+
+  it('keeps explicit week ahead of currentMatchupPeriod', async () => {
+    espnFetchMock.mockResolvedValue(jsonResponse({
+      scoringPeriodId: 130,
+      status: { currentMatchupPeriod: 10 },
+      schedule: [
+        { matchupPeriodId: 9, home: { teamId: 1, totalPoints: 100 }, away: { teamId: 2, totalPoints: 90 } },
+        { matchupPeriodId: 10, home: { teamId: 3, totalPoints: 80 }, away: { teamId: 4, totalPoints: 70 } },
+      ],
+    }));
+
+    const params = withSeasonContext({ sport: 'baseball', league_id: '789', season_year: 2026, week: 9 });
+    const result = await baseballHandlers.get_matchups({} as never, params, 'Bearer x', 'cid');
+
+    expect(result.success).toBe(true);
+    const data = result.data as { matchupPeriod: number | null; matchups: unknown[] };
+    expect(data.matchupPeriod).toBe(9);
+    expect(data.matchups).toHaveLength(1);
+  });
+});

--- a/workers/espn-client/src/sports/baseball/__tests__/standings.test.ts
+++ b/workers/espn-client/src/sports/baseball/__tests__/standings.test.ts
@@ -173,6 +173,7 @@ describe('baseball get_standings handler — outcome fields', () => {
   it('returns regular_season with null outcome fields during current regular season', async () => {
     espnFetchMock.mockResolvedValue(jsonResponse({
       scoringPeriodId: 10,
+      currentMatchupPeriod: 10,
       settings: { regularSeasonMatchupPeriods: 18 },
       teams: [
         {
@@ -192,6 +193,36 @@ describe('baseball get_standings handler — outcome fields', () => {
 
     const standings = data.standings as Array<Record<string, unknown>>;
     expect(standings[0].rank).toBe(1);
+    expect(standings[0].finalRank).toBeNull();
+    expect(standings[0].championshipWon).toBeNull();
+    expect(standings[0].playoffOutcome).toBeNull();
+    expect(standings[0].outcomeConfidence).toBeNull();
+    expect(standings[0].madePlayoffs).toBeNull();
+  });
+
+  it('uses currentMatchupPeriod instead of daily scoringPeriodId for active baseball standings', async () => {
+    espnFetchMock.mockResolvedValue(jsonResponse({
+      scoringPeriodId: 130,
+      status: { currentMatchupPeriod: 10 },
+      settings: { regularSeasonMatchupPeriods: 18 },
+      teams: [
+        {
+          id: 1,
+          location: 'Alpha', nickname: 'Aces',
+          rankCalculatedFinal: 1,
+          record: { overall: { wins: 8, losses: 2, ties: 0, pointsFor: 780, pointsAgainst: 640 } },
+        },
+      ],
+    }));
+
+    const result = await baseballHandlers.get_standings({} as never, makeParams(CURRENT_SEASON_YEAR), 'Bearer x', 'cid');
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.seasonPhase).toBe('regular_season');
+    expect(data.seasonComplete).toBe(false);
+
+    const standings = data.standings as Array<Record<string, unknown>>;
     expect(standings[0].finalRank).toBeNull();
     expect(standings[0].championshipWon).toBeNull();
     expect(standings[0].playoffOutcome).toBeNull();

--- a/workers/espn-client/src/sports/baseball/handlers.ts
+++ b/workers/espn-client/src/sports/baseball/handlers.ts
@@ -122,6 +122,7 @@ async function handleGetLeagueInfo(
     }
 
     const data = await response.json() as EspnLeagueResponse;
+    const currentMatchupPeriod = data.currentMatchupPeriod ?? data.status?.currentMatchupPeriod;
 
     if (!data || !data.settings) {
       return {
@@ -153,7 +154,7 @@ async function handleGetLeagueInfo(
         size: data.settings.size,
         status: normalizeEspnLeagueStatus(data.status, 'baseball'),
         scoringPeriodId: data.scoringPeriodId,
-        currentMatchupPeriod: data.currentMatchupPeriod,
+        currentMatchupPeriod,
         seasonId: canonicalYear,
         segmentId: data.segmentId,
         teams,
@@ -204,12 +205,14 @@ async function handleGetStandings(
     }
 
     const data = await response.json() as EspnLeagueResponse;
+    const currentMatchupPeriod = data.currentMatchupPeriod ?? data.status?.currentMatchupPeriod;
     const teams = data.teams || [];
 
     const seasonPhase = deriveStandingsSeasonPhase({
       requestedSeasonYear: season_year,
       currentSeasonYear: getCurrentSeasonYear('baseball'),
       scoringPeriodId: data.scoringPeriodId,
+      currentMatchupPeriod,
       regularSeasonMatchupPeriods: data.settings?.regularSeasonMatchupPeriods,
       teams,
     });
@@ -304,6 +307,7 @@ async function handleGetMatchups(
     }
 
     const data = await response.json() as EspnLeagueResponse;
+    const currentMatchupPeriod = data.currentMatchupPeriod ?? data.status?.currentMatchupPeriod;
     const schedule = data.schedule || [];
     const teamsById = Object.fromEntries(
       (data.teams || []).map((team) => [
@@ -315,7 +319,7 @@ async function handleGetMatchups(
     );
 
     // Transform matchups
-    const matchupPeriod = week ?? data.scoringPeriodId ?? data.currentMatchupPeriod;
+    const matchupPeriod = week ?? currentMatchupPeriod ?? data.scoringPeriodId;
     const matchups = schedule
       .filter((matchup) => matchupPeriod == null || matchup.matchupPeriodId === matchupPeriod)
       .map((matchup) => ({

--- a/workers/espn-client/src/sports/baseball/handlers.ts
+++ b/workers/espn-client/src/sports/baseball/handlers.ts
@@ -121,8 +121,7 @@ async function handleGetLeagueInfo(
       handleEspnError(response);
     }
 
-    const data = await response.json() as EspnLeagueResponse;
-    const currentMatchupPeriod = data.currentMatchupPeriod ?? data.status?.currentMatchupPeriod;
+    const data = await response.json() as EspnLeagueResponse | null;
 
     if (!data || !data.settings) {
       return {
@@ -131,6 +130,7 @@ async function handleGetLeagueInfo(
         code: 'ESPN_INVALID_RESPONSE'
       };
     }
+    const currentMatchupPeriod = data.currentMatchupPeriod ?? data.status?.currentMatchupPeriod;
 
     const teams = (data.teams || []).map((team) => {
       const ownerNames = team.owners?.map((o) => o.displayName || o.firstName).filter(Boolean) as string[] | undefined;
@@ -204,16 +204,16 @@ async function handleGetStandings(
       handleEspnError(response);
     }
 
-    const data = await response.json() as EspnLeagueResponse;
-    const currentMatchupPeriod = data.currentMatchupPeriod ?? data.status?.currentMatchupPeriod;
-    const teams = data.teams || [];
+    const data = await response.json() as EspnLeagueResponse | null;
+    const currentMatchupPeriod = data?.currentMatchupPeriod ?? data?.status?.currentMatchupPeriod;
+    const teams = data?.teams || [];
 
     const seasonPhase = deriveStandingsSeasonPhase({
       requestedSeasonYear: season_year,
       currentSeasonYear: getCurrentSeasonYear('baseball'),
-      scoringPeriodId: data.scoringPeriodId,
+      scoringPeriodId: data?.scoringPeriodId,
       currentMatchupPeriod,
-      regularSeasonMatchupPeriods: data.settings?.regularSeasonMatchupPeriods,
+      regularSeasonMatchupPeriods: data?.settings?.regularSeasonMatchupPeriods,
       teams,
     });
     const seasonComplete = seasonPhase === 'season_complete';
@@ -306,11 +306,11 @@ async function handleGetMatchups(
       handleEspnError(response);
     }
 
-    const data = await response.json() as EspnLeagueResponse;
-    const currentMatchupPeriod = data.currentMatchupPeriod ?? data.status?.currentMatchupPeriod;
-    const schedule = data.schedule || [];
+    const data = await response.json() as EspnLeagueResponse | null;
+    const currentMatchupPeriod = data?.currentMatchupPeriod ?? data?.status?.currentMatchupPeriod;
+    const schedule = data?.schedule || [];
     const teamsById = Object.fromEntries(
-      (data.teams || []).map((team) => [
+      (data?.teams || []).map((team) => [
         team.id,
         team.location && team.nickname
           ? `${team.location} ${team.nickname}`
@@ -319,7 +319,7 @@ async function handleGetMatchups(
     );
 
     // Transform matchups
-    const matchupPeriod = week ?? currentMatchupPeriod ?? data.scoringPeriodId;
+    const matchupPeriod = week ?? currentMatchupPeriod ?? data?.scoringPeriodId;
     const matchups = schedule
       .filter((matchup) => matchupPeriod == null || matchup.matchupPeriodId === matchupPeriod)
       .map((matchup) => ({
@@ -347,7 +347,7 @@ async function handleGetMatchups(
       data: {
         leagueId: league_id,
         seasonYear: season_year,
-        currentScoringPeriod: data.scoringPeriodId,
+        currentScoringPeriod: data?.scoringPeriodId,
         matchupPeriod: matchupPeriod ?? null,
         matchups
       }

--- a/workers/espn-client/src/sports/basketball/__tests__/standings.test.ts
+++ b/workers/espn-client/src/sports/basketball/__tests__/standings.test.ts
@@ -161,7 +161,8 @@ describe('basketball get_standings handler — seasonPhase and canonical year', 
 
   it('returns regular_season for current season within regular season periods', async () => {
     espnFetchMock.mockResolvedValue(jsonResponse({
-      scoringPeriodId: 10,
+      scoringPeriodId: 130,
+      status: { currentMatchupPeriod: 10 },
       settings: { regularSeasonMatchupPeriods: 20 },
       teams: [
         {

--- a/workers/espn-client/src/sports/basketball/handlers.ts
+++ b/workers/espn-client/src/sports/basketball/handlers.ts
@@ -123,6 +123,7 @@ async function handleGetLeagueInfo(
     }
 
     const data = await response.json() as EspnLeagueResponse;
+    const currentMatchupPeriod = data.currentMatchupPeriod ?? data.status?.currentMatchupPeriod;
 
     if (!data || !data.settings) {
       return {
@@ -154,7 +155,7 @@ async function handleGetLeagueInfo(
         size: data.settings.size,
         status: normalizeEspnLeagueStatus(data.status, 'basketball'),
         scoringPeriodId: data.scoringPeriodId,
-        currentMatchupPeriod: data.currentMatchupPeriod,
+        currentMatchupPeriod,
         seasonId: canonicalYear,
         segmentId: data.segmentId,
         teams,
@@ -206,12 +207,14 @@ async function handleGetStandings(
     }
 
     const data = await response.json() as EspnLeagueResponse;
+    const currentMatchupPeriod = data.currentMatchupPeriod ?? data.status?.currentMatchupPeriod;
     const teams = data.teams || [];
 
     const seasonPhase = deriveStandingsSeasonPhase({
       requestedSeasonYear: canonicalYear,
       currentSeasonYear: getCurrentSeasonYear('basketball'),
       scoringPeriodId: data.scoringPeriodId,
+      currentMatchupPeriod,
       regularSeasonMatchupPeriods: data.settings?.regularSeasonMatchupPeriods,
       teams,
     });
@@ -307,6 +310,7 @@ async function handleGetMatchups(
     }
 
     const data = await response.json() as EspnLeagueResponse;
+    const currentMatchupPeriod = data.currentMatchupPeriod ?? data.status?.currentMatchupPeriod;
     const schedule = data.schedule || [];
     const teamsById = Object.fromEntries(
       (data.teams || []).map((team) => [
@@ -318,7 +322,7 @@ async function handleGetMatchups(
     );
 
     // Transform matchups
-    const matchupPeriod = week ?? data.scoringPeriodId ?? data.currentMatchupPeriod;
+    const matchupPeriod = week ?? currentMatchupPeriod ?? data.scoringPeriodId;
     const matchups = schedule
       .filter((matchup) => matchupPeriod == null || matchup.matchupPeriodId === matchupPeriod)
       .map((matchup) => ({

--- a/workers/espn-client/src/sports/basketball/handlers.ts
+++ b/workers/espn-client/src/sports/basketball/handlers.ts
@@ -122,8 +122,7 @@ async function handleGetLeagueInfo(
       handleEspnError(response);
     }
 
-    const data = await response.json() as EspnLeagueResponse;
-    const currentMatchupPeriod = data.currentMatchupPeriod ?? data.status?.currentMatchupPeriod;
+    const data = await response.json() as EspnLeagueResponse | null;
 
     if (!data || !data.settings) {
       return {
@@ -132,6 +131,7 @@ async function handleGetLeagueInfo(
         code: 'ESPN_INVALID_RESPONSE'
       };
     }
+    const currentMatchupPeriod = data.currentMatchupPeriod ?? data.status?.currentMatchupPeriod;
 
     const teams = (data.teams || []).map((team) => {
       const ownerNames = team.owners?.map((o) => o.displayName || o.firstName).filter(Boolean) as string[] | undefined;
@@ -206,16 +206,16 @@ async function handleGetStandings(
       handleEspnError(response);
     }
 
-    const data = await response.json() as EspnLeagueResponse;
-    const currentMatchupPeriod = data.currentMatchupPeriod ?? data.status?.currentMatchupPeriod;
-    const teams = data.teams || [];
+    const data = await response.json() as EspnLeagueResponse | null;
+    const currentMatchupPeriod = data?.currentMatchupPeriod ?? data?.status?.currentMatchupPeriod;
+    const teams = data?.teams || [];
 
     const seasonPhase = deriveStandingsSeasonPhase({
       requestedSeasonYear: canonicalYear,
       currentSeasonYear: getCurrentSeasonYear('basketball'),
-      scoringPeriodId: data.scoringPeriodId,
+      scoringPeriodId: data?.scoringPeriodId,
       currentMatchupPeriod,
-      regularSeasonMatchupPeriods: data.settings?.regularSeasonMatchupPeriods,
+      regularSeasonMatchupPeriods: data?.settings?.regularSeasonMatchupPeriods,
       teams,
     });
     const seasonComplete = seasonPhase === 'season_complete';
@@ -309,11 +309,11 @@ async function handleGetMatchups(
       handleEspnError(response);
     }
 
-    const data = await response.json() as EspnLeagueResponse;
-    const currentMatchupPeriod = data.currentMatchupPeriod ?? data.status?.currentMatchupPeriod;
-    const schedule = data.schedule || [];
+    const data = await response.json() as EspnLeagueResponse | null;
+    const currentMatchupPeriod = data?.currentMatchupPeriod ?? data?.status?.currentMatchupPeriod;
+    const schedule = data?.schedule || [];
     const teamsById = Object.fromEntries(
-      (data.teams || []).map((team) => [
+      (data?.teams || []).map((team) => [
         team.id,
         team.location && team.nickname
           ? `${team.location} ${team.nickname}`
@@ -322,7 +322,7 @@ async function handleGetMatchups(
     );
 
     // Transform matchups
-    const matchupPeriod = week ?? currentMatchupPeriod ?? data.scoringPeriodId;
+    const matchupPeriod = week ?? currentMatchupPeriod ?? data?.scoringPeriodId;
     const matchups = schedule
       .filter((matchup) => matchupPeriod == null || matchup.matchupPeriodId === matchupPeriod)
       .map((matchup) => ({
@@ -350,7 +350,7 @@ async function handleGetMatchups(
       data: {
         leagueId: league_id,
         seasonYear: canonicalYear,
-        currentScoringPeriod: data.scoringPeriodId,
+        currentScoringPeriod: data?.scoringPeriodId,
         matchupPeriod: matchupPeriod ?? null,
         matchups
       }

--- a/workers/espn-client/src/sports/football/__tests__/standings.test.ts
+++ b/workers/espn-client/src/sports/football/__tests__/standings.test.ts
@@ -156,7 +156,8 @@ describe('football get_standings handler — outcome fields', () => {
 
   it('returns regular_season for current season within regular season periods', async () => {
     espnFetchMock.mockResolvedValue(jsonResponse({
-      scoringPeriodId: 10,
+      scoringPeriodId: 130,
+      status: { currentMatchupPeriod: 10 },
       settings: { regularSeasonMatchupPeriods: 14 },
       teams: [
         {

--- a/workers/espn-client/src/sports/football/handlers.ts
+++ b/workers/espn-client/src/sports/football/handlers.ts
@@ -61,6 +61,7 @@ async function handleGetLeagueInfo(
     }
 
     const data = await response.json() as EspnLeagueResponse;
+    const currentMatchupPeriod = data.currentMatchupPeriod ?? data.status?.currentMatchupPeriod;
 
     if (!data || !data.settings) {
       return {
@@ -92,7 +93,7 @@ async function handleGetLeagueInfo(
         size: data.settings.size,
         status: normalizeEspnLeagueStatus(data.status, 'football'),
         scoringPeriodId: data.scoringPeriodId,
-        currentMatchupPeriod: data.currentMatchupPeriod,
+        currentMatchupPeriod,
         seasonId: canonicalYear,
         segmentId: data.segmentId,
         teams,
@@ -143,12 +144,14 @@ async function handleGetStandings(
     }
 
     const data = await response.json() as EspnLeagueResponse;
+    const currentMatchupPeriod = data.currentMatchupPeriod ?? data.status?.currentMatchupPeriod;
     const teams = data.teams || [];
 
     const seasonPhase = deriveStandingsSeasonPhase({
       requestedSeasonYear: season_year,
       currentSeasonYear: getCurrentSeasonYear('football'),
       scoringPeriodId: data.scoringPeriodId,
+      currentMatchupPeriod,
       regularSeasonMatchupPeriods: data.settings?.regularSeasonMatchupPeriods,
       teams,
     });
@@ -243,6 +246,7 @@ async function handleGetMatchups(
     }
 
     const data = await response.json() as EspnLeagueResponse;
+    const currentMatchupPeriod = data.currentMatchupPeriod ?? data.status?.currentMatchupPeriod;
     const schedule = data.schedule || [];
     const teamsById = Object.fromEntries(
       (data.teams || []).map((team) => [
@@ -254,7 +258,7 @@ async function handleGetMatchups(
     );
 
     // Transform matchups
-    const matchupPeriod = week ?? data.scoringPeriodId ?? data.currentMatchupPeriod;
+    const matchupPeriod = week ?? currentMatchupPeriod ?? data.scoringPeriodId;
     const matchups = schedule
       .filter((matchup) => matchupPeriod == null || matchup.matchupPeriodId === matchupPeriod)
       .map((matchup) => ({

--- a/workers/espn-client/src/sports/football/handlers.ts
+++ b/workers/espn-client/src/sports/football/handlers.ts
@@ -60,8 +60,7 @@ async function handleGetLeagueInfo(
       handleEspnError(response);
     }
 
-    const data = await response.json() as EspnLeagueResponse;
-    const currentMatchupPeriod = data.currentMatchupPeriod ?? data.status?.currentMatchupPeriod;
+    const data = await response.json() as EspnLeagueResponse | null;
 
     if (!data || !data.settings) {
       return {
@@ -70,6 +69,7 @@ async function handleGetLeagueInfo(
         code: 'ESPN_INVALID_RESPONSE'
       };
     }
+    const currentMatchupPeriod = data.currentMatchupPeriod ?? data.status?.currentMatchupPeriod;
 
     const teams = (data.teams || []).map((team) => {
       const ownerNames = team.owners?.map((o) => o.displayName || o.firstName).filter(Boolean) as string[] | undefined;
@@ -143,16 +143,16 @@ async function handleGetStandings(
       handleEspnError(response);
     }
 
-    const data = await response.json() as EspnLeagueResponse;
-    const currentMatchupPeriod = data.currentMatchupPeriod ?? data.status?.currentMatchupPeriod;
-    const teams = data.teams || [];
+    const data = await response.json() as EspnLeagueResponse | null;
+    const currentMatchupPeriod = data?.currentMatchupPeriod ?? data?.status?.currentMatchupPeriod;
+    const teams = data?.teams || [];
 
     const seasonPhase = deriveStandingsSeasonPhase({
       requestedSeasonYear: season_year,
       currentSeasonYear: getCurrentSeasonYear('football'),
-      scoringPeriodId: data.scoringPeriodId,
+      scoringPeriodId: data?.scoringPeriodId,
       currentMatchupPeriod,
-      regularSeasonMatchupPeriods: data.settings?.regularSeasonMatchupPeriods,
+      regularSeasonMatchupPeriods: data?.settings?.regularSeasonMatchupPeriods,
       teams,
     });
     const seasonComplete = seasonPhase === 'season_complete';
@@ -245,11 +245,11 @@ async function handleGetMatchups(
       handleEspnError(response);
     }
 
-    const data = await response.json() as EspnLeagueResponse;
-    const currentMatchupPeriod = data.currentMatchupPeriod ?? data.status?.currentMatchupPeriod;
-    const schedule = data.schedule || [];
+    const data = await response.json() as EspnLeagueResponse | null;
+    const currentMatchupPeriod = data?.currentMatchupPeriod ?? data?.status?.currentMatchupPeriod;
+    const schedule = data?.schedule || [];
     const teamsById = Object.fromEntries(
-      (data.teams || []).map((team) => [
+      (data?.teams || []).map((team) => [
         team.id,
         team.location && team.nickname
           ? `${team.location} ${team.nickname}`
@@ -258,7 +258,7 @@ async function handleGetMatchups(
     );
 
     // Transform matchups
-    const matchupPeriod = week ?? currentMatchupPeriod ?? data.scoringPeriodId;
+    const matchupPeriod = week ?? currentMatchupPeriod ?? data?.scoringPeriodId;
     const matchups = schedule
       .filter((matchup) => matchupPeriod == null || matchup.matchupPeriodId === matchupPeriod)
       .map((matchup) => ({
@@ -286,7 +286,7 @@ async function handleGetMatchups(
       data: {
         leagueId: league_id,
         seasonYear: season_year,
-        currentScoringPeriod: data.scoringPeriodId,
+        currentScoringPeriod: data?.scoringPeriodId,
         matchupPeriod: matchupPeriod ?? null,
         matchups
       }

--- a/workers/espn-client/src/sports/hockey/__tests__/standings.test.ts
+++ b/workers/espn-client/src/sports/hockey/__tests__/standings.test.ts
@@ -161,7 +161,8 @@ describe('hockey get_standings handler — seasonPhase and canonical year', () =
 
   it('returns regular_season for current season within regular season periods', async () => {
     espnFetchMock.mockResolvedValue(jsonResponse({
-      scoringPeriodId: 10,
+      scoringPeriodId: 130,
+      status: { currentMatchupPeriod: 10 },
       settings: { regularSeasonMatchupPeriods: 22 },
       teams: [
         {

--- a/workers/espn-client/src/sports/hockey/handlers.ts
+++ b/workers/espn-client/src/sports/hockey/handlers.ts
@@ -122,8 +122,7 @@ async function handleGetLeagueInfo(
       handleEspnError(response);
     }
 
-    const data = await response.json() as EspnLeagueResponse;
-    const currentMatchupPeriod = data.currentMatchupPeriod ?? data.status?.currentMatchupPeriod;
+    const data = await response.json() as EspnLeagueResponse | null;
 
     if (!data || !data.settings) {
       return {
@@ -132,6 +131,7 @@ async function handleGetLeagueInfo(
         code: 'ESPN_INVALID_RESPONSE'
       };
     }
+    const currentMatchupPeriod = data.currentMatchupPeriod ?? data.status?.currentMatchupPeriod;
 
     const teams = (data.teams || []).map((team) => {
       const ownerNames = team.owners?.map((o) => o.displayName || o.firstName).filter(Boolean) as string[] | undefined;
@@ -206,16 +206,16 @@ async function handleGetStandings(
       handleEspnError(response);
     }
 
-    const data = await response.json() as EspnLeagueResponse;
-    const currentMatchupPeriod = data.currentMatchupPeriod ?? data.status?.currentMatchupPeriod;
-    const teams = data.teams || [];
+    const data = await response.json() as EspnLeagueResponse | null;
+    const currentMatchupPeriod = data?.currentMatchupPeriod ?? data?.status?.currentMatchupPeriod;
+    const teams = data?.teams || [];
 
     const seasonPhase = deriveStandingsSeasonPhase({
       requestedSeasonYear: canonicalYear,
       currentSeasonYear: getCurrentSeasonYear('hockey'),
-      scoringPeriodId: data.scoringPeriodId,
+      scoringPeriodId: data?.scoringPeriodId,
       currentMatchupPeriod,
-      regularSeasonMatchupPeriods: data.settings?.regularSeasonMatchupPeriods,
+      regularSeasonMatchupPeriods: data?.settings?.regularSeasonMatchupPeriods,
       teams,
     });
     const seasonComplete = seasonPhase === 'season_complete';
@@ -309,11 +309,11 @@ async function handleGetMatchups(
       handleEspnError(response);
     }
 
-    const data = await response.json() as EspnLeagueResponse;
-    const currentMatchupPeriod = data.currentMatchupPeriod ?? data.status?.currentMatchupPeriod;
-    const schedule = data.schedule || [];
+    const data = await response.json() as EspnLeagueResponse | null;
+    const currentMatchupPeriod = data?.currentMatchupPeriod ?? data?.status?.currentMatchupPeriod;
+    const schedule = data?.schedule || [];
     const teamsById = Object.fromEntries(
-      (data.teams || []).map((team) => [
+      (data?.teams || []).map((team) => [
         team.id,
         team.location && team.nickname
           ? `${team.location} ${team.nickname}`
@@ -322,7 +322,7 @@ async function handleGetMatchups(
     );
 
     // Transform matchups
-    const matchupPeriod = week ?? currentMatchupPeriod ?? data.scoringPeriodId;
+    const matchupPeriod = week ?? currentMatchupPeriod ?? data?.scoringPeriodId;
     const matchups = schedule
       .filter((matchup) => matchupPeriod == null || matchup.matchupPeriodId === matchupPeriod)
       .map((matchup) => ({
@@ -350,7 +350,7 @@ async function handleGetMatchups(
       data: {
         leagueId: league_id,
         seasonYear: canonicalYear,
-        currentScoringPeriod: data.scoringPeriodId,
+        currentScoringPeriod: data?.scoringPeriodId,
         matchupPeriod: matchupPeriod ?? null,
         matchups
       }

--- a/workers/espn-client/src/sports/hockey/handlers.ts
+++ b/workers/espn-client/src/sports/hockey/handlers.ts
@@ -123,6 +123,7 @@ async function handleGetLeagueInfo(
     }
 
     const data = await response.json() as EspnLeagueResponse;
+    const currentMatchupPeriod = data.currentMatchupPeriod ?? data.status?.currentMatchupPeriod;
 
     if (!data || !data.settings) {
       return {
@@ -154,7 +155,7 @@ async function handleGetLeagueInfo(
         size: data.settings.size,
         status: normalizeEspnLeagueStatus(data.status, 'hockey'),
         scoringPeriodId: data.scoringPeriodId,
-        currentMatchupPeriod: data.currentMatchupPeriod,
+        currentMatchupPeriod,
         seasonId: canonicalYear,
         segmentId: data.segmentId,
         teams,
@@ -206,12 +207,14 @@ async function handleGetStandings(
     }
 
     const data = await response.json() as EspnLeagueResponse;
+    const currentMatchupPeriod = data.currentMatchupPeriod ?? data.status?.currentMatchupPeriod;
     const teams = data.teams || [];
 
     const seasonPhase = deriveStandingsSeasonPhase({
       requestedSeasonYear: canonicalYear,
       currentSeasonYear: getCurrentSeasonYear('hockey'),
       scoringPeriodId: data.scoringPeriodId,
+      currentMatchupPeriod,
       regularSeasonMatchupPeriods: data.settings?.regularSeasonMatchupPeriods,
       teams,
     });
@@ -307,6 +310,7 @@ async function handleGetMatchups(
     }
 
     const data = await response.json() as EspnLeagueResponse;
+    const currentMatchupPeriod = data.currentMatchupPeriod ?? data.status?.currentMatchupPeriod;
     const schedule = data.schedule || [];
     const teamsById = Object.fromEntries(
       (data.teams || []).map((team) => [
@@ -318,7 +322,7 @@ async function handleGetMatchups(
     );
 
     // Transform matchups
-    const matchupPeriod = week ?? data.scoringPeriodId ?? data.currentMatchupPeriod;
+    const matchupPeriod = week ?? currentMatchupPeriod ?? data.scoringPeriodId;
     const matchups = schedule
       .filter((matchup) => matchupPeriod == null || matchup.matchupPeriodId === matchupPeriod)
       .map((matchup) => ({

--- a/workers/espn-client/src/types.ts
+++ b/workers/espn-client/src/types.ts
@@ -14,10 +14,17 @@ export interface EspnLeagueResponse {
   segmentId?: number;
   scoringPeriodId?: number;
   currentMatchupPeriod?: number;
-  status?: unknown;
+  status?: EspnLeagueStatus;
   settings?: EspnLeagueSettings;
   teams?: EspnTeam[];
   schedule?: EspnMatchup[];
+}
+
+export interface EspnLeagueStatus {
+  currentMatchupPeriod?: number;
+  isActive?: boolean;
+  previousSeasons?: number[];
+  [key: string]: unknown;
 }
 
 export interface EspnLeagueSettings {


### PR DESCRIPTION
## Summary

Fix ESPN standings phase detection so current-season leagues are not marked complete just because ESPN exposes `rankFinal` or `rankCalculatedFinal` fields.

## Root Cause

The shared ESPN standings helper treated final-rank-like fields as definitive completion evidence before checking whether the requested season is still the active season. For ESPN baseball, daily `scoringPeriodId` can move far beyond weekly `regularSeasonMatchupPeriods` while `currentMatchupPeriod` still indicates regular-season play, which caused active standings to surface postseason outcome fields too early.

## Changes

- Prefer `currentMatchupPeriod` over `scoringPeriodId` for current-season phase detection.
- Only treat explicit final-rank fields as completion evidence once current matchup context is beyond the regular season.
- Read matchup period from either top-level `currentMatchupPeriod` or `status.currentMatchupPeriod`.
- Prefer `currentMatchupPeriod` for default `get_matchups` selection while preserving explicit `week` behavior.
- Add baseball regression coverage for active standings and matchup defaults.

## Validation

- `corepack pnpm --dir workers/espn-client run test`
- `corepack pnpm --dir workers/espn-client run type-check`