### PR TITLE
[codex] Add Yahoo refresh cooldown

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,8 @@ Follow Keep a Changelog; stamp a version when submitting to directories.
 - **Changed**: Yahoo Refresh on `/leagues` now uses the stored connection to rediscover leagues instead of starting a fresh OAuth flow every time.
 - **Changed**: Yahoo refresh lease waiters now return an explicit retryable response before the MCP gateway timeout budget is exhausted.
 - **Fixed**: Yahoo league discovery rate limits (`429`/`999`) and transient upstream failures now return retryable responses with `Retry-After` instead of generic refresh failures.
+- **Fixed**: Yahoo transient token-refresh failures now set a short cooldown so near-concurrent tool calls do not immediately re-hit Yahoo's token endpoint.
+- **Fixed**: Yahoo token-refresh retry hints now include `retry_after` for text-classified rate limits and preserve upstream status metadata through MCP tool errors.
 - **Fixed**: Yahoo retry metadata now propagates through yahoo-client and fantasy-mcp instead of collapsing into generic tool errors.
 - **Fixed**: Yahoo discovery now persists `team_key` for pending waiver/trade transaction lookups.
 

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -60,8 +60,8 @@ Stores Yahoo OAuth credentials for a Clerk user.
 | refresh_token | text | Yahoo OAuth refresh token |
 | expires_at | timestamptz | Access token expiry |
 | yahoo_guid | text | Optional Yahoo user GUID |
-| refresh_lease_owner | text | Short-lived owner ID for single-writer token refresh |
-| refresh_lease_expires_at | timestamptz | Expiry for the refresh lease |
+| refresh_lease_owner | text | Short-lived owner ID for single-writer token refresh; `cooldown:*` marks transient refresh backoff |
+| refresh_lease_expires_at | timestamptz | Expiry for the refresh lease or cooldown marker |
 | created_at | timestamptz | Created timestamp |
 | updated_at | timestamptz | Updated timestamp |
 

