### PR TITLE
[codex] Extend MCP OAuth refresh lifetime

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -141,7 +141,7 @@ Users connect their own AI subscription to Flaim's MCP servers:
 - **OAuth Flow**: Full OAuth 2.1 with PKCE, Dynamic Client Registration (RFC 7591), Protected Resource Metadata (RFC 9728)
 - **Endpoints**: `/auth/register` (DCR), `/auth/authorize`, `/auth/token`, `/auth/revoke`
 - **Metadata**: `/.well-known/oauth-authorization-server`, `/.well-known/oauth-protected-resource`
-- **Token lifetime**: MCP access tokens are short-lived (1 hour). Refresh tokens rotate on each successful refresh and use a 90-day inactivity window by default (`OAUTH_REFRESH_TOKEN_TTL_SECONDS`, default `7776000`).
+- **Token lifetime**: MCP access tokens are short-lived (1 hour). Refresh tokens rotate on each successful refresh and use a 90-day inactivity window by default (`OAUTH_REFRESH_TOKEN_TTL_SECONDS`, default `7776000`, clamped to 1 hour minimum and 1 year maximum).
 
 **User flow**: Add MCP URL in Claude, ChatGPT, Perplexity, or another supported MCP client → 401 triggers OAuth → user consents at `flaim.app/oauth/consent` → token exchange → tools available.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -141,7 +141,7 @@ Users connect their own AI subscription to Flaim's MCP servers:
 - **OAuth Flow**: Full OAuth 2.1 with PKCE, Dynamic Client Registration (RFC 7591), Protected Resource Metadata (RFC 9728)
 - **Endpoints**: `/auth/register` (DCR), `/auth/authorize`, `/auth/token`, `/auth/revoke`
 - **Metadata**: `/.well-known/oauth-authorization-server`, `/.well-known/oauth-protected-resource`
-- **Token lifetime**: MCP access tokens are short-lived (1 hour). Refresh tokens rotate on each successful refresh and use a 90-day inactivity window by default (`OAUTH_REFRESH_TOKEN_TTL_SECONDS`, default `7776000`, clamped to 1 hour minimum and 1 year maximum).
+- **Token lifetime**: MCP access tokens are short-lived (1 hour). Refresh tokens rotate on each successful refresh and use a 1-year inactivity window by default (`OAUTH_REFRESH_TOKEN_TTL_SECONDS`, default `31536000`, clamped to 1 hour minimum and 1 year maximum).
 
 **User flow**: Add MCP URL in Claude, ChatGPT, Perplexity, or another supported MCP client → 401 triggers OAuth → user consents at `flaim.app/oauth/consent` → token exchange → tools available.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -133,7 +133,7 @@ ESPN Cookies → POST /api/extension/sync → Auth Worker → Supabase
 - Clerk JWT verification in auth-worker
 - Extension never stores long-lived custom tokens
 
-## Claude + ChatGPT OAuth 2.1
+## AI Client OAuth 2.1
 
 Users connect their own AI subscription to Flaim's MCP servers:
 
@@ -141,8 +141,9 @@ Users connect their own AI subscription to Flaim's MCP servers:
 - **OAuth Flow**: Full OAuth 2.1 with PKCE, Dynamic Client Registration (RFC 7591), Protected Resource Metadata (RFC 9728)
 - **Endpoints**: `/auth/register` (DCR), `/auth/authorize`, `/auth/token`, `/auth/revoke`
 - **Metadata**: `/.well-known/oauth-authorization-server`, `/.well-known/oauth-protected-resource`
+- **Token lifetime**: MCP access tokens are short-lived (1 hour). Refresh tokens rotate on each successful refresh and use a 90-day inactivity window by default (`OAUTH_REFRESH_TOKEN_TTL_SECONDS`, default `7776000`).
 
-**User flow**: Add MCP URL in Claude/ChatGPT → 401 triggers OAuth → user consents at `flaim.app/oauth/consent` → token exchange → tools available.
+**User flow**: Add MCP URL in Claude, ChatGPT, Perplexity, or another supported MCP client → 401 triggers OAuth → user consents at `flaim.app/oauth/consent` → token exchange → tools available.
 
 ## MCP Tools
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,7 @@ Follow Keep a Changelog; stamp a version when submitting to directories.
 ## [Unreleased]
 
 ### MCP OAuth
-- **Changed**: MCP OAuth refresh-token inactivity window is now 90 days by default (`OAUTH_REFRESH_TOKEN_TTL_SECONDS`, default `7776000`) while access tokens remain 1 hour and refresh tokens continue rotating on successful refresh.
+- **Changed**: MCP OAuth refresh-token inactivity window is now 90 days by default (`OAUTH_REFRESH_TOKEN_TTL_SECONDS`, default `7776000`, clamped to 1 hour minimum and 1 year maximum) while access tokens remain 1 hour and refresh tokens continue rotating on successful refresh.
 - **Fixed**: `/oauth/status` now reports an active AI connector when a non-revoked refresh token is still valid, even after the current 1-hour access token expires.
 
 ### Documentation

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,7 @@ Follow Keep a Changelog; stamp a version when submitting to directories.
 ## [Unreleased]
 
 ### MCP OAuth
-- **Changed**: MCP OAuth refresh-token inactivity window is now 90 days by default (`OAUTH_REFRESH_TOKEN_TTL_SECONDS`, default `7776000`, clamped to 1 hour minimum and 1 year maximum) while access tokens remain 1 hour and refresh tokens continue rotating on successful refresh.
+- **Changed**: MCP OAuth refresh-token inactivity window is now 1 year by default (`OAUTH_REFRESH_TOKEN_TTL_SECONDS`, default `31536000`, clamped to 1 hour minimum and 1 year maximum) while access tokens remain 1 hour and refresh tokens continue rotating on successful refresh.
 - **Fixed**: `/oauth/status` now reports an active AI connector when a non-revoked refresh token is still valid, even after the current 1-hour access token expires.
 
 ### Documentation

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,10 @@ Follow Keep a Changelog; stamp a version when submitting to directories.
 
 ## [Unreleased]
 
+### MCP OAuth
+- **Changed**: MCP OAuth refresh-token inactivity window is now 90 days by default (`OAUTH_REFRESH_TOKEN_TTL_SECONDS`, default `7776000`) while access tokens remain 1 hour and refresh tokens continue rotating on successful refresh.
+- **Fixed**: `/oauth/status` now reports an active AI connector when a non-revoked refresh token is still valid, even after the current 1-hour access token expires.
+
 ### Documentation
 - **Changed**: Updated repo docs to reflect the current chat split: public `/chat` live demo and internal `/dev` lab.
 - **Fixed**: Removed stale dev-only chat framing and cleaned unresolved merge-conflict markers from `docs/ARCHITECTURE.md`.

--- a/docs/CONNECTOR-DOCS.md
+++ b/docs/CONNECTOR-DOCS.md
@@ -18,7 +18,7 @@ Flaim cannot place trades, add/drop players, or modify league settings.
 - **Token URL:** `https://api.flaim.app/auth/token`
 - **Revocation URL:** `https://api.flaim.app/auth/revoke`
 - **Discovery:** `https://api.flaim.app/.well-known/oauth-authorization-server`
-- **Token lifetime:** 1-hour access tokens plus rotating refresh tokens with a 90-day inactivity window by default (`OAUTH_REFRESH_TOKEN_TTL_SECONDS`, default `7776000`, clamped to 1 hour minimum and 1 year maximum)
+- **Token lifetime:** 1-hour access tokens plus rotating refresh tokens with a 1-year inactivity window by default (`OAUTH_REFRESH_TOKEN_TTL_SECONDS`, default `31536000`, clamped to 1 hour minimum and 1 year maximum)
 
 ## Setup (Once)
 

