### PR TITLE
[codex] Add Yahoo auth observability

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ Follow Keep a Changelog; stamp a version when submitting to directories.
 - **Fixed**: Removed stale dev-only chat framing and cleaned unresolved merge-conflict markers from `docs/ARCHITECTURE.md`.
 
 ### Yahoo Connection Reliability
+- **Added**: Yahoo token-refresh diagnostics now emit structured non-secret refresh events and expose an internal credential-health endpoint for production incident triage.
 - **Changed**: Yahoo Refresh on `/leagues` now uses the stored connection to rediscover leagues instead of starting a fresh OAuth flow every time.
 - **Changed**: Yahoo refresh lease waiters now return an explicit retryable response before the MCP gateway timeout budget is exhausted.
 - **Fixed**: Yahoo league discovery rate limits (`429`/`999`) and transient upstream failures now return retryable responses with `Retry-After` instead of generic refresh failures.

--- a/workers/auth-worker/README.md
+++ b/workers/auth-worker/README.md
@@ -57,6 +57,8 @@ These endpoints manage the OAuth 2.0 client flow with Yahoo Fantasy.
 | `GET /internal/leagues/yahoo` | Internal + Clerk JWT / OAuth / Eval key | Get stored Yahoo leagues for internal workers |
 | `DELETE /leagues/yahoo/:id` | Clerk JWT | Delete a Yahoo league |
 
+`/internal/connect/yahoo/credential-health` returns no access or refresh tokens. Its `refresh.state` can be `idle`, `in_progress`, `cooldown`, or `expired`; `leaseExpiresAt` is included when a lease timestamp exists, while `retryAfterSeconds` is only included for active `in_progress` or `cooldown` waits.
+
 ### Sleeper Connect
 
 | Endpoint | Auth | Purpose |

--- a/workers/auth-worker/README.md
+++ b/workers/auth-worker/README.md
@@ -49,6 +49,7 @@ These endpoints manage the OAuth 2.0 client flow with Yahoo Fantasy.
 | `GET /connect/yahoo/authorize` | Clerk JWT | Start Yahoo OAuth flow |
 | `GET /connect/yahoo/callback` | None (state param) | Handle Yahoo redirect |
 | `GET /internal/connect/yahoo/credentials` | Internal + Clerk JWT / OAuth / Eval key | Get Yahoo tokens (auto-refreshes) for internal workers |
+| `GET /internal/connect/yahoo/credential-health` | Internal + Clerk JWT / OAuth | Non-secret Yahoo credential/refresh health for diagnostics |
 | `GET /connect/yahoo/status` | Clerk JWT | Check Yahoo connection status |
 | `DELETE /connect/yahoo/disconnect` | Clerk JWT | Remove Yahoo connection |
 | `POST /connect/yahoo/discover` | Clerk JWT | Discover Yahoo leagues |

--- a/workers/auth-worker/README.md
+++ b/workers/auth-worker/README.md
@@ -57,7 +57,7 @@ These endpoints manage the OAuth 2.0 client flow with Yahoo Fantasy.
 | `GET /internal/leagues/yahoo` | Internal + Clerk JWT / OAuth / Eval key | Get stored Yahoo leagues for internal workers |
 | `DELETE /leagues/yahoo/:id` | Clerk JWT | Delete a Yahoo league |
 
-`/internal/connect/yahoo/credential-health` returns no access or refresh tokens. Its `refresh.state` can be `idle`, `in_progress`, `cooldown`, or `expired`; `leaseExpiresAt` is included when a lease owner and timestamp exist, while `retryAfterSeconds` is only included for active `in_progress` or `cooldown` waits.
+`/internal/connect/yahoo/credential-health` returns no access or refresh tokens. Its `refresh.state` can be `idle`, `in_progress`, `cooldown`, or `expired`; `leaseExpiresAt` is included when a lease owner and timestamp exist, including past timestamps for `expired` leases, while `retryAfterSeconds` is only included for active `in_progress` or `cooldown` waits. `lastUpdated` is `null` when the credential row has no update timestamp.
 
 ### Sleeper Connect
 

--- a/workers/auth-worker/README.md
+++ b/workers/auth-worker/README.md
@@ -57,7 +57,7 @@ These endpoints manage the OAuth 2.0 client flow with Yahoo Fantasy.
 | `GET /internal/leagues/yahoo` | Internal + Clerk JWT / OAuth / Eval key | Get stored Yahoo leagues for internal workers |
 | `DELETE /leagues/yahoo/:id` | Clerk JWT | Delete a Yahoo league |
 
-`/internal/connect/yahoo/credential-health` returns no access or refresh tokens. Its `refresh.state` can be `idle`, `in_progress`, `cooldown`, or `expired`; `leaseExpiresAt` is included when a lease timestamp exists, while `retryAfterSeconds` is only included for active `in_progress` or `cooldown` waits.
+`/internal/connect/yahoo/credential-health` returns no access or refresh tokens. Its `refresh.state` can be `idle`, `in_progress`, `cooldown`, or `expired`; `leaseExpiresAt` is included when a lease owner and timestamp exist, while `retryAfterSeconds` is only included for active `in_progress` or `cooldown` waits.
 
 ### Sleeper Connect
 