--- a/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
@@ -43,6 +43,7 @@ describe('yahoo-connect-handlers', () => {
     updateYahooCredentials: ReturnType<typeof vi.fn>;
     acquireRefreshLease: ReturnType<typeof vi.fn>;
     releaseRefreshLease: ReturnType<typeof vi.fn>;
+    markRefreshCooldown: ReturnType<typeof vi.fn>;
     deleteYahooCredentials: ReturnType<typeof vi.fn>;
     deleteAllYahooLeagues: ReturnType<typeof vi.fn>;
     hasYahooCredentials: ReturnType<typeof vi.fn>;
@@ -61,6 +62,7 @@ describe('yahoo-connect-handlers', () => {
       updateYahooCredentials: vi.fn().mockResolvedValue(true),
       acquireRefreshLease: vi.fn().mockResolvedValue(true),
       releaseRefreshLease: vi.fn().mockResolvedValue(undefined),
+      markRefreshCooldown: vi.fn().mockResolvedValue(undefined),
       deleteYahooCredentials: vi.fn().mockResolvedValue(undefined),
       deleteAllYahooLeagues: vi.fn().mockResolvedValue(undefined),
       hasYahooCredentials: vi.fn(),
@@ -687,7 +689,10 @@ describe('yahoo-connect-handlers', () => {
       expect(body.error).toBe('refresh_temporarily_unavailable');
       expect(body.error_description).toBe('Failed to refresh access token');
       expect(body.retryable).toBe(true);
-      expect(mockStorage.releaseRefreshLease).toHaveBeenCalledWith('user_123', capturedOwnerId);
+      expect(body.retry_after).toBe(60);
+      expect(response.headers.get('Retry-After')).toBe('60');
+      expect(mockStorage.markRefreshCooldown).toHaveBeenCalledWith('user_123', capturedOwnerId, 60);
+      expect(mockStorage.releaseRefreshLease).not.toHaveBeenCalled();
       expect(mockStorage.updateYahooCredentials).not.toHaveBeenCalled();
     });
 
@@ -775,6 +780,9 @@ describe('yahoo-connect-handlers', () => {
       expect(body.error).toBe('refresh_temporarily_unavailable');
       expect(body.error_description).toBe('Try again later');
       expect(body.retryable).toBe(true);
+      expect(body.retry_after).toBe(300);
+      expect(body.upstream_status).toBe(503);
+      expect(mockStorage.markRefreshCooldown).toHaveBeenCalledWith('user_123', expect.any(String), 300);
       expect(mockStorage.updateYahooCredentials).not.toHaveBeenCalled();
     });
 
@@ -805,6 +813,9 @@ describe('yahoo-connect-handlers', () => {
       expect(body.error).toBe('refresh_temporarily_unavailable');
       expect(body.error_description).toBe('Too many token requests');
       expect(body.retryable).toBe(true);
+      expect(body.retry_after).toBe(900);
+      expect(body.upstream_status).toBe(429);
+      expect(mockStorage.markRefreshCooldown).toHaveBeenCalledWith('user_123', expect.any(String), 900);
       expect(mockStorage.updateYahooCredentials).not.toHaveBeenCalled();
     });
 
@@ -874,7 +885,7 @@ describe('yahoo-connect-handlers', () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
-    it('winner: Yahoo timeout (AbortError) releases lease and returns retryable temporary error', async () => {
+    it('winner: Yahoo timeout (AbortError) marks cooldown and returns retryable temporary error', async () => {
       mockStorage.getYahooCredentials.mockResolvedValue({
         clerkUserId: 'user_123',
         accessToken: 'old-access-token',
@@ -902,10 +913,12 @@ describe('yahoo-connect-handlers', () => {
       expect(body.error).toBe('refresh_temporarily_unavailable');
       expect(body.error_description).toBe('Yahoo token refresh timed out. Please try again later.');
       expect(body.retryable).toBe(true);
-      expect(mockStorage.releaseRefreshLease).toHaveBeenCalledWith('user_123', capturedOwnerId);
+      expect(body.retry_after).toBe(300);
+      expect(mockStorage.markRefreshCooldown).toHaveBeenCalledWith('user_123', capturedOwnerId, 300);
+      expect(mockStorage.releaseRefreshLease).not.toHaveBeenCalled();
     });
 
-    it('winner: lease release failure after timeout still returns retryable temporary error', async () => {
+    it('winner: cooldown mark failure after timeout falls back to releasing the lease', async () => {
       mockStorage.getYahooCredentials.mockResolvedValue({
         clerkUserId: 'user_123',
         accessToken: 'old-access-token',
@@ -914,7 +927,7 @@ describe('yahoo-connect-handlers', () => {
         needsRefresh: true,
       });
       mockStorage.acquireRefreshLease.mockResolvedValue(true);
-      mockStorage.releaseRefreshLease.mockRejectedValue(new Error('release failed'));
+      mockStorage.markRefreshCooldown.mockRejectedValue(new Error('cooldown failed'));
 
       const abortError = new DOMException('The operation was aborted', 'AbortError');
       mockFetch.mockRejectedValue(abortError);
@@ -926,6 +939,38 @@ describe('yahoo-connect-handlers', () => {
       expect(body.error).toBe('refresh_temporarily_unavailable');
       expect(body.error_description).toBe('Yahoo token refresh timed out. Please try again later.');
       expect(body.retryable).toBe(true);
+      expect(mockStorage.releaseRefreshLease).toHaveBeenCalledWith('user_123', expect.any(String));
+    });
+
+    it('returns active refresh cooldown without hitting Yahoo again', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-05-11T18:15:00Z'));
+      try {
+        mockStorage.getYahooCredentials.mockResolvedValue({
+          clerkUserId: 'user_123',
+          accessToken: 'old-access-token',
+          refreshToken: 'refresh-token',
+          expiresAt: new Date(Date.now() + 2 * 60 * 1000),
+          needsRefresh: true,
+          refreshLeaseOwner: 'cooldown:owner-1',
+          refreshLeaseExpiresAt: new Date(Date.now() + 45_000),
+        });
+        mockStorage.acquireRefreshLease.mockResolvedValue(false);
+
+        const response = await handleYahooCredentials(env, 'user_123', corsHeaders);
+
+        expect(response.status).toBe(503);
+        expect(response.headers.get('Retry-After')).toBe('45');
+        const body = (await response.json()) as Record<string, unknown>;
+        expect(body.error).toBe('refresh_temporarily_unavailable');
+        expect(body.error_description).toBe('Yahoo token refresh is cooling down after a transient failure. Please try again shortly.');
+        expect(body.retryable).toBe(true);
+        expect(body.retry_after).toBe(45);
+        expect(mockFetch).not.toHaveBeenCalled();
+        expect(mockStorage.markRefreshCooldown).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('winner: owner-guarded write returns false, reread shows fresh token', async () => {
@@ -1331,6 +1376,8 @@ describe('yahoo-connect-handlers', () => {
       expect(body.error).toBe('refresh_temporarily_unavailable');
       expect(body.error_description).toBe('Failed to refresh access token');
       expect(body.retryable).toBe(true);
+      expect(body.retry_after).toBe(60);
+      expect(mockStorage.markRefreshCooldown).toHaveBeenCalledWith('user_123', expect.any(String), 60);
       expect(mockStorage.updateYahooCredentials).not.toHaveBeenCalled();
       expect(mockStorage.upsertYahooLeague).not.toHaveBeenCalled();
     });

--- a/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
@@ -62,7 +62,7 @@ describe('yahoo-connect-handlers', () => {
       updateYahooCredentials: vi.fn().mockResolvedValue(true),
       acquireRefreshLease: vi.fn().mockResolvedValue(true),
       releaseRefreshLease: vi.fn().mockResolvedValue(undefined),
-      markRefreshCooldown: vi.fn().mockResolvedValue(undefined),
+      markRefreshCooldown: vi.fn().mockResolvedValue(true),
       deleteYahooCredentials: vi.fn().mockResolvedValue(undefined),
       deleteAllYahooLeagues: vi.fn().mockResolvedValue(undefined),
       hasYahooCredentials: vi.fn(),
@@ -966,6 +966,7 @@ describe('yahoo-connect-handlers', () => {
         expect(body.error_description).toBe('Yahoo token refresh is cooling down after a transient failure. Please try again shortly.');
         expect(body.retryable).toBe(true);
         expect(body.retry_after).toBe(45);
+        expect(mockStorage.acquireRefreshLease).not.toHaveBeenCalled();
         expect(mockFetch).not.toHaveBeenCalled();
         expect(mockStorage.markRefreshCooldown).not.toHaveBeenCalled();
       } finally {

--- a/workers/auth-worker/src/__tests__/yahoo-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-storage.test.ts
@@ -440,8 +440,11 @@ describe('YahooStorage', () => {
 
   describe('markRefreshCooldown', () => {
     it('replaces the current lease owner with a bounded cooldown marker', async () => {
-      await storage.markRefreshCooldown('user_123', 'owner-1', 60);
+      mockSelect.mockResolvedValue({ data: [{ clerk_user_id: 'user_123' }], error: null });
 
+      const result = await storage.markRefreshCooldown('user_123', 'owner-1', 60);
+
+      expect(result).toBe(true);
       expect(mockUpdate).toHaveBeenCalledWith(
         expect.objectContaining({
           refresh_lease_owner: 'cooldown:owner-1',
@@ -454,18 +457,16 @@ describe('YahooStorage', () => {
       expect(mockEq).toHaveBeenNthCalledWith(2, 'refresh_lease_owner', 'owner-1');
     });
 
+    it('returns false when the owner guard rejects the cooldown marker', async () => {
+      mockSelect.mockResolvedValue({ data: [], error: null });
+
+      const result = await storage.markRefreshCooldown('user_123', 'owner-1', 60);
+
+      expect(result).toBe(false);
+    });
+
     it('throws when cooldown marking hits a storage error', async () => {
-      mockEq
-        .mockReturnValueOnce({
-          eq: mockEq,
-          or: mockOr,
-          single: mockSingle,
-          select: mockSelect,
-          delete: mockDelete,
-          is: mockIs,
-          error: { message: 'DB down' },
-        })
-        .mockReturnValueOnce({ error: { message: 'DB down' } });
+      mockSelect.mockResolvedValue({ data: null, error: { message: 'DB down' } });
 
       await expect(
         storage.markRefreshCooldown('user_123', 'owner-1', 60)

--- a/workers/auth-worker/src/__tests__/yahoo-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-storage.test.ts
@@ -438,6 +438,41 @@ describe('YahooStorage', () => {
     });
   });
 
+  describe('markRefreshCooldown', () => {
+    it('replaces the current lease owner with a bounded cooldown marker', async () => {
+      await storage.markRefreshCooldown('user_123', 'owner-1', 60);
+
+      expect(mockUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          refresh_lease_owner: 'cooldown:owner-1',
+          refresh_lease_expires_at: expect.any(String),
+        })
+      );
+      const call = mockUpdate.mock.calls[0][0];
+      expect(new Date(call.refresh_lease_expires_at).getTime()).toBeGreaterThan(Date.now());
+      expect(mockEq).toHaveBeenNthCalledWith(1, 'clerk_user_id', 'user_123');
+      expect(mockEq).toHaveBeenNthCalledWith(2, 'refresh_lease_owner', 'owner-1');
+    });
+
+    it('throws when cooldown marking hits a storage error', async () => {
+      mockEq
+        .mockReturnValueOnce({
+          eq: mockEq,
+          or: mockOr,
+          single: mockSingle,
+          select: mockSelect,
+          delete: mockDelete,
+          is: mockIs,
+          error: { message: 'DB down' },
+        })
+        .mockReturnValueOnce({ error: { message: 'DB down' } });
+
+      await expect(
+        storage.markRefreshCooldown('user_123', 'owner-1', 60)
+      ).rejects.toThrow('Failed to mark Yahoo refresh cooldown');
+    });
+  });
+
   describe('deleteYahooCredentials', () => {
     it('deletes credentials for user', async () => {
       mockEq.mockReturnValue({ error: null });

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -72,6 +72,8 @@ const YAHOO_TOKEN_REQUEST_TIMEOUT_MS = 20_000;
 const MAX_LEASE_WAIT_MS = 10_000;
 const POLL_INTERVAL_MS   =    300;
 const MAX_REFRESH_ATTEMPTS = 3;
+const REFRESH_COOLDOWN_OWNER_PREFIX = 'cooldown:';
+const YAHOO_TOKEN_TEXT_TRANSIENT_RETRY_AFTER_SECONDS = 60;
 
 /**
  * Get the OAuth callback URL based on environment
@@ -267,7 +269,7 @@ async function readYahooTokenResponse(
 
 type GetTokenResult =
   | { accessToken: string; expiresIn: number }
-  | { error: string; errorDescription?: string; retryable?: boolean; retryAfter?: number };
+  | { error: string; errorDescription?: string; retryable?: boolean; retryAfter?: number; upstreamStatus?: number };
 
 type RetryTokenResult =
   | GetTokenResult
@@ -289,6 +291,52 @@ function leaseExpired(credentials: { refreshLeaseOwner?: string; refreshLeaseExp
     : true;
 }
 
+function isRefreshCooldown(credentials: { refreshLeaseOwner?: string; refreshLeaseExpiresAt?: Date } | null): boolean {
+  return Boolean(credentials?.refreshLeaseOwner?.startsWith(REFRESH_COOLDOWN_OWNER_PREFIX))
+    && !leaseExpired(credentials);
+}
+
+function retryAfterFromLease(credentials: { refreshLeaseExpiresAt?: Date } | null): number | undefined {
+  if (!credentials?.refreshLeaseExpiresAt) {
+    return undefined;
+  }
+  const seconds = Math.ceil((credentials.refreshLeaseExpiresAt.getTime() - Date.now()) / 1000);
+  return seconds > 0 ? seconds : undefined;
+}
+
+function yahooRefreshCooldownResult(credentials: YahooCredentials): GetTokenResult {
+  return {
+    error: YahooAuthWorkerErrorCode.REFRESH_TEMPORARILY_UNAVAILABLE,
+    errorDescription: 'Yahoo token refresh is cooling down after a transient failure. Please try again shortly.',
+    retryable: true,
+    retryAfter: retryAfterFromLease(credentials) ?? YAHOO_REFRESH_IN_PROGRESS_RETRY_AFTER_SECONDS,
+  };
+}
+
+function retryAfterForTransientYahooTokenFailure(response: Pick<YahooTokenResponse, 'status' | 'retry_after'>): number {
+  return response.retry_after
+    ?? defaultYahooRetryAfterSeconds(response.status)
+    ?? YAHOO_TOKEN_TEXT_TRANSIENT_RETRY_AFTER_SECONDS;
+}
+
+async function markYahooRefreshCooldown(
+  storage: YahooStorage,
+  userId: string,
+  ownerId: string,
+  retryAfterSeconds: number
+): Promise<void> {
+  try {
+    await storage.markRefreshCooldown(userId, ownerId, retryAfterSeconds);
+  } catch (cooldownError) {
+    console.warn('[yahoo-connect] Failed to mark Yahoo refresh cooldown after transient refresh failure:', cooldownError);
+    try {
+      await storage.releaseRefreshLease(userId, ownerId);
+    } catch (releaseError) {
+      console.warn('[yahoo-connect] Failed to release Yahoo refresh lease after cooldown failure:', releaseError);
+    }
+  }
+}
+
 async function waitForFreshCredentialsOrLeaseClear(
   storage: YahooStorage,
   userId: string,
@@ -298,6 +346,10 @@ async function waitForFreshCredentialsOrLeaseClear(
   const deadline = Date.now() + MAX_LEASE_WAIT_MS;
 
   while (latest && !leaseExpired(latest)) {
+    if (isRefreshCooldown(latest)) {
+      return yahooRefreshCooldownResult(latest);
+    }
+
     const remainingMs = deadline - Date.now();
     if (remainingMs <= 0) {
       return {
@@ -371,6 +423,9 @@ async function getValidYahooAccessToken(
       if (!latest.needsRefresh) {
         return toTokenResult(latest);
       }
+      if (isRefreshCooldown(latest)) {
+        return yahooRefreshCooldownResult(latest);
+      }
       if (leaseExpired(latest)) {
         credentials = latest;
         continue;
@@ -401,11 +456,12 @@ async function getValidYahooAccessToken(
         `[yahoo-connect] Yahoo token refresh request failed for user ${maskUserId(userId)}:`,
         error instanceof Error ? error.message : error
       );
-      try {
-        await storage.releaseRefreshLease(userId, ownerId);
-      } catch (releaseError) {
-        console.warn('[yahoo-connect] Failed to release Yahoo refresh lease after refresh exception:', releaseError);
-      }
+      await markYahooRefreshCooldown(
+        storage,
+        userId,
+        ownerId,
+        YAHOO_DEFAULT_TRANSIENT_RETRY_AFTER_SECONDS
+      );
       return {
         error: YahooAuthWorkerErrorCode.REFRESH_TEMPORARILY_UNAVAILABLE,
         errorDescription: isAbort
@@ -423,23 +479,31 @@ async function getValidYahooAccessToken(
         `[yahoo-connect] Yahoo token refresh failed for user ${maskUserId(userId)}: ${result.error}${statusSuffix}` +
           (result.error_description ? ` - ${result.error_description}` : '')
       );
-      try {
-        await storage.releaseRefreshLease(userId, ownerId);
-      } catch (releaseError) {
-        console.warn('[yahoo-connect] Failed to release Yahoo refresh lease after Yahoo refresh error:', releaseError);
-      }
       const latest = await storage.getYahooCredentials(userId);
       if (latest && !latest.needsRefresh && looksLikeNewerCredentials(credentials, latest)) {
         console.log(`[yahoo-connect] Using concurrently refreshed token for user ${maskUserId(userId)}`);
+        try {
+          await storage.releaseRefreshLease(userId, ownerId);
+        } catch (releaseError) {
+          console.warn('[yahoo-connect] Failed to release Yahoo refresh lease after concurrent refresh:', releaseError);
+        }
         return toTokenResult(latest);
       }
       if (isTransientYahooTokenFailure(result)) {
+        const retryAfter = retryAfterForTransientYahooTokenFailure(result);
+        await markYahooRefreshCooldown(storage, userId, ownerId, retryAfter);
         return {
           error: YahooAuthWorkerErrorCode.REFRESH_TEMPORARILY_UNAVAILABLE,
           errorDescription: result.error_description || 'Yahoo token refresh is temporarily unavailable',
           retryable: true,
-          retryAfter: result.retry_after ?? defaultYahooRetryAfterSeconds(result.status),
+          retryAfter,
+          upstreamStatus: result.status,
         };
+      }
+      try {
+        await storage.releaseRefreshLease(userId, ownerId);
+      } catch (releaseError) {
+        console.warn('[yahoo-connect] Failed to release Yahoo refresh lease after Yahoo refresh error:', releaseError);
       }
       return {
         error: 'refresh_failed',
@@ -504,6 +568,7 @@ function yahooRefreshFailureResponse(
         error_description: result.errorDescription || 'Yahoo token refresh is temporarily unavailable. Please try again later.',
         retryable: true,
         retry_after: retryAfter,
+        upstream_status: result.upstreamStatus,
       }),
       {
         status: 503,

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -73,6 +73,8 @@ const MAX_LEASE_WAIT_MS = 10_000;
 const POLL_INTERVAL_MS   =    300;
 const MAX_REFRESH_ATTEMPTS = 3;
 const REFRESH_COOLDOWN_OWNER_PREFIX = 'cooldown:';
+// Plain-text "too many token requests" deserves a short pause; network
+// timeouts use the longer generic Yahoo transient cooldown.
 const YAHOO_TOKEN_TEXT_TRANSIENT_RETRY_AFTER_SECONDS = 60;
 
 /**
@@ -326,7 +328,10 @@ async function markYahooRefreshCooldown(
   retryAfterSeconds: number
 ): Promise<void> {
   try {
-    await storage.markRefreshCooldown(userId, ownerId, retryAfterSeconds);
+    const marked = await storage.markRefreshCooldown(userId, ownerId, retryAfterSeconds);
+    if (!marked) {
+      console.debug('[yahoo-connect] Skipped Yahoo refresh cooldown because the lease is no longer owned by this request');
+    }
   } catch (cooldownError) {
     console.warn('[yahoo-connect] Failed to mark Yahoo refresh cooldown after transient refresh failure:', cooldownError);
     try {
@@ -405,6 +410,9 @@ async function getValidYahooAccessToken(
   for (let attempt = 0; attempt < MAX_REFRESH_ATTEMPTS; attempt++) {
     if (!credentials.needsRefresh) {
       return toTokenResult(credentials);
+    }
+    if (isRefreshCooldown(credentials)) {
+      return yahooRefreshCooldownResult(credentials);
     }
 
     const ownerId = crypto.randomUUID();

--- a/workers/auth-worker/src/yahoo-storage.ts
+++ b/workers/auth-worker/src/yahoo-storage.ts
@@ -344,6 +344,35 @@ export class YahooStorage {
   }
 
   /**
+   * Convert the caller-owned refresh lease into a short cooldown marker.
+   *
+   * This reuses the existing lease columns so near-concurrent requests do not
+   * immediately stampede Yahoo's token endpoint after a transient refresh
+   * failure.
+   */
+  async markRefreshCooldown(
+    clerkUserId: string,
+    ownerId: string,
+    retryAfterSeconds: number
+  ): Promise<void> {
+    const boundedRetryAfterSeconds = Math.max(1, Math.ceil(retryAfterSeconds));
+    const expiresAt = new Date(Date.now() + boundedRetryAfterSeconds * 1000).toISOString();
+    const { error } = await this.supabase
+      .from('yahoo_credentials')
+      .update({
+        refresh_lease_owner: `cooldown:${ownerId}`,
+        refresh_lease_expires_at: expiresAt,
+      })
+      .eq('clerk_user_id', clerkUserId)
+      .eq('refresh_lease_owner', ownerId);
+
+    if (error) {
+      console.error('[yahoo-storage] Failed to mark Yahoo refresh cooldown:', error);
+      throw new Error('Failed to mark Yahoo refresh cooldown');
+    }
+  }
+
+  /**
    * Delete Yahoo credentials for a user
    */
   async deleteYahooCredentials(clerkUserId: string): Promise<void> {

--- a/workers/auth-worker/src/yahoo-storage.ts
+++ b/workers/auth-worker/src/yahoo-storage.ts
@@ -354,22 +354,25 @@ export class YahooStorage {
     clerkUserId: string,
     ownerId: string,
     retryAfterSeconds: number
-  ): Promise<void> {
+  ): Promise<boolean> {
     const boundedRetryAfterSeconds = Math.max(1, Math.ceil(retryAfterSeconds));
     const expiresAt = new Date(Date.now() + boundedRetryAfterSeconds * 1000).toISOString();
-    const { error } = await this.supabase
+    const { data, error } = await this.supabase
       .from('yahoo_credentials')
       .update({
         refresh_lease_owner: `cooldown:${ownerId}`,
         refresh_lease_expires_at: expiresAt,
       })
       .eq('clerk_user_id', clerkUserId)
-      .eq('refresh_lease_owner', ownerId);
+      .eq('refresh_lease_owner', ownerId)
+      .select('clerk_user_id');
 
     if (error) {
       console.error('[yahoo-storage] Failed to mark Yahoo refresh cooldown:', error);
       throw new Error('Failed to mark Yahoo refresh cooldown');
     }
+
+    return (data?.length ?? 0) > 0;
   }
 
   /**

--- a/workers/fantasy-mcp/src/__tests__/router.test.ts
+++ b/workers/fantasy-mcp/src/__tests__/router.test.ts
@@ -151,6 +151,7 @@ describe('fantasy-mcp router', () => {
             success: false,
             error: 'YAHOO_AUTH_UNAVAILABLE: Yahoo token refresh is already in progress',
             code: 'YAHOO_AUTH_UNAVAILABLE',
+            upstream_status: 429,
             retryable: true,
             retry_after: 5,
           }), {
@@ -167,6 +168,7 @@ describe('fantasy-mcp router', () => {
         error: 'YAHOO_AUTH_UNAVAILABLE: Yahoo token refresh is already in progress',
         code: 'YAHOO_AUTH_UNAVAILABLE',
         status: 503,
+        upstream_status: 429,
         retryable: true,
         retry_after: 5,
       });

--- a/workers/fantasy-mcp/src/__tests__/tools.test.ts
+++ b/workers/fantasy-mcp/src/__tests__/tools.test.ts
@@ -367,6 +367,7 @@ describe('fantasy-mcp tools', () => {
       error: 'YAHOO_AUTH_UNAVAILABLE: Yahoo token refresh is already in progress',
       code: 'YAHOO_AUTH_UNAVAILABLE',
       status: 503,
+      upstream_status: 429,
       retryable: true,
       retry_after: 5,
     });
@@ -386,11 +387,13 @@ describe('fantasy-mcp tools', () => {
       success: false,
       code: 'YAHOO_AUTH_UNAVAILABLE',
       status: 503,
+      upstream_status: 429,
       retryable: true,
       retry_after: 5,
     });
     expect(result._meta).toMatchObject({
       status: 503,
+      upstream_status: 429,
       retryable: true,
       retry_after: 5,
     });

--- a/workers/fantasy-mcp/src/mcp/tools.ts
+++ b/workers/fantasy-mcp/src/mcp/tools.ts
@@ -355,11 +355,13 @@ function routeResultToMcp(result: RouteResult): McpToolResponse {
     error: result.error || 'Unknown error',
   };
   if (result.status !== undefined) errorPayload.status = result.status;
+  if (result.upstream_status !== undefined) errorPayload.upstream_status = result.upstream_status;
   if (result.retryable !== undefined) errorPayload.retryable = result.retryable;
   if (result.retry_after !== undefined) errorPayload.retry_after = result.retry_after;
 
   const meta: Record<string, unknown> = {};
   if (result.status !== undefined) meta.status = result.status;
+  if (result.upstream_status !== undefined) meta.upstream_status = result.upstream_status;
   if (result.retryable !== undefined) meta.retryable = result.retryable;
   if (result.retry_after !== undefined) meta.retry_after = result.retry_after;
 

--- a/workers/fantasy-mcp/src/router.ts
+++ b/workers/fantasy-mcp/src/router.ts
@@ -13,6 +13,7 @@ export interface RouteResult {
   error?: string;
   code?: string;
   status?: number;
+  upstream_status?: number;
   retryable?: boolean;
   retry_after?: number;
 }
@@ -74,6 +75,7 @@ export async function routeToClient(
       const errorData = await response.json().catch(() => ({})) as {
         error?: string;
         code?: string;
+        upstream_status?: number;
         retryable?: boolean;
         retry_after?: number;
       };
@@ -83,6 +85,7 @@ export async function routeToClient(
         error: errorData.error || `Platform worker returned ${response.status}`,
         code: errorData.code || 'PLATFORM_ERROR',
         status: response.status,
+        upstream_status: errorData.upstream_status,
         retryable: errorData.retryable,
         retry_after: retryAfter,
       };

--- a/workers/shared/src/errors.ts
+++ b/workers/shared/src/errors.ts
@@ -99,6 +99,7 @@ export interface ExecuteResponse {
   error?: string;
   code?: string;
   status?: number;
+  upstream_status?: number;
   retryable?: boolean;
   retry_after?: number;
 }

--- a/workers/yahoo-client/src/shared/__tests__/auth.test.ts
+++ b/workers/yahoo-client/src/shared/__tests__/auth.test.ts
@@ -94,6 +94,7 @@ describe('getYahooCredentials', () => {
           error_description: 'Try again later',
           retryable: true,
           retry_after: 120,
+          upstream_status: 429,
         }),
         { status: 503, headers: { 'Retry-After': '120' } }
       )
@@ -102,6 +103,7 @@ describe('getYahooCredentials', () => {
     await expect(getYahooCredentials(env, 'Bearer token')).rejects.toMatchObject({
       code: 'YAHOO_AUTH_UNAVAILABLE',
       status: 503,
+      upstreamStatus: 429,
       retryable: true,
       retryAfter: 120,
     } satisfies Partial<YahooClientError>);

--- a/workers/yahoo-client/src/shared/__tests__/handlers-utils.test.ts
+++ b/workers/yahoo-client/src/shared/__tests__/handlers-utils.test.ts
@@ -19,6 +19,7 @@ describe('shared handler utilities', () => {
       code: 'YAHOO_RATE_LIMITED',
       message: 'Too many requests. Please wait.',
       status: 429,
+      upstreamStatus: 999,
       retryable: true,
       retryAfter: 900,
     }))).toEqual({
@@ -26,6 +27,7 @@ describe('shared handler utilities', () => {
       error: 'YAHOO_RATE_LIMITED: Too many requests. Please wait.',
       code: 'YAHOO_RATE_LIMITED',
       status: 429,
+      upstream_status: 999,
       retryable: true,
       retry_after: 900,
     });

--- a/workers/yahoo-client/src/shared/auth.ts
+++ b/workers/yahoo-client/src/shared/auth.ts
@@ -16,6 +16,7 @@ async function throwYahooAuthWorkerError(response: Response): Promise<never> {
     error_description?: string;
     retryable?: boolean;
     retry_after?: number;
+    upstream_status?: number;
   };
   const headerRetryAfter = parseRetryAfterSeconds(response.headers.get('Retry-After'));
   const retryAfter = headerRetryAfter ?? (typeof errorData.retry_after === 'number' ? errorData.retry_after : undefined);
@@ -37,6 +38,7 @@ async function throwYahooAuthWorkerError(response: Response): Promise<never> {
       code: 'YAHOO_AUTH_UNAVAILABLE',
       message: errorDetail,
       status: response.status,
+      upstreamStatus: errorData.upstream_status,
       retryable: true,
       retryAfter,
     });

--- a/workers/yahoo-client/src/shared/errors.ts
+++ b/workers/yahoo-client/src/shared/errors.ts
@@ -7,6 +7,7 @@ export interface YahooClientErrorOptions {
   code: string;
   message: string;
   status?: number;
+  upstreamStatus?: number;
   retryable?: boolean;
   retryAfter?: number;
 }
@@ -14,6 +15,7 @@ export interface YahooClientErrorOptions {
 export class YahooClientError extends Error {
   readonly code: string;
   readonly status?: number;
+  readonly upstreamStatus?: number;
   readonly retryable?: boolean;
   readonly retryAfter?: number;
 
@@ -22,6 +24,7 @@ export class YahooClientError extends Error {
     this.name = 'YahooClientError';
     this.code = options.code;
     this.status = options.status;
+    this.upstreamStatus = options.upstreamStatus;
     this.retryable = options.retryable;
     this.retryAfter = options.retryAfter;
   }

--- a/workers/yahoo-client/src/shared/handlers/utils.ts
+++ b/workers/yahoo-client/src/shared/handlers/utils.ts
@@ -12,6 +12,7 @@ export function toExecuteErrorResponse(error: unknown): ExecuteResponse {
     error: error instanceof Error ? error.message : 'Unknown error',
     code,
     status: metadata.status,
+    upstream_status: isYahooClientError(error) ? error.upstreamStatus : undefined,
     retryable: metadata.retryable,
     retry_after: metadata.retryAfter,
   };

--- a/workers/yahoo-client/src/shared/yahoo-api.ts
+++ b/workers/yahoo-client/src/shared/yahoo-api.ts
@@ -88,6 +88,7 @@ export function handleYahooError(response: Response): never {
         code: 'YAHOO_RATE_LIMITED',
         message: 'Too many requests. Please wait.',
         status: classification.status,
+        upstreamStatus: classification.upstreamStatus,
         retryable: classification.retryable,
         retryAfter: classification.retryAfter,
       });
@@ -96,6 +97,7 @@ export function handleYahooError(response: Response): never {
         code: ErrorCode.YAHOO_TRANSIENT_ERROR,
         message: 'Yahoo is temporarily unavailable. Please try again later.',
         status: classification.status,
+        upstreamStatus: classification.upstreamStatus,
         retryable: classification.retryable,
         retryAfter: classification.retryAfter,
       });
@@ -105,6 +107,7 @@ export function handleYahooError(response: Response): never {
         code: 'YAHOO_API_ERROR',
         message: 'An unexpected error occurred with Yahoo. Please try again.',
         status: classification.status,
+        upstreamStatus: classification.upstreamStatus,
         retryable: classification.retryable,
         retryAfter: classification.retryAfter,
       });


### PR DESCRIPTION
## Summary
- add a short Yahoo token-refresh cooldown using the existing refresh lease columns
- return retry metadata for text-classified Yahoo token endpoint rate limits
- propagate upstream Yahoo status metadata through yahoo-client and fantasy-mcp tool errors

## Root cause / incident context
The May 11 Yahoo failures surfaced as YAHOO_AUTH_UNAVAILABLE / refresh_temporarily_unavailable across several near-concurrent Yahoo MCP tool calls. That points to Yahoo's OAuth token endpoint failing or rate-limiting refresh, not a reconnect-required auth failure. PR #73 made that path retryable, but a transient winner released the refresh lease immediately, so follow-on tool calls could immediately re-hit Yahoo and repeat the failure.

## Impact
After a transient Yahoo refresh failure, near-concurrent requests now reuse a cooldown signal with Retry-After instead of stampeding Yahoo's token endpoint. MCP clients also receive upstream_status where available, making future incidents easier to classify.

## Validation
- corepack pnpm --dir workers/auth-worker test -- yahoo-connect-handlers yahoo-storage
- corepack pnpm --dir workers/yahoo-client test
- corepack pnpm --dir workers/fantasy-mcp test
- corepack pnpm --dir workers/shared test
- corepack pnpm --dir workers/auth-worker type-check
- corepack pnpm --dir workers/yahoo-client type-check
- corepack pnpm --dir workers/fantasy-mcp type-check
- corepack pnpm --dir workers/shared type-check
- git diff --check

Note: local auth-worker commands warn because this shell is Node v26 while the repo declares Node 24.x; tests and type-check passed.