--- a/docs/CONNECTOR-DOCS.md
+++ b/docs/CONNECTOR-DOCS.md
@@ -18,7 +18,7 @@ Flaim cannot place trades, add/drop players, or modify league settings.
 - **Token URL:** `https://api.flaim.app/auth/token`
 - **Revocation URL:** `https://api.flaim.app/auth/revoke`
 - **Discovery:** `https://api.flaim.app/.well-known/oauth-authorization-server`
-- **Token lifetime:** 1-hour access tokens plus rotating refresh tokens with a 90-day inactivity window by default (`OAUTH_REFRESH_TOKEN_TTL_SECONDS`, default `7776000`)
+- **Token lifetime:** 1-hour access tokens plus rotating refresh tokens with a 90-day inactivity window by default (`OAUTH_REFRESH_TOKEN_TTL_SECONDS`, default `7776000`, clamped to 1 hour minimum and 1 year maximum)
 
 ## Setup (Once)
 

--- a/docs/CONNECTOR-DOCS.md
+++ b/docs/CONNECTOR-DOCS.md
@@ -1,6 +1,6 @@
-# Flaim Setup Docs (Claude + ChatGPT + Gemini)
+# Flaim Setup Docs (Claude + ChatGPT + Perplexity + Gemini)
 
-This page is the single user-facing guide for connecting Flaim to AI clients (Claude, ChatGPT, Gemini CLI) and using read-only fantasy analysis tools.
+This page is the single user-facing guide for connecting Flaim to AI clients (Claude, ChatGPT, Perplexity, Gemini CLI) and using read-only fantasy analysis tools.
 
 ## What Flaim Is
 
@@ -18,6 +18,7 @@ Flaim cannot place trades, add/drop players, or modify league settings.
 - **Token URL:** `https://api.flaim.app/auth/token`
 - **Revocation URL:** `https://api.flaim.app/auth/revoke`
 - **Discovery:** `https://api.flaim.app/.well-known/oauth-authorization-server`
+- **Token lifetime:** 1-hour access tokens plus rotating refresh tokens with a 90-day inactivity window by default (`OAUTH_REFRESH_TOKEN_TTL_SECONDS`, default `7776000`)
 
 ## Setup (Once)
 
@@ -38,6 +39,11 @@ Flaim cannot place trades, add/drop players, or modify league settings.
 ### Claude (Claude Desktop or claude.ai)
 
 1. Add a remote MCP server with URL `https://api.flaim.app/mcp`.
+2. Complete the OAuth consent screen when prompted.
+
+### Perplexity (Custom Remote Connector)
+
+1. Add a custom remote connector with URL `https://api.flaim.app/mcp`, OAuth auth, and Streamable HTTP transport.
 2. Complete the OAuth consent screen when prompted.
 
 ### Gemini CLI

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -161,7 +161,7 @@ Access and refresh tokens for MCP clients.
 | expires_at | timestamptz | Access token expiry |
 | revoked_at | timestamptz | Revocation time |
 | refresh_token | text | Optional refresh token |
-| refresh_token_expires_at | timestamptz | Refresh token expiry |
+| refresh_token_expires_at | timestamptz | MCP refresh-token inactivity expiry (90 days by default; `OAUTH_REFRESH_TOKEN_TTL_SECONDS`) |
 | created_at | timestamptz | Created timestamp |
 
 ### oauth_states

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -161,7 +161,7 @@ Access and refresh tokens for MCP clients.
 | expires_at | timestamptz | Access token expiry |
 | revoked_at | timestamptz | Revocation time |
 | refresh_token | text | Optional refresh token |
-| refresh_token_expires_at | timestamptz | MCP refresh-token inactivity expiry (90 days by default; `OAUTH_REFRESH_TOKEN_TTL_SECONDS`) |
+| refresh_token_expires_at | timestamptz | MCP refresh-token inactivity expiry (1 year by default; `OAUTH_REFRESH_TOKEN_TTL_SECONDS`) |
 | created_at | timestamptz | Created timestamp |
 
 When extending the MCP refresh-token inactivity window for an existing deployment, non-revoked rows with still-valid refresh tokens can be backfilled so current connectors inherit the longer window without reconnecting:
@@ -170,7 +170,7 @@ When extending the MCP refresh-token inactivity window for an existing deploymen
 UPDATE oauth_tokens
 SET refresh_token_expires_at = GREATEST(
   refresh_token_expires_at,
-  now() + interval '90 days'
+  now() + interval '1 year'
 )
 WHERE refresh_token IS NOT NULL
   AND revoked_at IS NULL

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -164,6 +164,19 @@ Access and refresh tokens for MCP clients.
 | refresh_token_expires_at | timestamptz | MCP refresh-token inactivity expiry (90 days by default; `OAUTH_REFRESH_TOKEN_TTL_SECONDS`) |
 | created_at | timestamptz | Created timestamp |
 
+When extending the MCP refresh-token inactivity window for an existing deployment, non-revoked rows with still-valid refresh tokens can be backfilled so current connectors inherit the longer window without reconnecting:
+
+```sql
+UPDATE oauth_tokens
+SET refresh_token_expires_at = GREATEST(
+  refresh_token_expires_at,
+  now() + interval '90 days'
+)
+WHERE refresh_token IS NOT NULL
+  AND revoked_at IS NULL
+  AND refresh_token_expires_at > now();
+```
+
 ### oauth_states
 Short-lived OAuth state values used for server-side validation.
 