--- a/workers/auth-worker/src/__tests__/eval-api-key.test.ts
+++ b/workers/auth-worker/src/__tests__/eval-api-key.test.ts
@@ -102,6 +102,9 @@ vi.mock('../yahoo-connect-handlers', () => ({
   handleYahooCredentials: vi.fn().mockResolvedValue(
     new Response(JSON.stringify({ access_token: 'test' }), { status: 200 })
   ),
+  handleYahooCredentialHealth: vi.fn().mockResolvedValue(
+    new Response(JSON.stringify({ connected: true }), { status: 200 })
+  ),
   handleYahooDisconnect: vi.fn(),
   handleYahooDiscover: vi.fn(),
   handleYahooStatus: vi.fn(),
@@ -209,6 +212,15 @@ describe('eval API key auth', () => {
       })
     );
     expect(res.status).toBe(200);
+  });
+
+  it('GET /auth/internal/connect/yahoo/credential-health rejects static API keys', async () => {
+    const res = await appFetch(
+      makeRequest('/auth/internal/connect/yahoo/credential-health', {
+        headers: internalHeaders(EVAL_API_KEY),
+      })
+    );
+    expect(res.status).toBe(401);
   });
 
   it('GET /auth/internal/user/preferences with valid API key returns preferences', async () => {

--- a/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
@@ -1333,6 +1333,7 @@ describe('yahoo-connect-handlers', () => {
           yahooGuidPresent: true,
           needsRefresh: false,
           updatedAt,
+          refreshLeaseExpiresAt: new Date('2026-05-12T01:31:00Z'),
         });
 
         const response = await handleYahooCredentialHealth(env, 'user_123', corsHeaders);

--- a/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
@@ -1396,6 +1396,34 @@ describe('yahoo-connect-handlers', () => {
       }
     });
 
+    it('returns in-progress state with retry timing without exposing the lease owner', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-05-12T01:30:00Z'));
+      try {
+        mockStorage.getYahooCredentialHealth.mockResolvedValue({
+          clerkUserId: 'user_123',
+          expiresAt: new Date('2026-05-12T01:31:00Z'),
+          yahooGuidPresent: true,
+          needsRefresh: true,
+          refreshLeaseOwner: 'refresh:owner-1',
+          refreshLeaseExpiresAt: new Date('2026-05-12T01:30:45Z'),
+        });
+
+        const response = await handleYahooCredentialHealth(env, 'user_123', corsHeaders);
+
+        expect(response.status).toBe(200);
+        const body = (await response.json()) as Record<string, unknown>;
+        expect(body.refresh).toEqual({
+          state: 'in_progress',
+          leaseExpiresAt: '2026-05-12T01:30:45.000Z',
+          retryAfterSeconds: 45,
+        });
+        expect(JSON.stringify(body)).not.toContain('owner-1');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('returns expired lease state without exposing the lease owner', async () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date('2026-05-12T01:30:00Z'));

--- a/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
@@ -1634,6 +1634,7 @@ describe('yahoo-connect-handlers', () => {
     });
 
     it('returns retryable 503 from discovery path for transient Yahoo refresh response', async () => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
       mockStorage.getYahooCredentials.mockResolvedValue({
         clerkUserId: 'user_123',
         accessToken: 'old-token',
@@ -1649,7 +1650,7 @@ describe('yahoo-connect-handlers', () => {
         })
       );
 
-      const response = await handleYahooDiscover(env, 'user_123', corsHeaders);
+      const response = await handleYahooDiscover(env, 'user_123', corsHeaders, 'req_discover');
 
       expect(response.status).toBe(503);
       const body = (await response.json()) as Record<string, unknown>;
@@ -1660,6 +1661,22 @@ describe('yahoo-connect-handlers', () => {
       expect(mockStorage.markRefreshCooldown).toHaveBeenCalledWith('user_123', expect.any(String), 60);
       expect(mockStorage.updateYahooCredentials).not.toHaveBeenCalled();
       expect(mockStorage.upsertYahooLeague).not.toHaveBeenCalled();
+      expect(yahooRefreshDiagnostics(logSpy)).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            event: 'refresh_response_error',
+            correlation_id: 'req_discover',
+          }),
+          expect.objectContaining({
+            event: 'refresh_transient_failure',
+            correlation_id: 'req_discover',
+          }),
+          expect.objectContaining({
+            event: 'cooldown_mark_attempted',
+            correlation_id: 'req_discover',
+          }),
+        ])
+      );
     });
 
     it('returns retryable rate-limit response when Yahoo league discovery returns HTTP 999', async () => {

--- a/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
@@ -1467,6 +1467,7 @@ describe('yahoo-connect-handlers', () => {
 
         expect(response.status).toBe(200);
         const body = (await response.json()) as Record<string, unknown>;
+        expect(body.lastUpdated).toBeNull();
         expect(body.accessToken).toMatchObject({
           expiresAt: '2026-05-12T01:29:30.000Z',
           expiresInSeconds: 0,
@@ -1574,6 +1575,7 @@ describe('yahoo-connect-handlers', () => {
     });
 
     it('returns retryable 503 when a refresh lease stays active too long', async () => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
       vi.useFakeTimers();
 
       const stale = {
@@ -1590,7 +1592,7 @@ describe('yahoo-connect-handlers', () => {
       mockStorage.acquireRefreshLease.mockResolvedValue(false);
 
       try {
-        const responsePromise = handleYahooDiscover(env, 'user_123', corsHeaders);
+        const responsePromise = handleYahooDiscover(env, 'user_123', corsHeaders, 'req_wait_timeout');
         await vi.advanceTimersByTimeAsync(10_001);
         const response = await responsePromise;
 
@@ -1601,6 +1603,15 @@ describe('yahoo-connect-handlers', () => {
         expect(body.retryable).toBe(true);
         expect(body.retry_after).toBe(5);
         expect(mockFetch).not.toHaveBeenCalled();
+        expect(yahooRefreshDiagnostics(logSpy)).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              event: 'lease_wait_timeout',
+              correlation_id: 'req_wait_timeout',
+              retry_after: 5,
+            }),
+          ])
+        );
       } finally {
         vi.useRealTimers();
       }

--- a/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
@@ -3,6 +3,7 @@ import {
   handleYahooAuthorize,
   handleYahooCallback,
   handleYahooCredentials,
+  handleYahooCredentialHealth,
   handleYahooDisconnect,
   handleYahooDiscover,
   handleYahooStatus,
@@ -34,12 +35,26 @@ const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
 };
 
+function yahooRefreshDiagnostics(spy: { mock: { calls: unknown[][] } }): Array<Record<string, unknown>> {
+  return spy.mock.calls
+    .map(call => String(call[0]))
+    .map((line) => {
+      try {
+        return JSON.parse(line) as Record<string, unknown>;
+      } catch {
+        return null;
+      }
+    })
+    .filter((entry): entry is Record<string, unknown> => entry?.component === 'yahoo-connect');
+}
+
 describe('yahoo-connect-handlers', () => {
   let mockStorage: {
     createPlatformOAuthState: ReturnType<typeof vi.fn>;
     consumePlatformOAuthState: ReturnType<typeof vi.fn>;
     saveYahooCredentials: ReturnType<typeof vi.fn>;
     getYahooCredentials: ReturnType<typeof vi.fn>;
+    getYahooCredentialHealth: ReturnType<typeof vi.fn>;
     updateYahooCredentials: ReturnType<typeof vi.fn>;
     acquireRefreshLease: ReturnType<typeof vi.fn>;
     releaseRefreshLease: ReturnType<typeof vi.fn>;
@@ -59,6 +74,7 @@ describe('yahoo-connect-handlers', () => {
       consumePlatformOAuthState: vi.fn(),
       saveYahooCredentials: vi.fn().mockResolvedValue(undefined),
       getYahooCredentials: vi.fn(),
+      getYahooCredentialHealth: vi.fn(),
       updateYahooCredentials: vi.fn().mockResolvedValue(true),
       acquireRefreshLease: vi.fn().mockResolvedValue(true),
       releaseRefreshLease: vi.fn().mockResolvedValue(undefined),
@@ -571,6 +587,33 @@ describe('yahoo-connect-handlers', () => {
       expect(body.access_token).toBe('fresh-access-token');
     });
 
+    it('logs a non-secret diagnostic when returning a fresh token', async () => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+      mockStorage.getYahooCredentials.mockResolvedValue({
+        clerkUserId: 'user_123456789',
+        accessToken: 'fresh-access-token',
+        refreshToken: 'refresh-token',
+        expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        needsRefresh: false,
+      });
+
+      await handleYahooCredentials(env, 'user_123456789', corsHeaders, 'req_123');
+
+      const diagnostics = yahooRefreshDiagnostics(logSpy);
+      expect(diagnostics).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            event: 'token_fresh_returned',
+            user_id: 'user_123...',
+            correlation_id: 'req_123',
+          }),
+        ])
+      );
+      const serialized = JSON.stringify(diagnostics);
+      expect(serialized).not.toContain('fresh-access-token');
+      expect(serialized).not.toContain('refresh-token');
+    });
+
     it('refreshes token when needsRefresh is true', async () => {
       mockStorage.getYahooCredentials.mockResolvedValue({
         clerkUserId: 'user_123',
@@ -787,6 +830,7 @@ describe('yahoo-connect-handlers', () => {
     });
 
     it('returns retryable 503 when Yahoo returns HTTP 429 during refresh', async () => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
       mockStorage.getYahooCredentials.mockResolvedValue({
         clerkUserId: 'user_123',
         accessToken: 'old-access-token',
@@ -806,7 +850,7 @@ describe('yahoo-connect-handlers', () => {
         )
       );
 
-      const response = await handleYahooCredentials(env, 'user_123', corsHeaders);
+      const response = await handleYahooCredentials(env, 'user_123', corsHeaders, 'req_429');
 
       expect(response.status).toBe(503);
       const body = (await response.json()) as Record<string, unknown>;
@@ -817,6 +861,31 @@ describe('yahoo-connect-handlers', () => {
       expect(body.upstream_status).toBe(429);
       expect(mockStorage.markRefreshCooldown).toHaveBeenCalledWith('user_123', expect.any(String), 900);
       expect(mockStorage.updateYahooCredentials).not.toHaveBeenCalled();
+
+      const diagnostics = yahooRefreshDiagnostics(logSpy);
+      expect(diagnostics).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            event: 'refresh_response_error',
+            correlation_id: 'req_429',
+            upstream_status: 429,
+            token_error: 'rate_limited',
+            failure_kind: 'transient_http',
+          }),
+          expect.objectContaining({
+            event: 'refresh_transient_failure',
+            retry_after: 900,
+          }),
+          expect.objectContaining({
+            event: 'cooldown_mark_attempted',
+            retry_after: 900,
+            cooldown_marked: true,
+          }),
+        ])
+      );
+      const serialized = JSON.stringify(diagnostics);
+      expect(serialized).not.toContain('old-access-token');
+      expect(serialized).not.toContain('refresh-token');
     });
 
     it('uses newer stored credentials when a concurrent refresh already succeeded', async () => {
@@ -1244,6 +1313,107 @@ describe('yahoo-connect-handlers', () => {
       expect(body.connected).toBe(false);
       expect(body.leagueCount).toBe(0);
       expect(body.lastUpdated).toBeUndefined();
+    });
+  });
+
+  // ===========================================================================
+  // handleYahooCredentialHealth Tests
+  // ===========================================================================
+
+  describe('handleYahooCredentialHealth', () => {
+    it('returns non-secret credential health for a fresh token', async () => {
+      const expiresAt = new Date('2026-05-12T02:00:00Z');
+      const updatedAt = new Date('2026-05-12T01:00:00Z');
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-05-12T01:30:00Z'));
+      try {
+        mockStorage.getYahooCredentialHealth.mockResolvedValue({
+          clerkUserId: 'user_123',
+          expiresAt,
+          yahooGuidPresent: true,
+          needsRefresh: false,
+          updatedAt,
+        });
+
+        const response = await handleYahooCredentialHealth(env, 'user_123', corsHeaders);
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get('Cache-Control')).toBe('no-store');
+        const body = (await response.json()) as Record<string, any>;
+        expect(body).toEqual({
+          connected: true,
+          hasCredentials: true,
+          platform: 'yahoo',
+          checkedAt: '2026-05-12T01:30:00.000Z',
+          lastUpdated: '2026-05-12T01:00:00.000Z',
+          yahooGuidPresent: true,
+          accessToken: {
+            expiresAt: '2026-05-12T02:00:00.000Z',
+            expiresInSeconds: 1800,
+            needsRefresh: false,
+            state: 'fresh',
+          },
+          refresh: {
+            state: 'idle',
+          },
+        });
+        expect(JSON.stringify(body)).not.toContain('access-token');
+        expect(JSON.stringify(body)).not.toContain('refresh-token');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('returns cooldown state without exposing the lease owner', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-05-12T01:30:00Z'));
+      try {
+        mockStorage.getYahooCredentialHealth.mockResolvedValue({
+          clerkUserId: 'user_123',
+          expiresAt: new Date('2026-05-12T01:31:00Z'),
+          yahooGuidPresent: false,
+          needsRefresh: true,
+          refreshLeaseOwner: 'cooldown:owner-1',
+          refreshLeaseExpiresAt: new Date('2026-05-12T01:31:15Z'),
+        });
+
+        const response = await handleYahooCredentialHealth(env, 'user_123', corsHeaders);
+
+        expect(response.status).toBe(200);
+        const body = (await response.json()) as Record<string, any>;
+        expect(body.refresh).toEqual({
+          state: 'cooldown',
+          leaseExpiresAt: '2026-05-12T01:31:15.000Z',
+          retryAfterSeconds: 75,
+        });
+        expect(body.accessToken).toMatchObject({
+          needsRefresh: true,
+          state: 'needs_refresh',
+        });
+        expect(JSON.stringify(body)).not.toContain('owner-1');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('returns disconnected health when no Yahoo credential row exists', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-05-12T01:30:00Z'));
+      try {
+        mockStorage.getYahooCredentialHealth.mockResolvedValue(null);
+
+        const response = await handleYahooCredentialHealth(env, 'user_123', corsHeaders);
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({
+          connected: false,
+          hasCredentials: false,
+          platform: 'yahoo',
+          checkedAt: '2026-05-12T01:30:00.000Z',
+        });
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
@@ -1339,7 +1339,7 @@ describe('yahoo-connect-handlers', () => {
 
         expect(response.status).toBe(200);
         expect(response.headers.get('Cache-Control')).toBe('no-store');
-        const body = (await response.json()) as Record<string, any>;
+        const body = (await response.json()) as Record<string, unknown>;
         expect(body).toEqual({
           connected: true,
           hasCredentials: true,
@@ -1380,7 +1380,7 @@ describe('yahoo-connect-handlers', () => {
         const response = await handleYahooCredentialHealth(env, 'user_123', corsHeaders);
 
         expect(response.status).toBe(200);
-        const body = (await response.json()) as Record<string, any>;
+        const body = (await response.json()) as Record<string, unknown>;
         expect(body.refresh).toEqual({
           state: 'cooldown',
           leaseExpiresAt: '2026-05-12T01:31:15.000Z',
@@ -1412,12 +1412,38 @@ describe('yahoo-connect-handlers', () => {
         const response = await handleYahooCredentialHealth(env, 'user_123', corsHeaders);
 
         expect(response.status).toBe(200);
-        const body = (await response.json()) as Record<string, any>;
+        const body = (await response.json()) as Record<string, unknown>;
         expect(body.refresh).toEqual({
           state: 'expired',
           leaseExpiresAt: '2026-05-12T01:29:55.000Z',
         });
         expect(JSON.stringify(body)).not.toContain('owner-1');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('clamps expired access-token health timing to zero seconds', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-05-12T01:30:00Z'));
+      try {
+        mockStorage.getYahooCredentialHealth.mockResolvedValue({
+          clerkUserId: 'user_123',
+          expiresAt: new Date('2026-05-12T01:29:30Z'),
+          yahooGuidPresent: true,
+          needsRefresh: true,
+        });
+
+        const response = await handleYahooCredentialHealth(env, 'user_123', corsHeaders);
+
+        expect(response.status).toBe(200);
+        const body = (await response.json()) as Record<string, unknown>;
+        expect(body.accessToken).toMatchObject({
+          expiresAt: '2026-05-12T01:29:30.000Z',
+          expiresInSeconds: 0,
+          needsRefresh: true,
+          state: 'needs_refresh',
+        });
       } finally {
         vi.useRealTimers();
       }
@@ -1445,9 +1471,10 @@ describe('yahoo-connect-handlers', () => {
 
     it('returns server_error when credential health lookup fails', async () => {
       const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
       mockStorage.getYahooCredentialHealth.mockRejectedValue(new Error('db offline'));
 
-      const response = await handleYahooCredentialHealth(env, 'user_123', corsHeaders);
+      const response = await handleYahooCredentialHealth(env, 'user_123', corsHeaders, 'req_health');
 
       expect(response.status).toBe(500);
       expect(await response.json()).toEqual({
@@ -1457,6 +1484,15 @@ describe('yahoo-connect-handlers', () => {
       expect(errorSpy).toHaveBeenCalledWith(
         '[yahoo-connect] Credential health error:',
         expect.any(Error)
+      );
+      expect(yahooRefreshDiagnostics(logSpy)).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            event: 'credential_health_error',
+            correlation_id: 'req_health',
+            reason: 'storage_error',
+          }),
+        ])
       );
     });
   });

--- a/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
@@ -1396,6 +1396,33 @@ describe('yahoo-connect-handlers', () => {
       }
     });
 
+    it('returns expired lease state without exposing the lease owner', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-05-12T01:30:00Z'));
+      try {
+        mockStorage.getYahooCredentialHealth.mockResolvedValue({
+          clerkUserId: 'user_123',
+          expiresAt: new Date('2026-05-12T01:31:00Z'),
+          yahooGuidPresent: true,
+          needsRefresh: true,
+          refreshLeaseOwner: 'refresh:owner-1',
+          refreshLeaseExpiresAt: new Date('2026-05-12T01:29:55Z'),
+        });
+
+        const response = await handleYahooCredentialHealth(env, 'user_123', corsHeaders);
+
+        expect(response.status).toBe(200);
+        const body = (await response.json()) as Record<string, any>;
+        expect(body.refresh).toEqual({
+          state: 'expired',
+          leaseExpiresAt: '2026-05-12T01:29:55.000Z',
+        });
+        expect(JSON.stringify(body)).not.toContain('owner-1');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('returns disconnected health when no Yahoo credential row exists', async () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date('2026-05-12T01:30:00Z'));
@@ -1414,6 +1441,23 @@ describe('yahoo-connect-handlers', () => {
       } finally {
         vi.useRealTimers();
       }
+    });
+
+    it('returns server_error when credential health lookup fails', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      mockStorage.getYahooCredentialHealth.mockRejectedValue(new Error('db offline'));
+
+      const response = await handleYahooCredentialHealth(env, 'user_123', corsHeaders);
+
+      expect(response.status).toBe(500);
+      expect(await response.json()).toEqual({
+        error: 'server_error',
+        error_description: 'Failed to retrieve Yahoo credential health',
+      });
+      expect(errorSpy).toHaveBeenCalledWith(
+        '[yahoo-connect] Credential health error:',
+        expect.any(Error)
+      );
     });
   });
 

--- a/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
@@ -701,6 +701,65 @@ describe('yahoo-connect-handlers', () => {
       expect(body.error_description).toBe('Refresh token expired');
     });
 
+    it('classifies unexpected Yahoo refresh errors without retry metadata', async () => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+      mockStorage.getYahooCredentials.mockResolvedValue({
+        clerkUserId: 'user_123',
+        accessToken: 'old-access-token',
+        refreshToken: 'mystery-refresh-token',
+        expiresAt: new Date(Date.now() + 2 * 60 * 1000),
+        needsRefresh: true,
+      });
+      mockStorage.acquireRefreshLease.mockResolvedValue(true);
+
+      mockFetch.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            error: 'mystery_failure',
+            error_description: 'Unhandled Yahoo token response',
+          }),
+          { status: 400 }
+        )
+      );
+
+      const response = await handleYahooCredentials(env, 'user_123', corsHeaders, 'req_unexpected');
+
+      expect(response.status).toBe(401);
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.error).toBe('refresh_failed');
+      expect(body.error_description).toBe('Unhandled Yahoo token response');
+      expect(body.retryable).toBeUndefined();
+      expect(body.retry_after).toBeUndefined();
+      expect(mockStorage.markRefreshCooldown).not.toHaveBeenCalled();
+      expect(mockStorage.updateYahooCredentials).not.toHaveBeenCalled();
+
+      const diagnostics = yahooRefreshDiagnostics(logSpy);
+      expect(diagnostics).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            event: 'refresh_response_error',
+            correlation_id: 'req_unexpected',
+            token_error: 'mystery_failure',
+            failure_kind: 'unexpected',
+          }),
+          expect.objectContaining({
+            event: 'refresh_permanent_failure',
+            correlation_id: 'req_unexpected',
+            token_error: 'mystery_failure',
+            failure_kind: 'unexpected',
+          }),
+        ])
+      );
+      expect(diagnostics).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ event: 'refresh_transient_failure' }),
+        ])
+      );
+      const serialized = JSON.stringify(diagnostics);
+      expect(serialized).not.toContain('old-access-token');
+      expect(serialized).not.toContain('mystery-refresh-token');
+    });
+
     it('returns retryable 503 when Yahoo returns a non-JSON Too many token response', async () => {
       mockStorage.getYahooCredentials.mockResolvedValue({
         clerkUserId: 'user_123',
@@ -1507,6 +1566,7 @@ describe('yahoo-connect-handlers', () => {
       const response = await handleYahooCredentialHealth(env, 'user_123', corsHeaders, 'req_health');
 
       expect(response.status).toBe(500);
+      expect(response.headers.get('Cache-Control')).toBe('no-store');
       expect(await response.json()).toEqual({
         error: 'server_error',
         error_description: 'Failed to retrieve Yahoo credential health',

--- a/workers/auth-worker/src/__tests__/yahoo-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-storage.test.ts
@@ -246,6 +246,22 @@ describe('YahooStorage', () => {
   });
 
   describe('getYahooCredentials', () => {
+    it('selects token fields needed for refresh', async () => {
+      mockSingle.mockResolvedValue({
+        data: null,
+        error: { code: 'PGRST116', message: 'No rows' },
+      });
+
+      await storage.getYahooCredentials('user_123');
+
+      expect(mockSelect).toHaveBeenCalledWith(
+        expect.stringContaining('access_token')
+      );
+      expect(mockSelect).toHaveBeenCalledWith(
+        expect.stringContaining('refresh_token')
+      );
+    });
+
     it('returns credentials with needsRefresh=false when token is fresh', async () => {
       // Token expires in 30 minutes - well outside the 5-minute buffer
       const expiresAt = new Date(Date.now() + 30 * 60 * 1000);
@@ -317,6 +333,91 @@ describe('YahooStorage', () => {
       const result = await storage.getYahooCredentials('nonexistent-user');
 
       expect(result).toBeNull();
+    });
+  });
+
+  describe('getYahooCredentialHealth', () => {
+    it('selects only non-secret fields and maps credential health', async () => {
+      const expiresAt = new Date(Date.now() + 30 * 60 * 1000);
+      const updatedAt = new Date('2026-05-12T01:00:00Z');
+      const leaseExpiresAt = new Date(Date.now() + 60_000);
+      mockSingle.mockResolvedValue({
+        data: {
+          clerk_user_id: 'user_123',
+          expires_at: expiresAt.toISOString(),
+          yahoo_guid: 'guid-123',
+          updated_at: updatedAt.toISOString(),
+          refresh_lease_owner: 'cooldown:owner-1',
+          refresh_lease_expires_at: leaseExpiresAt.toISOString(),
+        },
+        error: null,
+      });
+
+      const result = await storage.getYahooCredentialHealth('user_123');
+
+      expect(mockSelect).toHaveBeenCalledWith(
+        'clerk_user_id, expires_at, yahoo_guid, updated_at, refresh_lease_owner, refresh_lease_expires_at'
+      );
+      const selectedFields = String(mockSelect.mock.calls[0][0]);
+      expect(selectedFields).not.toContain('access_token');
+      expect(selectedFields).not.toContain('refresh_token');
+      expect(result).toEqual({
+        clerkUserId: 'user_123',
+        expiresAt,
+        yahooGuidPresent: true,
+        needsRefresh: false,
+        updatedAt,
+        refreshLeaseOwner: 'cooldown:owner-1',
+        refreshLeaseExpiresAt: leaseExpiresAt,
+      });
+    });
+
+    it('returns health with needsRefresh=true when token is within the refresh buffer', async () => {
+      const expiresAt = new Date(Date.now() + 3 * 60 * 1000);
+      mockSingle.mockResolvedValue({
+        data: {
+          clerk_user_id: 'user_123',
+          expires_at: expiresAt.toISOString(),
+          yahoo_guid: null,
+          updated_at: null,
+          refresh_lease_owner: null,
+          refresh_lease_expires_at: null,
+        },
+        error: null,
+      });
+
+      const result = await storage.getYahooCredentialHealth('user_123');
+
+      expect(result?.needsRefresh).toBe(true);
+      expect(result?.yahooGuidPresent).toBe(false);
+      expect(result?.refreshLeaseOwner).toBeUndefined();
+    });
+
+    it('returns null when no credential health row exists', async () => {
+      mockSingle.mockResolvedValue({
+        data: null,
+        error: { code: 'PGRST116', message: 'No rows' },
+      });
+
+      const result = await storage.getYahooCredentialHealth('missing-user');
+
+      expect(result).toBeNull();
+    });
+
+    it('throws when the credential health query fails', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      mockSingle.mockResolvedValue({
+        data: null,
+        error: { code: '500', message: 'Database unavailable' },
+      });
+
+      await expect(storage.getYahooCredentialHealth('user_123')).rejects.toThrow(
+        'Failed to get Yahoo credential health'
+      );
+      expect(errorSpy).toHaveBeenCalledWith(
+        '[yahoo-storage] Failed to get Yahoo credential health:',
+        expect.objectContaining({ message: 'Database unavailable' })
+      );
     });
   });
 

--- a/workers/auth-worker/src/index-hono.ts
+++ b/workers/auth-worker/src/index-hono.ts
@@ -52,6 +52,7 @@ import {
   handleYahooAuthorize,
   handleYahooCallback,
   handleYahooCredentials,
+  handleYahooCredentialHealth,
   handleYahooDisconnect,
   handleYahooDiscover,
   handleYahooStatus,
@@ -924,7 +925,24 @@ api.get('/internal/connect/yahoo/credentials', async (c) => {
       error_description: authError || 'Authentication required',
     }, authStatus ?? 401);
   }
-  return handleYahooCredentials(c.env as YahooConnectEnv, userId, getCorsHeaders(c.req.raw));
+  return handleYahooCredentials(
+    c.env as YahooConnectEnv,
+    userId,
+    getCorsHeaders(c.req.raw),
+    c.req.header('X-Correlation-ID') || undefined
+  );
+});
+
+// Get non-secret Yahoo credential refresh health (internal diagnostics)
+api.get('/internal/connect/yahoo/credential-health', async (c) => {
+  const { userId, error: authError, status: authStatus } = await getInternalUserId(c.req.raw, c.env);
+  if (!userId) {
+    return c.json({
+      error: 'unauthorized',
+      error_description: authError || 'Authentication required',
+    }, authStatus ?? 401);
+  }
+  return handleYahooCredentialHealth(c.env as YahooConnectEnv, userId, getCorsHeaders(c.req.raw));
 });
 
 // Check Yahoo connection status (requires Clerk JWT)
@@ -960,7 +978,12 @@ api.post('/connect/yahoo/discover', async (c) => {
       error_description: authError || 'Authentication required',
     }, 401);
   }
-  return handleYahooDiscover(c.env as YahooConnectEnv, userId, getCorsHeaders(c.req.raw));
+  return handleYahooDiscover(
+    c.env as YahooConnectEnv,
+    userId,
+    getCorsHeaders(c.req.raw),
+    c.req.header('X-Correlation-ID') || undefined
+  );
 });
 
 // List Yahoo leagues (requires auth)

--- a/workers/auth-worker/src/index-hono.ts
+++ b/workers/auth-worker/src/index-hono.ts
@@ -942,7 +942,12 @@ api.get('/internal/connect/yahoo/credential-health', async (c) => {
       error_description: authError || 'Authentication required',
     }, authStatus ?? 401);
   }
-  return handleYahooCredentialHealth(c.env as YahooConnectEnv, userId, getCorsHeaders(c.req.raw));
+  return handleYahooCredentialHealth(
+    c.env as YahooConnectEnv,
+    userId,
+    getCorsHeaders(c.req.raw),
+    c.req.header('X-Correlation-ID') || undefined
+  );
 });
 
 // Check Yahoo connection status (requires Clerk JWT)

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -88,6 +88,8 @@ interface YahooRefreshDiagnosticFields {
   cooldownMarked?: boolean;
 }
 
+// Internal annotation from the Yahoo token endpoint parser. This is consumed by
+// diagnostics only and is never serialized to external callers.
 type YahooTokenDiagnosticResponse = YahooTokenResponse & {
   upstream_body_class?: YahooTokenBodyClass;
 };
@@ -273,23 +275,7 @@ function hasTransientYahooTokenFailureSignal(text: string): boolean {
     || text.includes('temporary');
 }
 
-function isTransientYahooTokenFailure(response: Pick<YahooTokenResponse, 'status' | 'error' | 'error_description' | 'upstream_error_text'>): boolean {
-  if (isTransientYahooTokenError(response.status)) {
-    return true;
-  }
-
-  const text = normalizeYahooTokenErrorText(response);
-  // Permanent signals win over transient-looking text so revoked/expired tokens still trigger reconnect.
-  if (hasPermanentYahooTokenFailureSignal(text)) {
-    return false;
-  }
-
-  // After permanent signals are ruled out, allow token-endpoint text matching on any error status.
-  // Without status, do not guess from text alone.
-  return response.status !== undefined && response.status >= 400 && hasTransientYahooTokenFailureSignal(text);
-}
-
-function classifyYahooTokenFailureForDiagnostics(
+function classifyYahooTokenFailure(
   response: Pick<YahooTokenResponse, 'status' | 'error' | 'error_description' | 'upstream_error_text'>
 ): YahooTokenFailureDiagnosticKind {
   if (isTransientYahooTokenError(response.status)) {
@@ -297,13 +283,23 @@ function classifyYahooTokenFailureForDiagnostics(
   }
 
   const text = normalizeYahooTokenErrorText(response);
+  // Permanent signals win over transient-looking text so revoked/expired tokens still trigger reconnect.
   if (hasPermanentYahooTokenFailureSignal(text)) {
     return 'permanent';
   }
+
+  // After permanent signals are ruled out, allow token-endpoint text matching on any error status.
+  // Without status, do not guess from text alone.
   if (response.status !== undefined && response.status >= 400 && hasTransientYahooTokenFailureSignal(text)) {
     return 'transient_text';
   }
+
   return 'unexpected';
+}
+
+function isTransientYahooTokenFailure(response: Pick<YahooTokenResponse, 'status' | 'error' | 'error_description' | 'upstream_error_text'>): boolean {
+  const failureKind = classifyYahooTokenFailure(response);
+  return failureKind === 'transient_http' || failureKind === 'transient_text';
 }
 
 // Empty token error bodies carry no useful diagnostic detail for logs or callers.
@@ -707,7 +703,7 @@ async function getValidYahooAccessToken(
     clearTimeout(timer);
 
     if (result.error) {
-      const failureKind = classifyYahooTokenFailureForDiagnostics(result);
+      const failureKind = classifyYahooTokenFailure(result);
       const statusSuffix = result.status ? ` (HTTP ${result.status})` : '';
       logDiagnostic('refresh_response_error', {
         userId,
@@ -1279,13 +1275,13 @@ export async function handleYahooCredentialHealth(
     const refreshState = yahooRefreshState(credentials, checkedAtNowMs);
     const responseRefreshState = refreshState === 'none' ? 'idle' : refreshState;
     const leaseRemainingSeconds = boundedPositiveSecondsUntil(credentials.refreshLeaseExpiresAt, checkedAtNowMs);
-    const refresh: Record<string, string | number | undefined> = {
+    const refresh: Record<string, string | number> = {
       state: responseRefreshState,
     };
-    if (refreshState !== 'none') {
-      refresh.leaseExpiresAt = credentials.refreshLeaseExpiresAt?.toISOString();
+    if (refreshState !== 'none' && credentials.refreshLeaseExpiresAt) {
+      refresh.leaseExpiresAt = credentials.refreshLeaseExpiresAt.toISOString();
     }
-    if (refreshState === 'cooldown' || refreshState === 'in_progress') {
+    if ((refreshState === 'cooldown' || refreshState === 'in_progress') && leaseRemainingSeconds !== undefined) {
       refresh.retryAfterSeconds = leaseRemainingSeconds;
     }
     const checkedAt = checkedAtDate.toISOString();

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -76,6 +76,7 @@ interface YahooRefreshDiagnosticFields {
   reason?: string;
   refreshState?: YahooCredentialRefreshState;
   accessTokenExpiresInSeconds?: number;
+  accessTokenLifetimeSeconds?: number;
   leaseRemainingSeconds?: number;
   retryAfter?: number;
   upstreamStatus?: number;
@@ -184,6 +185,7 @@ function logYahooRefreshDiagnostic(event: string, fields: YahooRefreshDiagnostic
   if (fields.reason !== undefined) payload.reason = fields.reason;
   if (fields.refreshState !== undefined) payload.refresh_state = fields.refreshState;
   if (fields.accessTokenExpiresInSeconds !== undefined) payload.access_token_expires_in_seconds = fields.accessTokenExpiresInSeconds;
+  if (fields.accessTokenLifetimeSeconds !== undefined) payload.access_token_lifetime_seconds = fields.accessTokenLifetimeSeconds;
   if (fields.leaseRemainingSeconds !== undefined) payload.lease_remaining_seconds = fields.leaseRemainingSeconds;
   if (fields.retryAfter !== undefined) payload.retry_after = fields.retryAfter;
   if (fields.upstreamStatus !== undefined) payload.upstream_status = fields.upstreamStatus;
@@ -799,7 +801,7 @@ async function getValidYahooAccessToken(
       logDiagnostic('credential_update_succeeded', {
         userId,
         attempt,
-        accessTokenExpiresInSeconds: result.expires_in,
+        accessTokenLifetimeSeconds: result.expires_in,
       });
       console.log(`[yahoo-connect] Token refreshed for user ${maskUserId(userId)}`);
       return { accessToken: result.access_token, expiresIn: result.expires_in };
@@ -1267,7 +1269,17 @@ export async function handleYahooCredentialHealth(
     }
 
     const refreshState = yahooRefreshState(credentials);
+    const responseRefreshState = refreshState === 'none' ? 'idle' : refreshState;
     const leaseRemainingSeconds = boundedPositiveSecondsUntil(credentials.refreshLeaseExpiresAt);
+    const refresh: Record<string, string | number | undefined> = {
+      state: responseRefreshState,
+    };
+    if (refreshState !== 'none') {
+      refresh.leaseExpiresAt = credentials.refreshLeaseExpiresAt?.toISOString();
+    }
+    if (refreshState === 'cooldown' || refreshState === 'in_progress') {
+      refresh.retryAfterSeconds = leaseRemainingSeconds;
+    }
     const checkedAt = new Date().toISOString();
 
     return new Response(
@@ -1284,13 +1296,7 @@ export async function handleYahooCredentialHealth(
           needsRefresh: credentials.needsRefresh,
           state: credentials.needsRefresh ? 'needs_refresh' : 'fresh',
         },
-        refresh: {
-          state: refreshState === 'none' ? 'idle' : refreshState,
-          leaseExpiresAt: credentials.refreshLeaseExpiresAt?.toISOString(),
-          retryAfterSeconds: refreshState === 'cooldown' || refreshState === 'in_progress'
-            ? leaseRemainingSeconds
-            : undefined,
-        },
+        refresh,
       }),
       {
         status: 200,

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -54,7 +54,6 @@ interface YahooTokenResponse {
   error_description?: string;
   upstream_error_text?: string;
   retry_after?: number;
-  upstream_body_class?: YahooTokenBodyClass;
 }
 
 type YahooCredentialRefreshState = 'none' | 'in_progress' | 'cooldown' | 'expired';
@@ -62,7 +61,6 @@ type YahooTokenBodyClass =
   | 'empty'
   | 'json_error'
   | 'plain_text'
-  | 'invalid_json'
   | 'invalid_success_shape'
   | 'usable_success';
 type YahooTokenFailureDiagnosticKind =
@@ -88,6 +86,10 @@ interface YahooRefreshDiagnosticFields {
   hasUpstreamErrorText?: boolean;
   cooldownMarked?: boolean;
 }
+
+type YahooTokenDiagnosticResponse = YahooTokenResponse & {
+  upstream_body_class?: YahooTokenBodyClass;
+};
 
 // =============================================================================
 // CONFIGURATION
@@ -318,17 +320,15 @@ async function readYahooTokenResponse(
   response: Response,
   fallbackError: string,
   fallbackErrorDescription: string
-): Promise<YahooTokenResponse> {
+): Promise<YahooTokenDiagnosticResponse> {
   const text = await response.text();
   const data = parseYahooTokenBody(text);
   const nonJsonDescription = data ? undefined : trimYahooTokenBody(text);
-  const bodyClass: YahooTokenBodyClass = data
+  const failureBodyClass: YahooTokenBodyClass = data
     ? 'json_error'
     : text.trim().length === 0
       ? 'empty'
-      : nonJsonDescription
-        ? 'plain_text'
-        : 'invalid_json';
+      : 'plain_text';
   const retryAfter = parseRetryAfterSeconds(response.headers.get('Retry-After'));
 
   if (!response.ok) {
@@ -343,7 +343,7 @@ async function readYahooTokenResponse(
       upstream_error_text: nonJsonDescription,
       status: response.status,
       retry_after: retryAfter ?? defaultYahooRetryAfterSeconds(response.status),
-      upstream_body_class: bodyClass,
+      upstream_body_class: failureBodyClass,
     };
   }
 
@@ -357,7 +357,7 @@ async function readYahooTokenResponse(
       upstream_error_text: nonJsonDescription,
       status: response.status,
       retry_after: retryAfter ?? defaultYahooRetryAfterSeconds(response.status),
-      upstream_body_class: bodyClass,
+      upstream_body_class: failureBodyClass,
     };
   }
 
@@ -418,12 +418,13 @@ function retryAfterFromLease(credentials: { refreshLeaseExpiresAt?: Date } | nul
 }
 
 function yahooRefreshCooldownResult(credentials: YahooCredentials, correlationId?: string): GetTokenResult {
-  const retryAfter = retryAfterFromLease(credentials) ?? YAHOO_REFRESH_IN_PROGRESS_RETRY_AFTER_SECONDS;
+  const leaseRemainingSeconds = retryAfterFromLease(credentials);
+  const retryAfter = leaseRemainingSeconds ?? YAHOO_REFRESH_IN_PROGRESS_RETRY_AFTER_SECONDS;
   logYahooRefreshDiagnostic('active_cooldown_returned', {
     correlationId,
     userId: credentials.clerkUserId,
     retryAfter,
-    leaseRemainingSeconds: retryAfterFromLease(credentials),
+    leaseRemainingSeconds,
     refreshState: yahooRefreshState(credentials),
   });
   return {
@@ -657,7 +658,7 @@ async function getValidYahooAccessToken(
     });
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), YAHOO_TOKEN_REQUEST_TIMEOUT_MS);
-    let result: YahooTokenResponse;
+    let result: YahooTokenDiagnosticResponse;
     try {
       logDiagnostic('refresh_request_started', { userId, attempt });
       result = await refreshAccessToken(credentials.refreshToken, env, controller.signal);
@@ -1410,7 +1411,7 @@ async function exchangeCodeForTokens(
   code: string,
   env: YahooConnectEnv,
   signal?: AbortSignal
-): Promise<YahooTokenResponse> {
+): Promise<YahooTokenDiagnosticResponse> {
   const credentials = btoa(`${env.YAHOO_CLIENT_ID}:${env.YAHOO_CLIENT_SECRET}`);
 
   const response = await fetch(YAHOO_TOKEN_URL, {
@@ -1443,7 +1444,7 @@ async function refreshAccessToken(
   refreshToken: string,
   env: YahooConnectEnv,
   signal?: AbortSignal
-): Promise<YahooTokenResponse> {
+): Promise<YahooTokenDiagnosticResponse> {
   const credentials = btoa(`${env.YAHOO_CLIENT_ID}:${env.YAHOO_CLIENT_SECRET}`);
 
   const response = await fetch(YAHOO_TOKEN_URL, {

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -44,16 +44,49 @@ export interface YahooConnectEnv {
 }
 
 interface YahooTokenResponse {
-  access_token: string;
+  access_token?: string;
   refresh_token?: string;
-  expires_in: number;
-  token_type: string;
+  expires_in?: number;
+  token_type?: string;
   xoauth_yahoo_guid?: string;
   status?: number;
   error?: string;
   error_description?: string;
   upstream_error_text?: string;
   retry_after?: number;
+  upstream_body_class?: YahooTokenBodyClass;
+}
+
+type YahooCredentialRefreshState = 'none' | 'in_progress' | 'cooldown' | 'expired';
+type YahooTokenBodyClass =
+  | 'empty'
+  | 'json_error'
+  | 'plain_text'
+  | 'invalid_json'
+  | 'invalid_success_shape'
+  | 'usable_success';
+type YahooTokenFailureDiagnosticKind =
+  | 'transient_http'
+  | 'transient_text'
+  | 'permanent'
+  | 'unexpected';
+
+interface YahooRefreshDiagnosticFields {
+  correlationId?: string;
+  userId?: string;
+  attempt?: number;
+  reason?: string;
+  refreshState?: YahooCredentialRefreshState;
+  accessTokenExpiresInSeconds?: number;
+  leaseRemainingSeconds?: number;
+  retryAfter?: number;
+  upstreamStatus?: number;
+  tokenError?: string;
+  failureKind?: YahooTokenFailureDiagnosticKind;
+  bodyClass?: YahooTokenBodyClass;
+  hasRetryAfter?: boolean;
+  hasUpstreamErrorText?: boolean;
+  cooldownMarked?: boolean;
 }
 
 // =============================================================================
@@ -107,6 +140,56 @@ function maskUserId(userId: string): string {
   return `${userId.substring(0, 8)}...`;
 }
 
+function secondsUntil(date?: Date): number | undefined {
+  if (!date) {
+    return undefined;
+  }
+  return Math.ceil((date.getTime() - Date.now()) / 1000);
+}
+
+function boundedPositiveSecondsUntil(date?: Date): number | undefined {
+  const seconds = secondsUntil(date);
+  return seconds !== undefined && seconds > 0 ? seconds : undefined;
+}
+
+function yahooRefreshState(credentials: { refreshLeaseOwner?: string; refreshLeaseExpiresAt?: Date } | null): YahooCredentialRefreshState {
+  if (!credentials?.refreshLeaseOwner) {
+    return 'none';
+  }
+  if (leaseExpired(credentials)) {
+    return 'expired';
+  }
+  return credentials.refreshLeaseOwner.startsWith(REFRESH_COOLDOWN_OWNER_PREFIX)
+    ? 'cooldown'
+    : 'in_progress';
+}
+
+function logYahooRefreshDiagnostic(event: string, fields: YahooRefreshDiagnosticFields = {}): void {
+  const payload: Record<string, unknown> = {
+    service: 'auth-worker',
+    component: 'yahoo-connect',
+    event,
+  };
+
+  if (fields.userId) payload.user_id = maskUserId(fields.userId);
+  if (fields.correlationId) payload.correlation_id = fields.correlationId;
+  if (fields.attempt !== undefined) payload.attempt = fields.attempt;
+  if (fields.reason !== undefined) payload.reason = fields.reason;
+  if (fields.refreshState !== undefined) payload.refresh_state = fields.refreshState;
+  if (fields.accessTokenExpiresInSeconds !== undefined) payload.access_token_expires_in_seconds = fields.accessTokenExpiresInSeconds;
+  if (fields.leaseRemainingSeconds !== undefined) payload.lease_remaining_seconds = fields.leaseRemainingSeconds;
+  if (fields.retryAfter !== undefined) payload.retry_after = fields.retryAfter;
+  if (fields.upstreamStatus !== undefined) payload.upstream_status = fields.upstreamStatus;
+  if (fields.tokenError !== undefined) payload.token_error = fields.tokenError;
+  if (fields.failureKind !== undefined) payload.failure_kind = fields.failureKind;
+  if (fields.bodyClass !== undefined) payload.body_class = fields.bodyClass;
+  if (fields.hasRetryAfter !== undefined) payload.has_retry_after = fields.hasRetryAfter;
+  if (fields.hasUpstreamErrorText !== undefined) payload.has_upstream_error_text = fields.hasUpstreamErrorText;
+  if (fields.cooldownMarked !== undefined) payload.cooldown_marked = fields.cooldownMarked;
+
+  console.log(JSON.stringify(payload));
+}
+
 function looksLikeNewerCredentials(
   original: { accessToken: string; refreshToken: string; updatedAt?: Date },
   latest: { accessToken: string; refreshToken: string; updatedAt?: Date }
@@ -125,8 +208,10 @@ function looksLikeNewerCredentials(
 const sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
 
 type UsableYahooTokenResponse =
-  Partial<YahooTokenResponse> &
-  Pick<YahooTokenResponse, 'access_token' | 'expires_in'>;
+  YahooTokenResponse & {
+    access_token: string;
+    expires_in: number;
+  };
 
 function isUsableTokenResponse(response: Partial<YahooTokenResponse>): response is UsableYahooTokenResponse {
   return typeof response.access_token === 'string'
@@ -192,6 +277,23 @@ function isTransientYahooTokenFailure(response: Pick<YahooTokenResponse, 'status
   return response.status !== undefined && response.status >= 400 && hasTransientYahooTokenFailureSignal(text);
 }
 
+function classifyYahooTokenFailureForDiagnostics(
+  response: Pick<YahooTokenResponse, 'status' | 'error' | 'error_description' | 'upstream_error_text'>
+): YahooTokenFailureDiagnosticKind {
+  if (isTransientYahooTokenError(response.status)) {
+    return 'transient_http';
+  }
+
+  const text = normalizeYahooTokenErrorText(response);
+  if (hasPermanentYahooTokenFailureSignal(text)) {
+    return 'permanent';
+  }
+  if (response.status !== undefined && response.status >= 400 && hasTransientYahooTokenFailureSignal(text)) {
+    return 'transient_text';
+  }
+  return 'unexpected';
+}
+
 // Empty token error bodies carry no useful diagnostic detail for logs or callers.
 function trimYahooTokenBody(text: string): string | undefined {
   const trimmed = text.trim();
@@ -220,6 +322,13 @@ async function readYahooTokenResponse(
   const text = await response.text();
   const data = parseYahooTokenBody(text);
   const nonJsonDescription = data ? undefined : trimYahooTokenBody(text);
+  const bodyClass: YahooTokenBodyClass = data
+    ? 'json_error'
+    : text.trim().length === 0
+      ? 'empty'
+      : nonJsonDescription
+        ? 'plain_text'
+        : 'invalid_json';
   const retryAfter = parseRetryAfterSeconds(response.headers.get('Retry-After'));
 
   if (!response.ok) {
@@ -234,6 +343,7 @@ async function readYahooTokenResponse(
       upstream_error_text: nonJsonDescription,
       status: response.status,
       retry_after: retryAfter ?? defaultYahooRetryAfterSeconds(response.status),
+      upstream_body_class: bodyClass,
     };
   }
 
@@ -247,6 +357,7 @@ async function readYahooTokenResponse(
       upstream_error_text: nonJsonDescription,
       status: response.status,
       retry_after: retryAfter ?? defaultYahooRetryAfterSeconds(response.status),
+      upstream_body_class: bodyClass,
     };
   }
 
@@ -259,10 +370,14 @@ async function readYahooTokenResponse(
       error_description: fallbackErrorDescription,
       status: response.status,
       retry_after: retryAfter ?? defaultYahooRetryAfterSeconds(response.status),
+      upstream_body_class: 'invalid_success_shape',
     };
   }
 
-  return toYahooTokenResponse(data);
+  return {
+    ...toYahooTokenResponse(data),
+    upstream_body_class: 'usable_success',
+  };
 }
 
 // =============================================================================
@@ -299,19 +414,23 @@ function isRefreshCooldown(credentials: { refreshLeaseOwner?: string; refreshLea
 }
 
 function retryAfterFromLease(credentials: { refreshLeaseExpiresAt?: Date } | null): number | undefined {
-  if (!credentials?.refreshLeaseExpiresAt) {
-    return undefined;
-  }
-  const seconds = Math.ceil((credentials.refreshLeaseExpiresAt.getTime() - Date.now()) / 1000);
-  return seconds > 0 ? seconds : undefined;
+  return boundedPositiveSecondsUntil(credentials?.refreshLeaseExpiresAt);
 }
 
-function yahooRefreshCooldownResult(credentials: YahooCredentials): GetTokenResult {
+function yahooRefreshCooldownResult(credentials: YahooCredentials, correlationId?: string): GetTokenResult {
+  const retryAfter = retryAfterFromLease(credentials) ?? YAHOO_REFRESH_IN_PROGRESS_RETRY_AFTER_SECONDS;
+  logYahooRefreshDiagnostic('active_cooldown_returned', {
+    correlationId,
+    userId: credentials.clerkUserId,
+    retryAfter,
+    leaseRemainingSeconds: retryAfterFromLease(credentials),
+    refreshState: yahooRefreshState(credentials),
+  });
   return {
     error: YahooAuthWorkerErrorCode.REFRESH_TEMPORARILY_UNAVAILABLE,
     errorDescription: 'Yahoo token refresh is cooling down after a transient failure. Please try again shortly.',
     retryable: true,
-    retryAfter: retryAfterFromLease(credentials) ?? YAHOO_REFRESH_IN_PROGRESS_RETRY_AFTER_SECONDS,
+    retryAfter,
   };
 }
 
@@ -325,14 +444,27 @@ async function markYahooRefreshCooldown(
   storage: YahooStorage,
   userId: string,
   ownerId: string,
-  retryAfterSeconds: number
+  retryAfterSeconds: number,
+  correlationId?: string
 ): Promise<void> {
   try {
     const marked = await storage.markRefreshCooldown(userId, ownerId, retryAfterSeconds);
+    logYahooRefreshDiagnostic('cooldown_mark_attempted', {
+      correlationId,
+      userId,
+      retryAfter: retryAfterSeconds,
+      cooldownMarked: marked,
+    });
     if (!marked) {
       console.debug('[yahoo-connect] Skipped Yahoo refresh cooldown because the lease is no longer owned by this request');
     }
   } catch (cooldownError) {
+    logYahooRefreshDiagnostic('cooldown_mark_failed', {
+      correlationId,
+      userId,
+      retryAfter: retryAfterSeconds,
+      reason: 'storage_error',
+    });
     console.warn('[yahoo-connect] Failed to mark Yahoo refresh cooldown after transient refresh failure:', cooldownError);
     try {
       await storage.releaseRefreshLease(userId, ownerId);
@@ -345,18 +477,26 @@ async function markYahooRefreshCooldown(
 async function waitForFreshCredentialsOrLeaseClear(
   storage: YahooStorage,
   userId: string,
-  credentials: YahooCredentials
+  credentials: YahooCredentials,
+  correlationId?: string
 ): Promise<RetryTokenResult> {
   let latest: YahooCredentials | null = credentials;
   const deadline = Date.now() + MAX_LEASE_WAIT_MS;
 
   while (latest && !leaseExpired(latest)) {
     if (isRefreshCooldown(latest)) {
-      return yahooRefreshCooldownResult(latest);
+      return yahooRefreshCooldownResult(latest, correlationId);
     }
 
     const remainingMs = deadline - Date.now();
     if (remainingMs <= 0) {
+      logYahooRefreshDiagnostic('lease_wait_timeout', {
+        correlationId,
+        userId,
+        retryAfter: YAHOO_REFRESH_IN_PROGRESS_RETRY_AFTER_SECONDS,
+        refreshState: yahooRefreshState(latest),
+        leaseRemainingSeconds: boundedPositiveSecondsUntil(latest.refreshLeaseExpiresAt),
+      });
       return {
         error: YahooAuthWorkerErrorCode.REFRESH_TEMPORARILY_UNAVAILABLE,
         errorDescription: 'Yahoo token refresh is already in progress. Please try again shortly.',
@@ -370,22 +510,44 @@ async function waitForFreshCredentialsOrLeaseClear(
     latest = await storage.getYahooCredentials(userId);
 
     if (!latest) {
+      logYahooRefreshDiagnostic('credentials_missing_while_waiting', { correlationId, userId });
       return { error: 'not_connected' };
     }
     if (!latest.needsRefresh) {
+      logYahooRefreshDiagnostic('lease_wait_finished_with_fresh_token', {
+        correlationId,
+        userId,
+        accessTokenExpiresInSeconds: secondsUntil(latest.expiresAt),
+      });
       return toTokenResult(latest);
     }
     if (leaseExpired(latest)) {
+      logYahooRefreshDiagnostic('lease_expired_retrying_refresh', {
+        correlationId,
+        userId,
+        refreshState: yahooRefreshState(latest),
+      });
       return { retry: true, credentials: latest };
     }
   }
 
   if (!latest) {
+    logYahooRefreshDiagnostic('credentials_missing_after_wait', { correlationId, userId });
     return { error: 'not_connected' };
   }
   if (!latest.needsRefresh) {
+    logYahooRefreshDiagnostic('lease_wait_finished_with_fresh_token', {
+      correlationId,
+      userId,
+      accessTokenExpiresInSeconds: secondsUntil(latest.expiresAt),
+    });
     return toTokenResult(latest);
   }
+  logYahooRefreshDiagnostic('lease_expired_retrying_refresh', {
+    correlationId,
+    userId,
+    refreshState: yahooRefreshState(latest),
+  });
   return { retry: true, credentials: latest };
 }
 
@@ -400,22 +562,40 @@ async function getValidYahooAccessToken(
   storage: YahooStorage,
   userId: string,
   env: YahooConnectEnv,
-  initialCredentials?: YahooCredentials
+  initialCredentials?: YahooCredentials,
+  correlationId?: string
 ): Promise<GetTokenResult> {
+  const logDiagnostic = (event: string, fields: YahooRefreshDiagnosticFields = {}) => {
+    logYahooRefreshDiagnostic(event, { correlationId, ...fields });
+  };
+
   let credentials = initialCredentials ?? await storage.getYahooCredentials(userId);
   if (!credentials) {
+    logDiagnostic('credentials_missing', { userId });
     return { error: 'not_connected' };
   }
 
   for (let attempt = 0; attempt < MAX_REFRESH_ATTEMPTS; attempt++) {
     if (!credentials.needsRefresh) {
+      logDiagnostic('token_fresh_returned', {
+        userId,
+        attempt,
+        accessTokenExpiresInSeconds: secondsUntil(credentials.expiresAt),
+        refreshState: yahooRefreshState(credentials),
+      });
       return toTokenResult(credentials);
     }
     if (isRefreshCooldown(credentials)) {
-      return yahooRefreshCooldownResult(credentials);
+      return yahooRefreshCooldownResult(credentials, correlationId);
     }
 
     const ownerId = crypto.randomUUID();
+    logDiagnostic('lease_acquire_attempt', {
+      userId,
+      attempt,
+      accessTokenExpiresInSeconds: secondsUntil(credentials.expiresAt),
+      refreshState: yahooRefreshState(credentials),
+    });
     const won = await storage.acquireRefreshLease(
       userId,
       ownerId,
@@ -424,17 +604,34 @@ async function getValidYahooAccessToken(
     );
 
     if (!won) {
+      logDiagnostic('lease_not_acquired', {
+        userId,
+        attempt,
+        refreshState: yahooRefreshState(credentials),
+        leaseRemainingSeconds: boundedPositiveSecondsUntil(credentials.refreshLeaseExpiresAt),
+      });
       const latest = await storage.getYahooCredentials(userId);
       if (!latest) {
+        logDiagnostic('credentials_missing_after_lease_loss', { userId, attempt });
         return { error: 'not_connected' };
       }
       if (!latest.needsRefresh) {
+        logDiagnostic('lease_loss_found_fresh_token', {
+          userId,
+          attempt,
+          accessTokenExpiresInSeconds: secondsUntil(latest.expiresAt),
+        });
         return toTokenResult(latest);
       }
       if (isRefreshCooldown(latest)) {
-        return yahooRefreshCooldownResult(latest);
+        return yahooRefreshCooldownResult(latest, correlationId);
       }
       if (leaseExpired(latest)) {
+        logDiagnostic('lease_loss_found_expired_lease_retrying', {
+          userId,
+          attempt,
+          refreshState: yahooRefreshState(latest),
+        });
         credentials = latest;
         continue;
       }
@@ -442,7 +639,8 @@ async function getValidYahooAccessToken(
       const loserResult = await waitForFreshCredentialsOrLeaseClear(
         storage,
         userId,
-        latest
+        latest,
+        correlationId
       );
 
       if ('retry' in loserResult) {
@@ -452,14 +650,26 @@ async function getValidYahooAccessToken(
       return loserResult;
     }
 
+    logDiagnostic('lease_acquired', {
+      userId,
+      attempt,
+      accessTokenExpiresInSeconds: secondsUntil(credentials.expiresAt),
+    });
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), YAHOO_TOKEN_REQUEST_TIMEOUT_MS);
     let result: YahooTokenResponse;
     try {
+      logDiagnostic('refresh_request_started', { userId, attempt });
       result = await refreshAccessToken(credentials.refreshToken, env, controller.signal);
     } catch (error) {
       clearTimeout(timer);
       const isAbort = error instanceof Error && error.name === 'AbortError';
+      logDiagnostic('refresh_request_exception', {
+        userId,
+        attempt,
+        reason: isAbort ? 'abort' : 'fetch_error',
+        retryAfter: YAHOO_DEFAULT_TRANSIENT_RETRY_AFTER_SECONDS,
+      });
       console.error(
         `[yahoo-connect] Yahoo token refresh request failed for user ${maskUserId(userId)}:`,
         error instanceof Error ? error.message : error
@@ -468,7 +678,8 @@ async function getValidYahooAccessToken(
         storage,
         userId,
         ownerId,
-        YAHOO_DEFAULT_TRANSIENT_RETRY_AFTER_SECONDS
+        YAHOO_DEFAULT_TRANSIENT_RETRY_AFTER_SECONDS,
+        correlationId
       );
       return {
         error: YahooAuthWorkerErrorCode.REFRESH_TEMPORARILY_UNAVAILABLE,
@@ -482,13 +693,29 @@ async function getValidYahooAccessToken(
     clearTimeout(timer);
 
     if (result.error) {
+      const failureKind = classifyYahooTokenFailureForDiagnostics(result);
       const statusSuffix = result.status ? ` (HTTP ${result.status})` : '';
+      logDiagnostic('refresh_response_error', {
+        userId,
+        attempt,
+        upstreamStatus: result.status,
+        tokenError: result.error,
+        failureKind,
+        bodyClass: result.upstream_body_class,
+        hasRetryAfter: result.retry_after !== undefined,
+        hasUpstreamErrorText: Boolean(result.upstream_error_text),
+      });
       console.error(
         `[yahoo-connect] Yahoo token refresh failed for user ${maskUserId(userId)}: ${result.error}${statusSuffix}` +
           (result.error_description ? ` - ${result.error_description}` : '')
       );
       const latest = await storage.getYahooCredentials(userId);
       if (latest && !latest.needsRefresh && looksLikeNewerCredentials(credentials, latest)) {
+        logDiagnostic('concurrent_refresh_used', {
+          userId,
+          attempt,
+          accessTokenExpiresInSeconds: secondsUntil(latest.expiresAt),
+        });
         console.log(`[yahoo-connect] Using concurrently refreshed token for user ${maskUserId(userId)}`);
         try {
           await storage.releaseRefreshLease(userId, ownerId);
@@ -499,7 +726,18 @@ async function getValidYahooAccessToken(
       }
       if (isTransientYahooTokenFailure(result)) {
         const retryAfter = retryAfterForTransientYahooTokenFailure(result);
-        await markYahooRefreshCooldown(storage, userId, ownerId, retryAfter);
+        logDiagnostic('refresh_transient_failure', {
+          userId,
+          attempt,
+          upstreamStatus: result.status,
+          tokenError: result.error,
+          failureKind,
+          bodyClass: result.upstream_body_class,
+          retryAfter,
+          hasRetryAfter: result.retry_after !== undefined,
+          hasUpstreamErrorText: Boolean(result.upstream_error_text),
+        });
+        await markYahooRefreshCooldown(storage, userId, ownerId, retryAfter, correlationId);
         return {
           error: YahooAuthWorkerErrorCode.REFRESH_TEMPORARILY_UNAVAILABLE,
           errorDescription: result.error_description || 'Yahoo token refresh is temporarily unavailable',
@@ -513,6 +751,14 @@ async function getValidYahooAccessToken(
       } catch (releaseError) {
         console.warn('[yahoo-connect] Failed to release Yahoo refresh lease after Yahoo refresh error:', releaseError);
       }
+      logDiagnostic('refresh_permanent_failure', {
+        userId,
+        attempt,
+        upstreamStatus: result.status,
+        tokenError: result.error,
+        failureKind,
+        bodyClass: result.upstream_body_class,
+      });
       return {
         error: 'refresh_failed',
         errorDescription: result.error_description || 'Failed to refresh access token',
@@ -520,6 +766,13 @@ async function getValidYahooAccessToken(
     }
 
     if (!isUsableTokenResponse(result)) {
+      logDiagnostic('refresh_invalid_response', {
+        userId,
+        attempt,
+        upstreamStatus: result.status,
+        bodyClass: result.upstream_body_class,
+        hasRetryAfter: result.retry_after !== undefined,
+      });
       console.error(`[yahoo-connect] Yahoo token refresh returned an invalid token response for user ${maskUserId(userId)}`);
       try {
         await storage.releaseRefreshLease(userId, ownerId);
@@ -537,15 +790,27 @@ async function getValidYahooAccessToken(
     );
 
     if (wrote) {
+      logDiagnostic('credential_update_succeeded', {
+        userId,
+        attempt,
+        accessTokenExpiresInSeconds: result.expires_in,
+      });
       console.log(`[yahoo-connect] Token refreshed for user ${maskUserId(userId)}`);
       return { accessToken: result.access_token, expiresIn: result.expires_in };
     }
 
+    logDiagnostic('credential_update_owner_guard_miss', { userId, attempt });
     const latest = await storage.getYahooCredentials(userId);
     if (!latest) {
+      logDiagnostic('credentials_missing_after_owner_guard_miss', { userId, attempt });
       return { error: 'not_connected' };
     }
     if (!latest.needsRefresh) {
+      logDiagnostic('owner_guard_miss_found_fresh_token', {
+        userId,
+        attempt,
+        accessTokenExpiresInSeconds: secondsUntil(latest.expiresAt),
+      });
       return toTokenResult(latest);
     }
     credentials = latest;
@@ -553,8 +818,13 @@ async function getValidYahooAccessToken(
 
   const latest = await storage.getYahooCredentials(userId);
   if (latest && !latest.needsRefresh) {
+    logDiagnostic('max_attempts_found_fresh_token', {
+      userId,
+      accessTokenExpiresInSeconds: secondsUntil(latest.expiresAt),
+    });
     return toTokenResult(latest);
   }
+  logDiagnostic('max_refresh_attempts_exhausted', { userId });
   return { error: 'refresh_failed' };
 }
 
@@ -902,11 +1172,12 @@ export async function handleYahooCallback(
 export async function handleYahooCredentials(
   env: YahooConnectEnv,
   userId: string,
-  corsHeaders: Record<string, string>
+  corsHeaders: Record<string, string>,
+  correlationId?: string
 ): Promise<Response> {
   try {
     const storage = YahooStorage.fromEnvironment(env);
-    const result = await getValidYahooAccessToken(storage, userId, env);
+    const result = await getValidYahooAccessToken(storage, userId, env, undefined, correlationId);
 
     if ('error' in result) {
       if (result.error === 'not_connected') {
@@ -944,6 +1215,91 @@ export async function handleYahooCredentials(
       JSON.stringify({
         error: 'server_error',
         error_description: 'Failed to retrieve credentials',
+      }),
+      {
+        status: 500,
+        headers: { 'Content-Type': 'application/json', ...corsHeaders },
+      }
+    );
+  }
+}
+
+/**
+ * GET /internal/connect/yahoo/credential-health
+ *
+ * Returns non-secret Yahoo credential timing and refresh lease state for
+ * production diagnostics. This never returns access tokens, refresh tokens, or
+ * raw lease owner IDs.
+ */
+export async function handleYahooCredentialHealth(
+  env: YahooConnectEnv,
+  userId: string,
+  corsHeaders: Record<string, string>
+): Promise<Response> {
+  try {
+    const storage = YahooStorage.fromEnvironment(env);
+    const credentials = await storage.getYahooCredentialHealth(userId);
+
+    if (!credentials) {
+      return new Response(
+        JSON.stringify({
+          connected: false,
+          hasCredentials: false,
+          platform: 'yahoo',
+          checkedAt: new Date().toISOString(),
+        }),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+            'Cache-Control': 'no-store',
+            ...corsHeaders,
+          },
+        }
+      );
+    }
+
+    const refreshState = yahooRefreshState(credentials);
+    const leaseRemainingSeconds = boundedPositiveSecondsUntil(credentials.refreshLeaseExpiresAt);
+    const checkedAt = new Date().toISOString();
+
+    return new Response(
+      JSON.stringify({
+        connected: true,
+        hasCredentials: true,
+        platform: 'yahoo',
+        checkedAt,
+        lastUpdated: credentials.updatedAt?.toISOString(),
+        yahooGuidPresent: credentials.yahooGuidPresent,
+        accessToken: {
+          expiresAt: credentials.expiresAt.toISOString(),
+          expiresInSeconds: secondsUntil(credentials.expiresAt),
+          needsRefresh: credentials.needsRefresh,
+          state: credentials.needsRefresh ? 'needs_refresh' : 'fresh',
+        },
+        refresh: {
+          state: refreshState === 'none' ? 'idle' : refreshState,
+          leaseExpiresAt: credentials.refreshLeaseExpiresAt?.toISOString(),
+          retryAfterSeconds: refreshState === 'cooldown' || refreshState === 'in_progress'
+            ? leaseRemainingSeconds
+            : undefined,
+        },
+      }),
+      {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+          'Cache-Control': 'no-store',
+          ...corsHeaders,
+        },
+      }
+    );
+  } catch (error) {
+    console.error('[yahoo-connect] Credential health error:', error);
+    return new Response(
+      JSON.stringify({
+        error: 'server_error',
+        error_description: 'Failed to retrieve Yahoo credential health',
       }),
       {
         status: 500,
@@ -1148,7 +1504,8 @@ interface DiscoveredYahooLeague {
 export async function handleYahooDiscover(
   env: YahooConnectEnv,
   userId: string,
-  corsHeaders: Record<string, string>
+  corsHeaders: Record<string, string>,
+  correlationId?: string
 ): Promise<Response> {
   try {
     const storage = YahooStorage.fromEnvironment(env);
@@ -1173,7 +1530,7 @@ export async function handleYahooDiscover(
     let accessToken = credentials.accessToken;
     if (credentials.needsRefresh) {
       console.log(`[yahoo-connect] Refreshing token before discovery for user ${maskUserId(userId)}`);
-      const tokenResult = await getValidYahooAccessToken(storage, userId, env, credentials);
+      const tokenResult = await getValidYahooAccessToken(storage, userId, env, credentials, correlationId);
       if ('error' in tokenResult) {
         return yahooRefreshFailureResponse(tokenResult, corsHeaders);
       }

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -734,7 +734,7 @@ async function getValidYahooAccessToken(
         }
         return toTokenResult(latest);
       }
-      if (isTransientYahooTokenFailure(result)) {
+      if (failureKind === 'transient_http' || failureKind === 'transient_text') {
         const retryAfter = retryAfterForTransientYahooTokenFailure(result);
         logDiagnostic('refresh_transient_failure', {
           userId,
@@ -1293,7 +1293,7 @@ export async function handleYahooCredentialHealth(
         hasCredentials: true,
         platform: 'yahoo',
         checkedAt,
-        lastUpdated: credentials.updatedAt?.toISOString(),
+        lastUpdated: credentials.updatedAt?.toISOString() ?? null,
         yahooGuidPresent: credentials.yahooGuidPresent,
         accessToken: {
           expiresAt: credentials.expiresAt.toISOString(),

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -149,6 +149,11 @@ function secondsUntil(date?: Date): number | undefined {
   return Math.ceil((date.getTime() - Date.now()) / 1000);
 }
 
+function nonNegativeSecondsUntil(date?: Date): number | undefined {
+  const seconds = secondsUntil(date);
+  return seconds !== undefined ? Math.max(seconds, 0) : undefined;
+}
+
 function boundedPositiveSecondsUntil(date?: Date): number | undefined {
   const seconds = secondsUntil(date);
   return seconds !== undefined && seconds > 0 ? seconds : undefined;
@@ -324,7 +329,7 @@ async function readYahooTokenResponse(
   const text = await response.text();
   const data = parseYahooTokenBody(text);
   const nonJsonDescription = data ? undefined : trimYahooTokenBody(text);
-  const failureBodyClass: YahooTokenBodyClass = data
+  const bodyClassForErrorPaths: YahooTokenBodyClass = data
     ? 'json_error'
     : text.trim().length === 0
       ? 'empty'
@@ -343,7 +348,7 @@ async function readYahooTokenResponse(
       upstream_error_text: nonJsonDescription,
       status: response.status,
       retry_after: retryAfter ?? defaultYahooRetryAfterSeconds(response.status),
-      upstream_body_class: failureBodyClass,
+      upstream_body_class: bodyClassForErrorPaths,
     };
   }
 
@@ -357,7 +362,7 @@ async function readYahooTokenResponse(
       upstream_error_text: nonJsonDescription,
       status: response.status,
       retry_after: retryAfter ?? defaultYahooRetryAfterSeconds(response.status),
-      upstream_body_class: failureBodyClass,
+      upstream_body_class: bodyClassForErrorPaths,
     };
   }
 
@@ -1235,7 +1240,8 @@ export async function handleYahooCredentials(
 export async function handleYahooCredentialHealth(
   env: YahooConnectEnv,
   userId: string,
-  corsHeaders: Record<string, string>
+  corsHeaders: Record<string, string>,
+  correlationId?: string
 ): Promise<Response> {
   try {
     const storage = YahooStorage.fromEnvironment(env);
@@ -1274,7 +1280,7 @@ export async function handleYahooCredentialHealth(
         yahooGuidPresent: credentials.yahooGuidPresent,
         accessToken: {
           expiresAt: credentials.expiresAt.toISOString(),
-          expiresInSeconds: secondsUntil(credentials.expiresAt),
+          expiresInSeconds: nonNegativeSecondsUntil(credentials.expiresAt),
           needsRefresh: credentials.needsRefresh,
           state: credentials.needsRefresh ? 'needs_refresh' : 'fresh',
         },
@@ -1296,6 +1302,11 @@ export async function handleYahooCredentialHealth(
       }
     );
   } catch (error) {
+    logYahooRefreshDiagnostic('credential_health_error', {
+      correlationId,
+      userId,
+      reason: 'storage_error',
+    });
     console.error('[yahoo-connect] Credential health error:', error);
     return new Response(
       JSON.stringify({

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -143,28 +143,31 @@ function maskUserId(userId: string): string {
   return `${userId.substring(0, 8)}...`;
 }
 
-function secondsUntil(date?: Date): number | undefined {
+function secondsUntil(date?: Date, nowMs = Date.now()): number | undefined {
   if (!date) {
     return undefined;
   }
-  return Math.ceil((date.getTime() - Date.now()) / 1000);
+  return Math.ceil((date.getTime() - nowMs) / 1000);
 }
 
-function nonNegativeSecondsUntil(date?: Date): number | undefined {
-  const seconds = secondsUntil(date);
+function nonNegativeSecondsUntil(date?: Date, nowMs = Date.now()): number | undefined {
+  const seconds = secondsUntil(date, nowMs);
   return seconds !== undefined ? Math.max(seconds, 0) : undefined;
 }
 
-function boundedPositiveSecondsUntil(date?: Date): number | undefined {
-  const seconds = secondsUntil(date);
+function boundedPositiveSecondsUntil(date?: Date, nowMs = Date.now()): number | undefined {
+  const seconds = secondsUntil(date, nowMs);
   return seconds !== undefined && seconds > 0 ? seconds : undefined;
 }
 
-function yahooRefreshState(credentials: { refreshLeaseOwner?: string; refreshLeaseExpiresAt?: Date } | null): YahooCredentialRefreshState {
+function yahooRefreshState(
+  credentials: { refreshLeaseOwner?: string; refreshLeaseExpiresAt?: Date } | null,
+  nowMs = Date.now()
+): YahooCredentialRefreshState {
   if (!credentials?.refreshLeaseOwner) {
     return 'none';
   }
-  if (leaseExpired(credentials)) {
+  if (leaseExpired(credentials, nowMs)) {
     return 'expired';
   }
   return credentials.refreshLeaseOwner.startsWith(REFRESH_COOLDOWN_OWNER_PREFIX)
@@ -406,12 +409,15 @@ function toTokenResult(credentials: { accessToken: string; expiresAt: Date }): G
   };
 }
 
-function leaseExpired(credentials: { refreshLeaseOwner?: string; refreshLeaseExpiresAt?: Date } | null): boolean {
+function leaseExpired(
+  credentials: { refreshLeaseOwner?: string; refreshLeaseExpiresAt?: Date } | null,
+  nowMs = Date.now()
+): boolean {
   if (!credentials?.refreshLeaseOwner) {
     return true;
   }
   return credentials.refreshLeaseExpiresAt
-    ? credentials.refreshLeaseExpiresAt.getTime() <= Date.now()
+    ? credentials.refreshLeaseExpiresAt.getTime() <= nowMs
     : true;
 }
 
@@ -1268,9 +1274,11 @@ export async function handleYahooCredentialHealth(
       );
     }
 
-    const refreshState = yahooRefreshState(credentials);
+    const checkedAtDate = new Date();
+    const checkedAtNowMs = checkedAtDate.getTime();
+    const refreshState = yahooRefreshState(credentials, checkedAtNowMs);
     const responseRefreshState = refreshState === 'none' ? 'idle' : refreshState;
-    const leaseRemainingSeconds = boundedPositiveSecondsUntil(credentials.refreshLeaseExpiresAt);
+    const leaseRemainingSeconds = boundedPositiveSecondsUntil(credentials.refreshLeaseExpiresAt, checkedAtNowMs);
     const refresh: Record<string, string | number | undefined> = {
       state: responseRefreshState,
     };
@@ -1280,7 +1288,7 @@ export async function handleYahooCredentialHealth(
     if (refreshState === 'cooldown' || refreshState === 'in_progress') {
       refresh.retryAfterSeconds = leaseRemainingSeconds;
     }
-    const checkedAt = new Date().toISOString();
+    const checkedAt = checkedAtDate.toISOString();
 
     return new Response(
       JSON.stringify({
@@ -1292,7 +1300,7 @@ export async function handleYahooCredentialHealth(
         yahooGuidPresent: credentials.yahooGuidPresent,
         accessToken: {
           expiresAt: credentials.expiresAt.toISOString(),
-          expiresInSeconds: nonNegativeSecondsUntil(credentials.expiresAt),
+          expiresInSeconds: nonNegativeSecondsUntil(credentials.expiresAt, checkedAtNowMs),
           needsRefresh: credentials.needsRefresh,
           state: credentials.needsRefresh ? 'needs_refresh' : 'fresh',
         },

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -43,11 +43,15 @@ export interface YahooConnectEnv {
   FRONTEND_URL?: string;
 }
 
+// Yahoo's token endpoint returns success and error bodies through the same
+// parser. Error bodies are normalized with inert placeholders for the required
+// token fields; use isUsableTokenResponse before treating a parsed body as a
+// usable token.
 interface YahooTokenResponse {
-  access_token?: string;
+  access_token: string;
   refresh_token?: string;
-  expires_in?: number;
-  token_type?: string;
+  expires_in: number;
+  token_type: string;
   xoauth_yahoo_guid?: string;
   status?: number;
   error?: string;
@@ -227,12 +231,16 @@ type UsableYahooTokenResponse =
     expires_in: number;
   };
 
-function isUsableTokenResponse(response: Partial<YahooTokenResponse>): response is UsableYahooTokenResponse {
+function hasUsableTokenFields(response: Partial<YahooTokenResponse>): boolean {
   return typeof response.access_token === 'string'
     && response.access_token.length > 0
     && typeof response.expires_in === 'number'
     && Number.isFinite(response.expires_in)
     && response.expires_in > 0;
+}
+
+function isUsableTokenResponse(response: Partial<YahooTokenResponse>): response is UsableYahooTokenResponse {
+  return hasUsableTokenFields(response);
 }
 
 function toYahooTokenResponse(response: UsableYahooTokenResponse): YahooTokenResponse {
@@ -739,13 +747,7 @@ async function getValidYahooAccessToken(
         logDiagnostic('refresh_transient_failure', {
           userId,
           attempt,
-          upstreamStatus: result.status,
-          tokenError: result.error,
-          failureKind,
-          bodyClass: result.upstream_body_class,
           retryAfter,
-          hasRetryAfter: result.retry_after !== undefined,
-          hasUpstreamErrorText: Boolean(result.upstream_error_text),
         });
         await markYahooRefreshCooldown(storage, userId, ownerId, retryAfter, correlationId);
         return {
@@ -775,7 +777,7 @@ async function getValidYahooAccessToken(
       };
     }
 
-    if (!isUsableTokenResponse(result)) {
+    if (!hasUsableTokenFields(result)) {
       logDiagnostic('refresh_invalid_response', {
         userId,
         attempt,
@@ -1134,7 +1136,7 @@ export async function handleYahooCallback(
       );
     }
 
-    if (!isUsableTokenResponse(validatedTokenResponse)) {
+    if (!hasUsableTokenFields(validatedTokenResponse)) {
       console.error('[yahoo-connect] Refresh token validation returned an invalid token response after Yahoo callback');
       return errorRedirect(
         'token_refresh_validation_failed',
@@ -1326,7 +1328,11 @@ export async function handleYahooCredentialHealth(
       }),
       {
         status: 500,
-        headers: { 'Content-Type': 'application/json', ...corsHeaders },
+        headers: {
+          'Content-Type': 'application/json',
+          'Cache-Control': 'no-store',
+          ...corsHeaders,
+        },
       }
     );
   }

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -1273,9 +1273,10 @@ export async function handleYahooCredentialHealth(
     const checkedAtDate = new Date();
     const checkedAtNowMs = checkedAtDate.getTime();
     const refreshState = yahooRefreshState(credentials, checkedAtNowMs);
+    // Keep the internal lease-state enum distinct from the external diagnostic contract.
     const responseRefreshState = refreshState === 'none' ? 'idle' : refreshState;
     const leaseRemainingSeconds = boundedPositiveSecondsUntil(credentials.refreshLeaseExpiresAt, checkedAtNowMs);
-    const refresh: Record<string, string | number> = {
+    const refresh: { state: string; leaseExpiresAt?: string; retryAfterSeconds?: number } = {
       state: responseRefreshState,
     };
     if (refreshState !== 'none' && credentials.refreshLeaseExpiresAt) {

--- a/workers/auth-worker/src/yahoo-storage.ts
+++ b/workers/auth-worker/src/yahoo-storage.ts
@@ -49,6 +49,16 @@ export interface YahooCredentials {
   refreshLeaseExpiresAt?: Date;
 }
 
+export interface YahooCredentialHealth {
+  clerkUserId: string;
+  expiresAt: Date;
+  yahooGuidPresent: boolean;
+  needsRefresh: boolean;
+  updatedAt?: Date;
+  refreshLeaseOwner?: string;
+  refreshLeaseExpiresAt?: Date;
+}
+
 export interface SaveCredentialsParams {
   clerkUserId: string;
   accessToken: string;
@@ -231,6 +241,45 @@ export class YahooStorage {
       refreshToken: data.refresh_token,
       expiresAt,
       yahooGuid: data.yahoo_guid || undefined,
+      needsRefresh,
+      updatedAt: data.updated_at ? new Date(data.updated_at) : undefined,
+      refreshLeaseOwner: data.refresh_lease_owner ?? undefined,
+      refreshLeaseExpiresAt: data.refresh_lease_expires_at
+        ? new Date(data.refresh_lease_expires_at)
+        : undefined,
+    };
+  }
+
+  /**
+   * Get non-secret Yahoo credential health for diagnostics.
+   * Does not select access_token or refresh_token.
+   */
+  async getYahooCredentialHealth(clerkUserId: string): Promise<YahooCredentialHealth | null> {
+    const { data, error } = await this.supabase
+      .from('yahoo_credentials')
+      .select('clerk_user_id, expires_at, yahoo_guid, updated_at, refresh_lease_owner, refresh_lease_expires_at')
+      .eq('clerk_user_id', clerkUserId)
+      .single();
+
+    if (error) {
+      if (error.code === 'PGRST116') {
+        return null;
+      }
+      console.error('[yahoo-storage] Failed to get Yahoo credential health:', error);
+      throw new Error('Failed to get Yahoo credential health');
+    }
+
+    if (!data) {
+      return null;
+    }
+
+    const expiresAt = new Date(data.expires_at);
+    const needsRefresh = expiresAt.getTime() - Date.now() < REFRESH_BUFFER_MS;
+
+    return {
+      clerkUserId: data.clerk_user_id,
+      expiresAt,
+      yahooGuidPresent: Boolean(data.yahoo_guid),
       needsRefresh,
       updatedAt: data.updated_at ? new Date(data.updated_at) : undefined,
       refreshLeaseOwner: data.refresh_lease_owner ?? undefined,


### PR DESCRIPTION
## Summary
- add structured, non-secret Yahoo refresh diagnostics across fresh-token, lease, cooldown, transient, and write-guard paths
- add internal Yahoo credential-health endpoint that exposes timing/refresh state without selecting tokens
- thread X-Correlation-ID through credentials/discovery refresh paths for incident tracing

## Why
Recent Yahoo cooldown errors tell the client to retry, but they do not give us enough production evidence to distinguish Yahoo upstream failure, active cooldown, lease contention, or storage/write-guard behavior. This PR keeps the reliability behavior intact and adds the minimum diagnostic surface needed for the next incident.

## Validation
- git diff --check
- corepack pnpm --dir workers/auth-worker test -- yahoo-connect-handlers yahoo-storage eval-api-key
- corepack pnpm --dir workers/auth-worker type-check

Note: local shell is Node v26.0.0 while the package declares Node 24.x; checks passed despite the engine warning.