--- a/web/app/api/oauth/status/route.ts
+++ b/web/app/api/oauth/status/route.ts
@@ -50,6 +50,7 @@ export async function GET() {
       connections?: Array<{
         id: string;
         expiresAt: string;
+        refreshTokenExpiresAt?: string;
         scope: string;
         clientName?: string;
       }>;

--- a/web/app/api/oauth/status/route.ts
+++ b/web/app/api/oauth/status/route.ts
@@ -50,7 +50,6 @@ export async function GET() {
       connections?: Array<{
         id: string;
         expiresAt: string;
-        refreshTokenExpiresAt?: string;
         scope: string;
         clientName?: string;
       }>;

--- a/workers/auth-worker/README.md
+++ b/workers/auth-worker/README.md
@@ -43,7 +43,7 @@ This avoids state collisions during sign-in redirects while maintaining backward
 MCP OAuth token lifetime:
 - Access tokens remain short-lived: 1 hour.
 - Refresh tokens rotate on every successful refresh.
-- Refresh-token inactivity window defaults to 90 days (`7776000` seconds) and can be overridden with `OAUTH_REFRESH_TOKEN_TTL_SECONDS`.
+- Refresh-token inactivity window defaults to 90 days (`7776000` seconds) and can be overridden with `OAUTH_REFRESH_TOKEN_TTL_SECONDS` (clamped to 1 hour minimum, 1 year maximum).
 - This provider-side MCP OAuth flow is separate from the downstream Yahoo OAuth token chain.
 
 ### Yahoo Connect (Flaim → Yahoo)

--- a/workers/auth-worker/README.md
+++ b/workers/auth-worker/README.md
@@ -22,7 +22,7 @@ This worker has three distinct responsibilities:
 
 ### OAuth 2.1 Provider (AI clients → Flaim)
 
-These endpoints let Claude, ChatGPT, and Gemini authenticate via MCP.
+These endpoints let Claude, ChatGPT, Perplexity, Gemini, and other MCP clients authenticate to Flaim.
 
 | Endpoint | Auth | Purpose |
 |----------|------|---------|
@@ -39,6 +39,12 @@ These endpoints let Claude, ChatGPT, and Gemini authenticate via MCP.
 OAuth consent callback note:
 The consent screen accepts `oauth_state` (preferred) and legacy `state` query params.
 This avoids state collisions during sign-in redirects while maintaining backward compatibility.
+
+MCP OAuth token lifetime:
+- Access tokens remain short-lived: 1 hour.
+- Refresh tokens rotate on every successful refresh.
+- Refresh-token inactivity window defaults to 90 days (`7776000` seconds) and can be overridden with `OAUTH_REFRESH_TOKEN_TTL_SECONDS`.
+- This provider-side MCP OAuth flow is separate from the downstream Yahoo OAuth token chain.
 
 ### Yahoo Connect (Flaim → Yahoo)
 

--- a/workers/auth-worker/README.md
+++ b/workers/auth-worker/README.md
@@ -43,7 +43,7 @@ This avoids state collisions during sign-in redirects while maintaining backward
 MCP OAuth token lifetime:
 - Access tokens remain short-lived: 1 hour.
 - Refresh tokens rotate on every successful refresh.
-- Refresh-token inactivity window defaults to 90 days (`7776000` seconds) and can be overridden with `OAUTH_REFRESH_TOKEN_TTL_SECONDS` (clamped to 1 hour minimum, 1 year maximum).
+- Refresh-token inactivity window defaults to 1 year (`31536000` seconds) and can be overridden with `OAUTH_REFRESH_TOKEN_TTL_SECONDS` (clamped to 1 hour minimum, 1 year maximum).
 - This provider-side MCP OAuth flow is separate from the downstream Yahoo OAuth token chain.
 
 ### Yahoo Connect (Flaim → Yahoo)

--- a/workers/auth-worker/src/__tests__/oauth-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/oauth-handlers.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { handleAuthorize, handleClientRegistration, handleMetadataDiscovery, validateOAuthToken } from '../oauth-handlers';
+import {
+  handleAuthorize,
+  handleCheckStatus,
+  handleClientRegistration,
+  handleMetadataDiscovery,
+  validateOAuthToken,
+} from '../oauth-handlers';
 import { isValidRedirectUri } from '@flaim/worker-shared';
 import { handleToken } from '../oauth-handlers';
 import { OAuthStorage } from '../oauth-storage';
@@ -232,6 +238,58 @@ describe('oauth-handlers', () => {
     expect(body.refresh_token).toBe('refresh-token');
     expect(typeof body.expires_in).toBe('number');
     expect(body.expires_in).toBeGreaterThan(0);
+  });
+
+  it('returns invalid_grant when refresh token is expired', async () => {
+    const refreshAccessToken = vi.fn().mockResolvedValue(null);
+    vi.spyOn(OAuthStorage, 'fromEnvironment').mockReturnValue({
+      refreshAccessToken,
+    } as unknown as OAuthStorage);
+
+    const req = new Request('https://api.flaim.app/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'refresh_token',
+        refresh_token: 'expired-refresh-token',
+      }),
+    });
+
+    const res = await handleToken(req, env, corsHeaders);
+    expect(res.status).toBe(400);
+
+    const body = await res.json() as { error?: string; error_description?: string };
+    expect(body.error).toBe('invalid_grant');
+    expect(body.error_description).toBe('Invalid or expired refresh token');
+    expect(refreshAccessToken).toHaveBeenCalledWith('expired-refresh-token');
+  });
+
+  it('reports active connection when access token expired but refresh token is still valid', async () => {
+    const getRefreshableUserTokens = vi.fn().mockResolvedValue([
+      {
+        id: 'token-id',
+        expiresAt: new Date(Date.now() - 60 * 60 * 1000),
+        refreshTokenExpiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+        scope: 'mcp:read',
+        clientName: 'Perplexity',
+      },
+    ]);
+    vi.spyOn(OAuthStorage, 'fromEnvironment').mockReturnValue({
+      getRefreshableUserTokens,
+    } as unknown as OAuthStorage);
+
+    const res = await handleCheckStatus(env, 'user_123', corsHeaders);
+    expect(res.status).toBe(200);
+
+    const body = await res.json() as {
+      hasConnection?: boolean;
+      connections?: Array<{ clientName?: string; refreshTokenExpiresAt?: string }>;
+    };
+    expect(body.hasConnection).toBe(true);
+    expect(body.connections).toHaveLength(1);
+    expect(body.connections?.[0].clientName).toBe('Perplexity');
+    expect(body.connections?.[0].refreshTokenExpiresAt).toBeTruthy();
+    expect(getRefreshableUserTokens).toHaveBeenCalledWith('user_123');
   });
 });
 

--- a/workers/auth-worker/src/__tests__/oauth-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/oauth-handlers.test.ts
@@ -283,12 +283,12 @@ describe('oauth-handlers', () => {
 
     const body = await res.json() as {
       hasConnection?: boolean;
-      connections?: Array<{ clientName?: string; refreshTokenExpiresAt?: string }>;
+      connections?: Array<Record<string, unknown> & { clientName?: string }>;
     };
     expect(body.hasConnection).toBe(true);
     expect(body.connections).toHaveLength(1);
     expect(body.connections?.[0].clientName).toBe('Perplexity');
-    expect(body.connections?.[0].refreshTokenExpiresAt).toBeTruthy();
+    expect(body.connections?.[0]).not.toHaveProperty('refreshTokenExpiresAt');
     expect(getRefreshableUserTokens).toHaveBeenCalledWith('user_123');
   });
 });

--- a/workers/auth-worker/src/__tests__/oauth-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/oauth-storage.test.ts
@@ -155,7 +155,7 @@ describe('OAuthStorage MCP token lifetimes', () => {
     );
   });
 
-  it('uses the default when OAUTH_REFRESH_TOKEN_TTL_SECONDS env override is below minimum', async () => {
+  it('clamps OAUTH_REFRESH_TOKEN_TTL_SECONDS env override to the 1-hour minimum', async () => {
     const { insertPayloads } = buildTableMock();
     const storage = OAuthStorage.fromEnvironment({
       SUPABASE_URL: 'https://example.supabase.co',
@@ -172,10 +172,10 @@ describe('OAuthStorage MCP token lifetimes', () => {
 
     const refreshTokenExpiresAt = new Date(insertPayloads[0].refresh_token_expires_at as string).getTime();
     expect(refreshTokenExpiresAt).toBeGreaterThanOrEqual(
-      before + DEFAULT_OAUTH_REFRESH_TOKEN_TTL_SECONDS * 1000 - 1000
+      before + MIN_OAUTH_REFRESH_TOKEN_TTL_SECONDS * 1000 - 1000
     );
     expect(refreshTokenExpiresAt).toBeLessThanOrEqual(
-      after + DEFAULT_OAUTH_REFRESH_TOKEN_TTL_SECONDS * 1000 + 1000
+      after + MIN_OAUTH_REFRESH_TOKEN_TTL_SECONDS * 1000 + 1000
     );
   });
 

--- a/workers/auth-worker/src/__tests__/oauth-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/oauth-storage.test.ts
@@ -89,7 +89,7 @@ describe('OAuthStorage MCP token lifetimes', () => {
     vi.clearAllMocks();
   });
 
-  it('defaults refresh-token inactivity TTL to 90 days', async () => {
+  it('defaults refresh-token inactivity TTL to 1 year', async () => {
     const { insertPayloads } = buildTableMock();
     const storage = new OAuthStorage('https://example.supabase.co', 'test-key');
 

--- a/workers/auth-worker/src/__tests__/oauth-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/oauth-storage.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DEFAULT_OAUTH_REFRESH_TOKEN_TTL_SECONDS, OAuthStorage } from '../oauth-storage';
+
+const mockFrom = vi.fn();
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    from: mockFrom,
+  }),
+}));
+
+function buildTableMock(options?: {
+  lookupRow?: Record<string, unknown> | null;
+  lookupError?: unknown;
+  insertId?: string;
+}) {
+  const insertPayloads: Record<string, unknown>[] = [];
+
+  const lookupSingle = vi.fn().mockResolvedValue({
+    data: options?.lookupRow ?? null,
+    error: options?.lookupError ?? null,
+  });
+  const insertSingle = vi.fn().mockResolvedValue({
+    data: { id: options?.insertId ?? 'token-id' },
+    error: null,
+  });
+
+  const selectEq = vi.fn().mockReturnValue({ single: lookupSingle });
+  const select = vi.fn((columns?: string) => {
+    if (columns === '*') {
+      return { eq: selectEq };
+    }
+
+    return { single: insertSingle };
+  });
+
+  const insert = vi.fn((payload: Record<string, unknown>) => {
+    insertPayloads.push(payload);
+    return { select };
+  });
+
+  const updateEq = vi.fn().mockReturnValue({ error: null });
+  const update = vi.fn().mockReturnValue({ eq: updateEq });
+
+  const table = {
+    insert,
+    select,
+    update,
+  };
+
+  mockFrom.mockReturnValue(table);
+
+  return {
+    insertPayloads,
+    insert,
+    select,
+    selectEq,
+    lookupSingle,
+    update,
+    updateEq,
+  };
+}
+
+describe('OAuthStorage MCP token lifetimes', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it('defaults refresh-token inactivity TTL to 90 days', async () => {
+    const { insertPayloads } = buildTableMock();
+    const storage = new OAuthStorage('https://example.supabase.co', 'test-key');
+
+    const before = Date.now();
+    await storage.createAccessToken({
+      userId: 'user_123',
+      scope: 'mcp:read',
+      includeRefreshToken: true,
+    });
+    const after = Date.now();
+
+    const refreshTokenExpiresAt = new Date(insertPayloads[0].refresh_token_expires_at as string).getTime();
+    expect(refreshTokenExpiresAt).toBeGreaterThanOrEqual(
+      before + DEFAULT_OAUTH_REFRESH_TOKEN_TTL_SECONDS * 1000 - 1000
+    );
+    expect(refreshTokenExpiresAt).toBeLessThanOrEqual(
+      after + DEFAULT_OAUTH_REFRESH_TOKEN_TTL_SECONDS * 1000 + 1000
+    );
+  });
+
+  it('uses OAUTH_REFRESH_TOKEN_TTL_SECONDS env override', async () => {
+    const { insertPayloads } = buildTableMock();
+    const storage = OAuthStorage.fromEnvironment({
+      SUPABASE_URL: 'https://example.supabase.co',
+      SUPABASE_SERVICE_KEY: 'test-key',
+      OAUTH_REFRESH_TOKEN_TTL_SECONDS: '1209600',
+    });
+
+    const before = Date.now();
+    await storage.createAccessToken({
+      userId: 'user_123',
+      includeRefreshToken: true,
+    });
+    const after = Date.now();
+
+    const refreshTokenExpiresAt = new Date(insertPayloads[0].refresh_token_expires_at as string).getTime();
+    expect(refreshTokenExpiresAt).toBeGreaterThanOrEqual(before + 1209600 * 1000 - 1000);
+    expect(refreshTokenExpiresAt).toBeLessThanOrEqual(after + 1209600 * 1000 + 1000);
+  });
+
+  it('refresh rotation carries forward the configured refresh-token TTL', async () => {
+    const { insertPayloads, updateEq } = buildTableMock({
+      lookupRow: {
+        access_token: 'old-access-token',
+        refresh_token: 'old-refresh-token',
+        refresh_token_expires_at: new Date(Date.now() + 60_000).toISOString(),
+        revoked_at: null,
+        user_id: 'user_123',
+        scope: 'mcp:read',
+        resource: 'https://api.flaim.app/mcp',
+        client_name: 'Perplexity',
+      },
+      insertId: 'new-token-id',
+    });
+    const storage = OAuthStorage.fromEnvironment({
+      SUPABASE_URL: 'https://example.supabase.co',
+      SUPABASE_SERVICE_KEY: 'test-key',
+      OAUTH_REFRESH_TOKEN_TTL_SECONDS: '2592000',
+    });
+
+    const before = Date.now();
+    const token = await storage.refreshAccessToken('old-refresh-token');
+    const after = Date.now();
+
+    expect(token).not.toBeNull();
+    expect(updateEq).toHaveBeenCalledWith('access_token', 'old-access-token');
+    const refreshTokenExpiresAt = new Date(insertPayloads[0].refresh_token_expires_at as string).getTime();
+    expect(refreshTokenExpiresAt).toBeGreaterThanOrEqual(before + 2592000 * 1000 - 1000);
+    expect(refreshTokenExpiresAt).toBeLessThanOrEqual(after + 2592000 * 1000 + 1000);
+  });
+
+  it('rejects expired refresh tokens', async () => {
+    buildTableMock({
+      lookupRow: {
+        access_token: 'old-access-token',
+        refresh_token: 'old-refresh-token',
+        refresh_token_expires_at: new Date(Date.now() - 60_000).toISOString(),
+        revoked_at: null,
+        user_id: 'user_123',
+        scope: 'mcp:read',
+      },
+    });
+    const storage = new OAuthStorage('https://example.supabase.co', 'test-key');
+
+    await expect(storage.refreshAccessToken('old-refresh-token')).resolves.toBeNull();
+  });
+});

--- a/workers/auth-worker/src/__tests__/oauth-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/oauth-storage.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   DEFAULT_OAUTH_REFRESH_TOKEN_TTL_SECONDS,
   MAX_OAUTH_REFRESH_TOKEN_TTL_SECONDS,
+  MIN_OAUTH_REFRESH_TOKEN_TTL_SECONDS,
   OAuthStorage,
 } from '../oauth-storage';
 
@@ -22,10 +23,11 @@ function buildTableMock(options?: {
 }) {
   const insertPayloads: Record<string, unknown>[] = [];
 
-  const refreshableGt = vi.fn().mockResolvedValue({
+  const refreshableLimit = vi.fn().mockResolvedValue({
     data: options?.refreshableRows ?? [],
     error: options?.refreshableError ?? null,
   });
+  const refreshableGt = vi.fn().mockReturnValue({ limit: refreshableLimit });
   const refreshableNot = vi.fn().mockReturnValue({ gt: refreshableGt });
   const refreshableIs = vi.fn().mockReturnValue({ not: refreshableNot });
 
@@ -75,6 +77,7 @@ function buildTableMock(options?: {
     refreshableIs,
     refreshableNot,
     refreshableGt,
+    refreshableLimit,
     lookupSingle,
     update,
     updateEq,
@@ -152,6 +155,30 @@ describe('OAuthStorage MCP token lifetimes', () => {
     );
   });
 
+  it('uses the default when OAUTH_REFRESH_TOKEN_TTL_SECONDS env override is below minimum', async () => {
+    const { insertPayloads } = buildTableMock();
+    const storage = OAuthStorage.fromEnvironment({
+      SUPABASE_URL: 'https://example.supabase.co',
+      SUPABASE_SERVICE_KEY: 'test-key',
+      OAUTH_REFRESH_TOKEN_TTL_SECONDS: String(MIN_OAUTH_REFRESH_TOKEN_TTL_SECONDS - 1),
+    });
+
+    const before = Date.now();
+    await storage.createAccessToken({
+      userId: 'user_123',
+      includeRefreshToken: true,
+    });
+    const after = Date.now();
+
+    const refreshTokenExpiresAt = new Date(insertPayloads[0].refresh_token_expires_at as string).getTime();
+    expect(refreshTokenExpiresAt).toBeGreaterThanOrEqual(
+      before + DEFAULT_OAUTH_REFRESH_TOKEN_TTL_SECONDS * 1000 - 1000
+    );
+    expect(refreshTokenExpiresAt).toBeLessThanOrEqual(
+      after + DEFAULT_OAUTH_REFRESH_TOKEN_TTL_SECONDS * 1000 + 1000
+    );
+  });
+
   it('refresh rotation carries forward the configured refresh-token TTL', async () => {
     const { insertPayloads, updateEq } = buildTableMock({
       lookupRow: {
@@ -202,7 +229,7 @@ describe('OAuthStorage MCP token lifetimes', () => {
   it('gets refreshable user tokens using refresh-token expiry, not access-token expiry', async () => {
     const expiredAccessToken = new Date(Date.now() - 60 * 60 * 1000).toISOString();
     const validRefreshToken = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
-    const { refreshableIs, refreshableNot, refreshableGt } = buildTableMock({
+    const { refreshableIs, refreshableNot, refreshableGt, refreshableLimit } = buildTableMock({
       refreshableRows: [
         {
           id: 'token-id',
@@ -227,6 +254,7 @@ describe('OAuthStorage MCP token lifetimes', () => {
     expect(refreshableIs).toHaveBeenCalledWith('revoked_at', null);
     expect(refreshableNot).toHaveBeenCalledWith('refresh_token', 'is', null);
     expect(refreshableGt).toHaveBeenCalledWith('refresh_token_expires_at', expect.any(String));
+    expect(refreshableLimit).toHaveBeenCalledWith(50);
   });
 
   it('treats active connection status as refreshable token status', async () => {

--- a/workers/auth-worker/src/__tests__/oauth-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/oauth-storage.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { DEFAULT_OAUTH_REFRESH_TOKEN_TTL_SECONDS, OAuthStorage } from '../oauth-storage';
+import {
+  DEFAULT_OAUTH_REFRESH_TOKEN_TTL_SECONDS,
+  MAX_OAUTH_REFRESH_TOKEN_TTL_SECONDS,
+  OAuthStorage,
+} from '../oauth-storage';
 
 const mockFrom = vi.fn();
 
@@ -13,8 +17,17 @@ function buildTableMock(options?: {
   lookupRow?: Record<string, unknown> | null;
   lookupError?: unknown;
   insertId?: string;
+  refreshableRows?: Record<string, unknown>[];
+  refreshableError?: unknown;
 }) {
   const insertPayloads: Record<string, unknown>[] = [];
+
+  const refreshableGt = vi.fn().mockResolvedValue({
+    data: options?.refreshableRows ?? [],
+    error: options?.refreshableError ?? null,
+  });
+  const refreshableNot = vi.fn().mockReturnValue({ gt: refreshableGt });
+  const refreshableIs = vi.fn().mockReturnValue({ not: refreshableNot });
 
   const lookupSingle = vi.fn().mockResolvedValue({
     data: options?.lookupRow ?? null,
@@ -32,6 +45,10 @@ function buildTableMock(options?: {
     }
 
     return { single: insertSingle };
+  });
+  selectEq.mockReturnValue({
+    single: lookupSingle,
+    is: refreshableIs,
   });
 
   const insert = vi.fn((payload: Record<string, unknown>) => {
@@ -55,6 +72,9 @@ function buildTableMock(options?: {
     insert,
     select,
     selectEq,
+    refreshableIs,
+    refreshableNot,
+    refreshableGt,
     lookupSingle,
     update,
     updateEq,
@@ -108,6 +128,30 @@ describe('OAuthStorage MCP token lifetimes', () => {
     expect(refreshTokenExpiresAt).toBeLessThanOrEqual(after + 1209600 * 1000 + 1000);
   });
 
+  it('caps oversized OAUTH_REFRESH_TOKEN_TTL_SECONDS env override at 1 year', async () => {
+    const { insertPayloads } = buildTableMock();
+    const storage = OAuthStorage.fromEnvironment({
+      SUPABASE_URL: 'https://example.supabase.co',
+      SUPABASE_SERVICE_KEY: 'test-key',
+      OAUTH_REFRESH_TOKEN_TTL_SECONDS: '9999999999',
+    });
+
+    const before = Date.now();
+    await storage.createAccessToken({
+      userId: 'user_123',
+      includeRefreshToken: true,
+    });
+    const after = Date.now();
+
+    const refreshTokenExpiresAt = new Date(insertPayloads[0].refresh_token_expires_at as string).getTime();
+    expect(refreshTokenExpiresAt).toBeGreaterThanOrEqual(
+      before + MAX_OAUTH_REFRESH_TOKEN_TTL_SECONDS * 1000 - 1000
+    );
+    expect(refreshTokenExpiresAt).toBeLessThanOrEqual(
+      after + MAX_OAUTH_REFRESH_TOKEN_TTL_SECONDS * 1000 + 1000
+    );
+  });
+
   it('refresh rotation carries forward the configured refresh-token TTL', async () => {
     const { insertPayloads, updateEq } = buildTableMock({
       lookupRow: {
@@ -153,5 +197,54 @@ describe('OAuthStorage MCP token lifetimes', () => {
     const storage = new OAuthStorage('https://example.supabase.co', 'test-key');
 
     await expect(storage.refreshAccessToken('old-refresh-token')).resolves.toBeNull();
+  });
+
+  it('gets refreshable user tokens using refresh-token expiry, not access-token expiry', async () => {
+    const expiredAccessToken = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const validRefreshToken = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+    const { refreshableIs, refreshableNot, refreshableGt } = buildTableMock({
+      refreshableRows: [
+        {
+          id: 'token-id',
+          access_token: 'expired-access-token',
+          user_id: 'user_123',
+          scope: 'mcp:read',
+          resource: 'https://api.flaim.app/mcp',
+          client_name: 'Perplexity',
+          expires_at: expiredAccessToken,
+          refresh_token: 'valid-refresh-token',
+          refresh_token_expires_at: validRefreshToken,
+        },
+      ],
+    });
+    const storage = new OAuthStorage('https://example.supabase.co', 'test-key');
+
+    const tokens = await storage.getRefreshableUserTokens('user_123');
+
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0].accessToken).toBe('expired-access-token');
+    expect(tokens[0].refreshToken).toBe('valid-refresh-token');
+    expect(refreshableIs).toHaveBeenCalledWith('revoked_at', null);
+    expect(refreshableNot).toHaveBeenCalledWith('refresh_token', 'is', null);
+    expect(refreshableGt).toHaveBeenCalledWith('refresh_token_expires_at', expect.any(String));
+  });
+
+  it('treats active connection status as refreshable token status', async () => {
+    buildTableMock({
+      refreshableRows: [
+        {
+          id: 'token-id',
+          access_token: 'expired-access-token',
+          user_id: 'user_123',
+          scope: 'mcp:read',
+          expires_at: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+          refresh_token: 'valid-refresh-token',
+          refresh_token_expires_at: new Date(Date.now() + 60_000).toISOString(),
+        },
+      ],
+    });
+    const storage = new OAuthStorage('https://example.supabase.co', 'test-key');
+
+    await expect(storage.hasActiveConnection('user_123')).resolves.toBe(true);
   });
 });

--- a/workers/auth-worker/src/__tests__/oauth-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/oauth-storage.test.ts
@@ -40,17 +40,16 @@ function buildTableMock(options?: {
     error: null,
   });
 
-  const selectEq = vi.fn().mockReturnValue({ single: lookupSingle });
+  const selectEq = vi.fn().mockReturnValue({
+    single: lookupSingle,
+    is: refreshableIs,
+  });
   const select = vi.fn((columns?: string) => {
     if (columns === '*') {
       return { eq: selectEq };
     }
 
     return { single: insertSingle };
-  });
-  selectEq.mockReturnValue({
-    single: lookupSingle,
-    is: refreshableIs,
   });
 
   const insert = vi.fn((payload: Record<string, unknown>) => {
@@ -254,6 +253,14 @@ describe('OAuthStorage MCP token lifetimes', () => {
     expect(refreshableIs).toHaveBeenCalledWith('revoked_at', null);
     expect(refreshableNot).toHaveBeenCalledWith('refresh_token', 'is', null);
     expect(refreshableGt).toHaveBeenCalledWith('refresh_token_expires_at', expect.any(String));
+    expect(refreshableLimit).toHaveBeenCalledWith(50);
+  });
+
+  it('returns no refreshable user tokens when none match', async () => {
+    const { refreshableLimit } = buildTableMock({ refreshableRows: [] });
+    const storage = new OAuthStorage('https://example.supabase.co', 'test-key');
+
+    await expect(storage.getRefreshableUserTokens('user_123')).resolves.toEqual([]);
     expect(refreshableLimit).toHaveBeenCalledWith(50);
   });
 

--- a/workers/auth-worker/src/index-hono.ts
+++ b/workers/auth-worker/src/index-hono.ts
@@ -82,6 +82,7 @@ export interface Env {
   NODE_ENV?: string;
   ENVIRONMENT?: string; // 'dev' | 'preview' | 'prod'
   FRONTEND_URL?: string;
+  OAUTH_REFRESH_TOKEN_TTL_SECONDS?: string; // MCP OAuth refresh-token inactivity TTL
   CLERK_ISSUER?: string; // Expected Clerk JWT issuer (e.g. "https://clerk.flaim.app")
   // Yahoo OAuth
   YAHOO_CLIENT_ID?: string;

--- a/workers/auth-worker/src/oauth-handlers.ts
+++ b/workers/auth-worker/src/oauth-handlers.ts
@@ -31,6 +31,7 @@ export interface OAuthEnv {
   NODE_ENV?: string;
   ENVIRONMENT?: string;
   FRONTEND_URL?: string;
+  OAUTH_REFRESH_TOKEN_TTL_SECONDS?: string;
 }
 
 interface AuthorizeParams {
@@ -681,7 +682,7 @@ export async function validateOAuthToken(
 
 /**
  * Check active connection status
- * Used by frontend to see if user has connected Claude/ChatGPT
+ * Used by frontend to see if user has refreshable MCP OAuth connections.
  */
 export async function handleCheckStatus(
   env: OAuthEnv,
@@ -690,12 +691,13 @@ export async function handleCheckStatus(
 ): Promise<Response> {
   try {
     const storage = OAuthStorage.fromEnvironment(env);
-    const tokens = await storage.getUserTokens(userId);
+    const tokens = await storage.getRefreshableUserTokens(userId);
 
     // Map to safe public format for display
     const connections = tokens.map(t => ({
       id: t.id, // Real ID for revocation
       expiresAt: t.expiresAt.toISOString(),
+      refreshTokenExpiresAt: t.refreshTokenExpiresAt?.toISOString(),
       scope: t.scope,
       clientName: t.clientName || 'MCP Client',
     }));

--- a/workers/auth-worker/src/oauth-handlers.ts
+++ b/workers/auth-worker/src/oauth-handlers.ts
@@ -697,7 +697,6 @@ export async function handleCheckStatus(
     const connections = tokens.map(t => ({
       id: t.id, // Real ID for revocation
       expiresAt: t.expiresAt.toISOString(),
-      refreshTokenExpiresAt: t.refreshTokenExpiresAt?.toISOString(),
       scope: t.scope,
       clientName: t.clientName || 'MCP Client',
     }));

--- a/workers/auth-worker/src/oauth-storage.ts
+++ b/workers/auth-worker/src/oauth-storage.ts
@@ -88,6 +88,7 @@ export interface TokenValidationResult {
 
 export const DEFAULT_OAUTH_ACCESS_TOKEN_TTL_SECONDS = 3600; // 1 hour
 export const DEFAULT_OAUTH_REFRESH_TOKEN_TTL_SECONDS = 7776000; // 90 days
+export const MAX_OAUTH_REFRESH_TOKEN_TTL_SECONDS = 31536000; // 1 year
 
 export interface OAuthStorageEnv {
   SUPABASE_URL: string;
@@ -686,7 +687,12 @@ export class OAuthStorage {
       .not('refresh_token', 'is', null)
       .gt('refresh_token_expires_at', new Date().toISOString());
 
-    if (error || !data) {
+    if (error) {
+      console.error('[oauth-storage] Failed to get refreshable user tokens:', error);
+      return [];
+    }
+
+    if (!data) {
       return [];
     }
 
@@ -706,7 +712,7 @@ export class OAuthStorage {
   }
 
   /**
-   * Check if a user has any active OAuth connections
+   * Check if a user has any active refreshable MCP OAuth connections.
    */
   async hasActiveConnection(userId: string): Promise<boolean> {
     const tokens = await this.getRefreshableUserTokens(userId);
@@ -738,6 +744,13 @@ function parseRefreshTokenTtlSeconds(value?: string): number {
       `[oauth-storage] Invalid OAUTH_REFRESH_TOKEN_TTL_SECONDS="${value}", using default ${DEFAULT_OAUTH_REFRESH_TOKEN_TTL_SECONDS}s`
     );
     return DEFAULT_OAUTH_REFRESH_TOKEN_TTL_SECONDS;
+  }
+
+  if (parsed > MAX_OAUTH_REFRESH_TOKEN_TTL_SECONDS) {
+    console.warn(
+      `[oauth-storage] OAUTH_REFRESH_TOKEN_TTL_SECONDS="${value}" exceeds max, clamping to ${MAX_OAUTH_REFRESH_TOKEN_TTL_SECONDS}s`
+    );
+    return MAX_OAUTH_REFRESH_TOKEN_TTL_SECONDS;
   }
 
   return Math.floor(parsed);

--- a/workers/auth-worker/src/oauth-storage.ts
+++ b/workers/auth-worker/src/oauth-storage.ts
@@ -88,6 +88,7 @@ export interface TokenValidationResult {
 
 export const DEFAULT_OAUTH_ACCESS_TOKEN_TTL_SECONDS = 3600; // 1 hour
 export const DEFAULT_OAUTH_REFRESH_TOKEN_TTL_SECONDS = 7776000; // 90 days
+export const MIN_OAUTH_REFRESH_TOKEN_TTL_SECONDS = 3600; // 1 hour
 export const MAX_OAUTH_REFRESH_TOKEN_TTL_SECONDS = 31536000; // 1 year
 
 export interface OAuthStorageEnv {
@@ -646,7 +647,10 @@ export class OAuthStorage {
   }
 
   /**
-   * Get all active tokens for a user
+   * Get all currently valid access tokens for a user.
+   *
+   * Connection status should use getRefreshableUserTokens so an idle MCP
+   * client remains connected between one-hour access token refreshes.
    */
   async getUserTokens(userId: string): Promise<OAuthToken[]> {
     const { data, error } = await this.supabase
@@ -685,7 +689,8 @@ export class OAuthStorage {
       .eq('user_id', userId)
       .is('revoked_at', null)
       .not('refresh_token', 'is', null)
-      .gt('refresh_token_expires_at', new Date().toISOString());
+      .gt('refresh_token_expires_at', new Date().toISOString())
+      .limit(50);
 
     if (error) {
       console.error('[oauth-storage] Failed to get refreshable user tokens:', error);
@@ -742,6 +747,13 @@ function parseRefreshTokenTtlSeconds(value?: string): number {
   if (!Number.isFinite(parsed) || parsed <= 0) {
     console.warn(
       `[oauth-storage] Invalid OAUTH_REFRESH_TOKEN_TTL_SECONDS="${value}", using default ${DEFAULT_OAUTH_REFRESH_TOKEN_TTL_SECONDS}s`
+    );
+    return DEFAULT_OAUTH_REFRESH_TOKEN_TTL_SECONDS;
+  }
+
+  if (parsed < MIN_OAUTH_REFRESH_TOKEN_TTL_SECONDS) {
+    console.warn(
+      `[oauth-storage] OAUTH_REFRESH_TOKEN_TTL_SECONDS="${value}" is below minimum, using default ${DEFAULT_OAUTH_REFRESH_TOKEN_TTL_SECONDS}s`
     );
     return DEFAULT_OAUTH_REFRESH_TOKEN_TTL_SECONDS;
   }

--- a/workers/auth-worker/src/oauth-storage.ts
+++ b/workers/auth-worker/src/oauth-storage.ts
@@ -753,9 +753,9 @@ function parseRefreshTokenTtlSeconds(value?: string): number {
 
   if (parsed < MIN_OAUTH_REFRESH_TOKEN_TTL_SECONDS) {
     console.warn(
-      `[oauth-storage] OAUTH_REFRESH_TOKEN_TTL_SECONDS="${value}" is below minimum, using default ${DEFAULT_OAUTH_REFRESH_TOKEN_TTL_SECONDS}s`
+      `[oauth-storage] OAUTH_REFRESH_TOKEN_TTL_SECONDS="${value}" is below minimum, clamping to ${MIN_OAUTH_REFRESH_TOKEN_TTL_SECONDS}s`
     );
-    return DEFAULT_OAUTH_REFRESH_TOKEN_TTL_SECONDS;
+    return MIN_OAUTH_REFRESH_TOKEN_TTL_SECONDS;
   }
 
   if (parsed > MAX_OAUTH_REFRESH_TOKEN_TTL_SECONDS) {

--- a/workers/auth-worker/src/oauth-storage.ts
+++ b/workers/auth-worker/src/oauth-storage.ts
@@ -68,7 +68,7 @@ export interface CreateTokenParams {
   clientName?: string; // AI platform name (Claude, ChatGPT, etc.)
   expiresInSeconds?: number; // Default: 3600 (1 hour)
   includeRefreshToken?: boolean;
-  refreshTokenExpiresInSeconds?: number; // Default: 604800 (7 days)
+  refreshTokenExpiresInSeconds?: number; // Default: 7776000 (90 days)
 }
 
 export interface CreateStateParams {
@@ -84,6 +84,15 @@ export interface TokenValidationResult {
   scope?: string;
   resource?: string | null;
   error?: string;
+}
+
+export const DEFAULT_OAUTH_ACCESS_TOKEN_TTL_SECONDS = 3600; // 1 hour
+export const DEFAULT_OAUTH_REFRESH_TOKEN_TTL_SECONDS = 7776000; // 90 days
+
+export interface OAuthStorageEnv {
+  SUPABASE_URL: string;
+  SUPABASE_SERVICE_KEY: string;
+  OAUTH_REFRESH_TOKEN_TTL_SECONDS?: string;
 }
 
 // =============================================================================
@@ -200,9 +209,11 @@ function redirectUrisMatch(expectedRedirectUri: string, actualRedirectUri: strin
 
 export class OAuthStorage {
   private supabase: SupabaseClient;
+  private refreshTokenTtlSeconds: number;
 
-  constructor(supabaseUrl: string, supabaseKey: string) {
+  constructor(supabaseUrl: string, supabaseKey: string, options?: { refreshTokenTtlSeconds?: number }) {
     this.supabase = createClient(supabaseUrl, supabaseKey);
+    this.refreshTokenTtlSeconds = options?.refreshTokenTtlSeconds ?? DEFAULT_OAUTH_REFRESH_TOKEN_TTL_SECONDS;
   }
 
   // ---------------------------------------------------------------------------
@@ -445,7 +456,7 @@ export class OAuthStorage {
    */
   async createAccessToken(params: CreateTokenParams): Promise<OAuthToken> {
     const accessToken = generateSecureToken(32);
-    const expiresInSeconds = params.expiresInSeconds ?? 3600; // 1 hour default
+    const expiresInSeconds = params.expiresInSeconds ?? DEFAULT_OAUTH_ACCESS_TOKEN_TTL_SECONDS; // 1 hour default
     const expiresAt = new Date(Date.now() + expiresInSeconds * 1000);
 
     // Derive clientName from redirectUri if not explicitly provided
@@ -456,7 +467,7 @@ export class OAuthStorage {
 
     if (params.includeRefreshToken) {
       refreshToken = generateSecureToken(32);
-      const refreshExpiresIn = params.refreshTokenExpiresInSeconds ?? 604800; // 7 days default
+      const refreshExpiresIn = params.refreshTokenExpiresInSeconds ?? this.refreshTokenTtlSeconds;
       refreshTokenExpiresAt = new Date(Date.now() + refreshExpiresIn * 1000);
     }
 
@@ -664,10 +675,41 @@ export class OAuthStorage {
   }
 
   /**
+   * Get all connections that can still be refreshed for a user.
+   */
+  async getRefreshableUserTokens(userId: string): Promise<OAuthToken[]> {
+    const { data, error } = await this.supabase
+      .from('oauth_tokens')
+      .select('*')
+      .eq('user_id', userId)
+      .is('revoked_at', null)
+      .not('refresh_token', 'is', null)
+      .gt('refresh_token_expires_at', new Date().toISOString());
+
+    if (error || !data) {
+      return [];
+    }
+
+    return data.map((row) => ({
+      id: row.id,
+      accessToken: row.access_token,
+      userId: row.user_id,
+      scope: row.scope,
+      resource: row.resource || undefined,
+      clientName: row.client_name || 'MCP Client',
+      expiresAt: new Date(row.expires_at),
+      refreshToken: row.refresh_token || undefined,
+      refreshTokenExpiresAt: row.refresh_token_expires_at
+        ? new Date(row.refresh_token_expires_at)
+        : undefined,
+    }));
+  }
+
+  /**
    * Check if a user has any active OAuth connections
    */
   async hasActiveConnection(userId: string): Promise<boolean> {
-    const tokens = await this.getUserTokens(userId);
+    const tokens = await this.getRefreshableUserTokens(userId);
     return tokens.length > 0;
   }
 
@@ -678,7 +720,25 @@ export class OAuthStorage {
   /**
    * Create instance from environment variables
    */
-  static fromEnvironment(env: { SUPABASE_URL: string; SUPABASE_SERVICE_KEY: string }): OAuthStorage {
-    return new OAuthStorage(env.SUPABASE_URL, env.SUPABASE_SERVICE_KEY);
+  static fromEnvironment(env: OAuthStorageEnv): OAuthStorage {
+    return new OAuthStorage(env.SUPABASE_URL, env.SUPABASE_SERVICE_KEY, {
+      refreshTokenTtlSeconds: parseRefreshTokenTtlSeconds(env.OAUTH_REFRESH_TOKEN_TTL_SECONDS),
+    });
   }
+}
+
+function parseRefreshTokenTtlSeconds(value?: string): number {
+  if (!value) {
+    return DEFAULT_OAUTH_REFRESH_TOKEN_TTL_SECONDS;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    console.warn(
+      `[oauth-storage] Invalid OAUTH_REFRESH_TOKEN_TTL_SECONDS="${value}", using default ${DEFAULT_OAUTH_REFRESH_TOKEN_TTL_SECONDS}s`
+    );
+    return DEFAULT_OAUTH_REFRESH_TOKEN_TTL_SECONDS;
+  }
+
+  return Math.floor(parsed);
 }

--- a/workers/auth-worker/src/oauth-storage.ts
+++ b/workers/auth-worker/src/oauth-storage.ts
@@ -68,7 +68,7 @@ export interface CreateTokenParams {
   clientName?: string; // AI platform name (Claude, ChatGPT, etc.)
   expiresInSeconds?: number; // Default: 3600 (1 hour)
   includeRefreshToken?: boolean;
-  refreshTokenExpiresInSeconds?: number; // Default: 7776000 (90 days)
+  refreshTokenExpiresInSeconds?: number; // Default: 31536000 (1 year)
 }
 
 export interface CreateStateParams {
@@ -87,7 +87,7 @@ export interface TokenValidationResult {
 }
 
 export const DEFAULT_OAUTH_ACCESS_TOKEN_TTL_SECONDS = 3600; // 1 hour
-export const DEFAULT_OAUTH_REFRESH_TOKEN_TTL_SECONDS = 7776000; // 90 days
+export const DEFAULT_OAUTH_REFRESH_TOKEN_TTL_SECONDS = 31536000; // 1 year
 export const MIN_OAUTH_REFRESH_TOKEN_TTL_SECONDS = 3600; // 1 hour
 export const MAX_OAUTH_REFRESH_TOKEN_TTL_SECONDS = 31536000; // 1 year
 

--- a/workers/auth-worker/src/oauth-storage.ts
+++ b/workers/auth-worker/src/oauth-storage.ts
@@ -651,6 +651,9 @@ export class OAuthStorage {
    *
    * Connection status should use getRefreshableUserTokens so an idle MCP
    * client remains connected between one-hour access token refreshes.
+   *
+   * @deprecated Use getRefreshableUserTokens for connection status. This only
+   * reflects current access-token validity.
    */
   async getUserTokens(userId: string): Promise<OAuthToken[]> {
     const { data, error } = await this.supabase
@@ -681,6 +684,9 @@ export class OAuthStorage {
 
   /**
    * Get all connections that can still be refreshed for a user.
+   *
+   * Returns raw token fields for server-side management. Do not expose returned
+   * OAuthToken objects directly to clients.
    */
   async getRefreshableUserTokens(userId: string): Promise<OAuthToken[]> {
     const { data, error } = await this.supabase

--- a/workers/auth-worker/wrangler.jsonc
+++ b/workers/auth-worker/wrangler.jsonc
@@ -16,6 +16,8 @@
   // - SUPABASE_SERVICE_KEY
   // - YAHOO_CLIENT_ID      (Yahoo Developer App)
   // - YAHOO_CLIENT_SECRET  (Yahoo Developer App)
+  // Optional vars:
+  // - OAUTH_REFRESH_TOKEN_TTL_SECONDS (defaults to 7776000 in code; set only to override)
 
   // Environment configurations
   "env": {
@@ -73,8 +75,7 @@
       "vars": {
         "NODE_ENV": "production",
         "ENVIRONMENT": "prod",
-        "FRONTEND_URL": "https://flaim.app",
-        "OAUTH_REFRESH_TOKEN_TTL_SECONDS": "7776000"
+        "FRONTEND_URL": "https://flaim.app"
       }
     },
     // Preview environment (remote dev/staging)
@@ -111,8 +112,7 @@
       "vars": {
         "NODE_ENV": "production",
         "ENVIRONMENT": "preview",
-        "FRONTEND_URL": "https://preview.flaim.app",
-        "OAUTH_REFRESH_TOKEN_TTL_SECONDS": "7776000"
+        "FRONTEND_URL": "https://preview.flaim.app"
       }
     },
     // Development environment (local)
@@ -136,8 +136,7 @@
       "vars": {
         "NODE_ENV": "development",
         "ENVIRONMENT": "dev",
-        "FRONTEND_URL": "http://localhost:3000",
-        "OAUTH_REFRESH_TOKEN_TTL_SECONDS": "7776000"
+        "FRONTEND_URL": "http://localhost:3000"
       }
     }
   }

--- a/workers/auth-worker/wrangler.jsonc
+++ b/workers/auth-worker/wrangler.jsonc
@@ -73,7 +73,8 @@
       "vars": {
         "NODE_ENV": "production",
         "ENVIRONMENT": "prod",
-        "FRONTEND_URL": "https://flaim.app"
+        "FRONTEND_URL": "https://flaim.app",
+        "OAUTH_REFRESH_TOKEN_TTL_SECONDS": "7776000"
       }
     },
     // Preview environment (remote dev/staging)
@@ -110,7 +111,8 @@
       "vars": {
         "NODE_ENV": "production",
         "ENVIRONMENT": "preview",
-        "FRONTEND_URL": "https://preview.flaim.app"
+        "FRONTEND_URL": "https://preview.flaim.app",
+        "OAUTH_REFRESH_TOKEN_TTL_SECONDS": "7776000"
       }
     },
     // Development environment (local)
@@ -134,7 +136,8 @@
       "vars": {
         "NODE_ENV": "development",
         "ENVIRONMENT": "dev",
-        "FRONTEND_URL": "http://localhost:3000"
+        "FRONTEND_URL": "http://localhost:3000",
+        "OAUTH_REFRESH_TOKEN_TTL_SECONDS": "7776000"
       }
     }
   }


### PR DESCRIPTION
## Summary

Extends Flaim's provider-side MCP OAuth refresh-token inactivity window from 7 days to 1 year while preserving the short-lived 1-hour access token model.

This is separate from Yahoo OAuth. It covers Claude, ChatGPT, Perplexity, Gemini, and other clients authenticating to Flaim's MCP server.

## Changes

- Keep MCP access tokens at 1 hour.
- Default MCP refresh-token inactivity TTL to 1 year (`31536000` seconds), matching the annual sports season cadence.
- Add `OAUTH_REFRESH_TOKEN_TTL_SECONDS` env override with 1-hour minimum and 1-year maximum clamping.
- Preserve refresh-token rotation on every successful refresh.
- Make `/oauth/status` report active connections based on non-revoked, non-expired refresh tokens instead of only unexpired access tokens.
- Keep refresh-token expiry metadata server-side; `/oauth/status` does not expose refresh-token timing to the browser.
- Add OAuth storage and handler tests for default TTL, env override, min/max clamping, refresh rotation, expired refresh tokens, refreshable-token query shape, and status after access-token expiry.
- Update docs/changelog for the MCP OAuth refresh-token inactivity window and tracked backfill SQL.

## Backfill Recommendation

We should backfill existing non-revoked, still-valid `oauth_tokens.refresh_token_expires_at` rows so current Perplexity users inherit the longer 1-year window without needing one more reconnect. Do not revive already-expired or revoked tokens.

Suggested SQL shape:

```sql
UPDATE oauth_tokens
SET refresh_token_expires_at = GREATEST(
  refresh_token_expires_at,
  now() + interval '1 year'
)
WHERE refresh_token IS NOT NULL
  AND revoked_at IS NULL
  AND refresh_token_expires_at > now();
```

## Validation

- `corepack pnpm --dir workers/auth-worker test src/__tests__/oauth-storage.test.ts`
- `corepack pnpm --dir workers/auth-worker test src/__tests__/oauth-handlers.test.ts`
- `corepack pnpm --dir workers/auth-worker type-check`
- `corepack pnpm --dir workers/auth-worker test`
- `corepack pnpm --dir workers/auth-worker exec wrangler deploy --dry-run --env prod`
- `corepack pnpm --dir web exec tsc --noEmit`
- `git diff --check`

Note: local Node is `v26.0.0`; `workers/auth-worker` declares `24.x`, so pnpm prints an engine warning locally.
