### PR TITLE
Clarify Yahoo connection actions

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,7 +14,8 @@ Follow Keep a Changelog; stamp a version when submitting to directories.
 
 ### Yahoo Connection Reliability
 - **Added**: Yahoo token-refresh diagnostics now emit structured non-secret refresh events and expose an internal credential-health endpoint for production incident triage.
-- **Changed**: Yahoo Refresh on `/leagues` now uses the stored connection to rediscover leagues instead of starting a fresh OAuth flow every time.
+- **Added**: Yahoo connection management on `/leagues` now separates **Sync leagues** from **Reconnect Yahoo** and shows coarse temporary-unavailable/reconnect-needed states.
+- **Changed**: Yahoo **Sync leagues** on `/leagues` now uses the stored connection to rediscover leagues instead of starting a fresh OAuth flow every time.
 - **Changed**: Yahoo refresh lease waiters now return an explicit retryable response before the MCP gateway timeout budget is exhausted.
 - **Fixed**: Yahoo league discovery rate limits (`429`/`999`) and transient upstream failures now return retryable responses with `Retry-After` instead of generic refresh failures.
 - **Fixed**: Yahoo transient token-refresh failures now set a short cooldown so near-concurrent tool calls do not immediately re-hit Yahoo's token endpoint.

--- a/web/app/(site)/guide/platforms/page.tsx
+++ b/web/app/(site)/guide/platforms/page.tsx
@@ -57,7 +57,7 @@ export default function PlatformsGuidePage() {
                 },
                 {
                   "@type": "HowToStep",
-                  name: "Authenticate Yahoo",
+                  name: "Connect Yahoo",
                   text: "Start Yahoo auth and approve Flaim access.",
                 },
                 {
@@ -236,6 +236,15 @@ export default function PlatformsGuidePage() {
             <h3 className="mb-2 font-medium">Yahoo troubleshooting</h3>
             <ul className="list-disc list-inside space-y-2 text-sm text-muted-foreground">
               <li>
+                Sync leagues pulls the latest league list using the current
+                Yahoo connection. Reconnect Yahoo opens Yahoo sign-in again.
+              </li>
+              <li>
+                Temporarily unavailable means Yahoo is asking Flaim to wait
+                before another sync. Try again after the suggested wait, or
+                reconnect Yahoo if it keeps happening.
+              </li>
+              <li>
                 Auth completed but Flaim still looks disconnected: retry from{" "}
                 <Link href="/leagues" className="text-primary hover:underline">
                   /leagues
@@ -247,7 +256,8 @@ export default function PlatformsGuidePage() {
                 has supported active leagues and reconnect.
               </li>
               <li>
-                Yahoo worked before and stopped: reconnect to refresh access.
+                Yahoo worked before and stopped: reconnect Yahoo to repair the
+                stored authorization.
               </li>
             </ul>
           </div>

--- a/web/app/(site)/leagues/page.tsx
+++ b/web/app/(site)/leagues/page.tsx
@@ -172,7 +172,7 @@ const EMPTY_USER_PREFERENCES: UserPreferencesState = {
   defaultBasketball: null,
   defaultHockey: null,
 };
-const YAHOO_STATUS_RECHECK_FALLBACK_SECONDS = 30;
+const YAHOO_STATUS_RECHECK_FALLBACK_SECONDS = 60;
 const YAHOO_STATUS_RECHECK_MAX_SECONDS = 15 * 60;
 
 function capitalize(s: string): string {
@@ -2585,6 +2585,7 @@ function LeaguesPageContent() {
               >
                 <div className="flex items-center gap-2">
                   <span className="text-lg">Yahoo</span>
+                  {/* Badge classes are literal strings in yahoo-connection-display.ts for Tailwind scanning. */}
                   <span className={`text-xs px-2 py-0.5 rounded-full ${yahooBadgeCopy.className}`}>
                     {isYahooStatusChecking ? (
                       <span className="flex items-center gap-1">

--- a/web/app/(site)/leagues/page.tsx
+++ b/web/app/(site)/leagues/page.tsx
@@ -938,8 +938,8 @@ function LeaguesPageContent() {
           return;
         }
         if (isYahooTransientAuthResponse(data)) {
-          // Surface the temporary Yahoo state where the sync/reconnect actions live,
-          // instead of leaving the user with a detached page-level notice.
+          // Intentionally open the Yahoo panel so the temporary state appears beside
+          // the Sync leagues and Reconnect Yahoo actions that resolve it.
           const retryAfterSeconds = typeof data.retry_after === 'number' &&
             Number.isFinite(data.retry_after) &&
             data.retry_after > 0

--- a/web/app/(site)/leagues/page.tsx
+++ b/web/app/(site)/leagues/page.tsx
@@ -790,6 +790,7 @@ function LeaguesPageContent() {
 
     let isActive = true;
     const retryTimer = window.setTimeout(() => {
+      // Show the checking state immediately; checkYahooStatus clears it when the status request settles.
       setIsCheckingYahoo(true);
       void checkYahooStatus(() => isActive);
     }, Math.ceil(recheckAfterSeconds * 1000));

--- a/web/app/(site)/leagues/page.tsx
+++ b/web/app/(site)/leagues/page.tsx
@@ -166,6 +166,7 @@ const EMPTY_USER_PREFERENCES: UserPreferencesState = {
   defaultHockey: null,
 };
 const YAHOO_STATUS_RECHECK_FALLBACK_SECONDS = 5;
+const YAHOO_STATUS_RECHECK_MAX_SECONDS = 15 * 60;
 
 function capitalize(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1);
@@ -867,21 +868,16 @@ function LeaguesPageContent() {
     if (refreshState !== 'cooldown' && refreshState !== 'in_progress') {
       return;
     }
-    const recheckAfterSeconds = typeof retryAfterSeconds === 'number' && retryAfterSeconds > 0
-      ? retryAfterSeconds
-      : YAHOO_STATUS_RECHECK_FALLBACK_SECONDS;
+    const recheckAfterSeconds = Math.min(
+      typeof retryAfterSeconds === 'number' && retryAfterSeconds > 0
+        ? retryAfterSeconds
+        : YAHOO_STATUS_RECHECK_FALLBACK_SECONDS,
+      YAHOO_STATUS_RECHECK_MAX_SECONDS
+    );
 
     let isActive = true;
     const retryTimer = window.setTimeout(() => {
-      setYahooHealth((current) => {
-        if (
-          current?.refreshState === refreshState &&
-          current.retryAfterSeconds === retryAfterSeconds
-        ) {
-          return { ...current, retryAfterSeconds: undefined };
-        }
-        return current;
-      });
+      setIsCheckingYahoo(true);
       void checkYahooStatus(() => isActive);
     }, Math.ceil(recheckAfterSeconds * 1000));
 
@@ -1634,8 +1630,6 @@ function LeaguesPageContent() {
   const isYahooTemporarilyBusy =
     yahooDisplayState === 'cooldown' ||
     yahooDisplayState === 'in_progress';
-  const isYahooSyncTemporarilyBlocked =
-    isYahooTemporarilyBusy;
   const shouldShowYahooStatusAlert =
     isYahooTemporarilyBusy ||
     yahooDisplayState === 'reconnect_needed';
@@ -2721,7 +2715,7 @@ function LeaguesPageContent() {
                           variant="default"
                           size="sm"
                           onClick={discoverYahooLeagues}
-                          disabled={isDiscoveringYahoo || isYahooSyncTemporarilyBlocked}
+                          disabled={isDiscoveringYahoo || isYahooTemporarilyBusy}
                           className="w-full sm:w-auto"
                         >
                           {isDiscoveringYahoo ? (

--- a/web/app/(site)/leagues/page.tsx
+++ b/web/app/(site)/leagues/page.tsx
@@ -2586,7 +2586,6 @@ function LeaguesPageContent() {
               >
                 <div className="flex items-center gap-2">
                   <span className="text-lg">Yahoo</span>
-                  {/* Badge classes are literal strings in yahoo-connection-display.ts for Tailwind scanning. */}
                   <span className={`text-xs px-2 py-0.5 rounded-full ${yahooBadgeCopy.className}`}>
                     {isYahooStatusChecking ? (
                       <span className="flex items-center gap-1">

--- a/web/app/(site)/leagues/page.tsx
+++ b/web/app/(site)/leagues/page.tsx
@@ -2602,7 +2602,7 @@ function LeaguesPageContent() {
               </button>
               {isYahooSetupOpen && (
                 <div id="yahoo-setup-content" className="px-4 pb-4 space-y-3">
-                  {!shouldShowYahooStatusAlert && (
+                  {!shouldShowYahooStatusAlert && yahooDisplayState !== 'checking' && (
                     <p className="text-sm text-muted-foreground">
                       {yahooStatusCopy}
                     </p>

--- a/web/app/(site)/leagues/page.tsx
+++ b/web/app/(site)/leagues/page.tsx
@@ -165,7 +165,7 @@ const EMPTY_USER_PREFERENCES: UserPreferencesState = {
   defaultBasketball: null,
   defaultHockey: null,
 };
-const YAHOO_STATUS_RECHECK_FALLBACK_SECONDS = 5;
+const YAHOO_STATUS_RECHECK_FALLBACK_SECONDS = 30;
 const YAHOO_STATUS_RECHECK_MAX_SECONDS = 15 * 60;
 
 function capitalize(s: string): string {
@@ -1027,16 +1027,19 @@ function LeaguesPageContent() {
         if (isYahooTransientAuthResponse(data)) {
           // Surface the temporary Yahoo state where the sync/reconnect actions live,
           // instead of leaving the user with a detached page-level notice.
+          const retryAfterSeconds = typeof data.retry_after === 'number' &&
+            Number.isFinite(data.retry_after) &&
+            data.retry_after > 0
+            ? data.retry_after
+            : undefined;
           setIsYahooSetupOpen(true);
           setIsYahooConnected(true);
           setIsYahooReconnectNeeded(false);
-          if (data.retry_after !== undefined) {
-            setYahooHealth({
-              accessTokenState: 'needs_refresh',
-              refreshState: 'cooldown',
-              retryAfterSeconds: data.retry_after,
-            });
-          }
+          setYahooHealth({
+            accessTokenState: 'needs_refresh',
+            refreshState: 'cooldown',
+            retryAfterSeconds,
+          });
           setLeagueError(null);
           setLeagueNotice(null);
           shouldCheckYahooStatus = false;

--- a/web/app/(site)/leagues/page.tsx
+++ b/web/app/(site)/leagues/page.tsx
@@ -47,8 +47,8 @@ import {
 import { useEspnCredentials } from '@/lib/use-espn-credentials';
 import { getDefaultSeasonYear, getPreviousSeasonYear, getSeasonYearOptions } from '@/lib/season-utils';
 import {
+  formatYahooRetryAfter,
   getYahooConnectErrorMessage,
-  getYahooTransientAuthMessage,
   isYahooReconnectRequired,
   isYahooTransientAuthError,
   isYahooTransientAuthResponse,
@@ -259,6 +259,99 @@ function canApplyState(shouldApply?: () => boolean): boolean {
 }
 
 type ConnectionStatusResult = 'connected' | 'disconnected' | 'unknown';
+type YahooAccessTokenState = 'fresh' | 'needs_refresh';
+type YahooRefreshState = 'idle' | 'in_progress' | 'cooldown' | 'expired';
+type YahooDisplayState =
+  | 'checking'
+  | 'not_connected'
+  | 'connected'
+  | 'in_progress'
+  | 'cooldown'
+  | 'reconnect_needed';
+
+interface YahooConnectionHealth {
+  accessTokenState: YahooAccessTokenState;
+  refreshState: YahooRefreshState;
+  retryAfterSeconds?: number;
+}
+
+function parseYahooConnectionHealth(value: unknown): YahooConnectionHealth | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  const accessTokenState = record.accessTokenState;
+  const refreshState = record.refreshState;
+  if (
+    (accessTokenState !== 'fresh' && accessTokenState !== 'needs_refresh') ||
+    (refreshState !== 'idle' && refreshState !== 'in_progress' && refreshState !== 'cooldown' && refreshState !== 'expired')
+  ) {
+    return null;
+  }
+
+  const retryAfterSeconds = typeof record.retryAfterSeconds === 'number' && Number.isFinite(record.retryAfterSeconds)
+    ? record.retryAfterSeconds
+    : undefined;
+
+  return {
+    accessTokenState,
+    refreshState,
+    retryAfterSeconds,
+  };
+}
+
+function getYahooDisplayState(
+  isChecking: boolean,
+  isConnected: boolean,
+  isReconnectNeeded: boolean,
+  health: YahooConnectionHealth | null
+): YahooDisplayState {
+  if (isChecking) return 'checking';
+  if (isReconnectNeeded) return 'reconnect_needed';
+  if (!isConnected) return 'not_connected';
+  if (health?.refreshState === 'cooldown') return 'cooldown';
+  if (health?.refreshState === 'in_progress') return 'in_progress';
+  return 'connected';
+}
+
+function getYahooBadgeCopy(state: YahooDisplayState): { label: string; className: string } {
+  switch (state) {
+    case 'checking':
+      return { label: 'Checking...', className: 'bg-muted text-muted-foreground' };
+    case 'connected':
+      return { label: 'Connected', className: 'bg-success/20 text-success' };
+    case 'cooldown':
+      return { label: 'Yahoo temporarily unavailable', className: 'bg-warning/20 text-warning' };
+    case 'in_progress':
+      return { label: 'Checking Yahoo', className: 'bg-warning/20 text-warning' };
+    case 'reconnect_needed':
+      return { label: 'Reconnect needed', className: 'bg-destructive/10 text-destructive' };
+    case 'not_connected':
+    default:
+      return { label: 'Not connected', className: 'bg-muted text-muted-foreground' };
+  }
+}
+
+function getYahooStatusCopy(state: YahooDisplayState, health: YahooConnectionHealth | null): string {
+  const retryAfter = formatYahooRetryAfter(health?.retryAfterSeconds);
+
+  switch (state) {
+    case 'connected':
+      return 'Sync leagues pulls your latest Yahoo leagues using your current Yahoo connection. Reconnect Yahoo opens Yahoo sign-in again if the connection needs repair.';
+    case 'cooldown':
+      return `Yahoo is temporarily unavailable. ${retryAfter ? `Try syncing leagues again in ${retryAfter}.` : 'Try syncing leagues again in a few minutes.'} If this keeps happening, reconnect Yahoo.`;
+    case 'in_progress':
+      return `Yahoo is finishing a login check from another request. ${retryAfter ? `Try syncing leagues again in ${retryAfter}.` : 'Try syncing leagues again shortly.'}`;
+    case 'reconnect_needed':
+      return 'Yahoo needs you to sign in again before Flaim can sync leagues or answer Yahoo questions.';
+    case 'not_connected':
+      return 'Connect your Yahoo account to add leagues.';
+    case 'checking':
+    default:
+      return 'Checking Yahoo connection...';
+  }
+}
 
 function isSleeperDisconnectedStatus(status: number, data: { error?: string }): boolean {
   return status === 401 || status === 403 || data.error === 'not_connected';
@@ -372,6 +465,8 @@ function LeaguesPageContent() {
   const [espnAdvancedOpen, setEspnAdvancedOpen] = useState(false);
   const [isYahooSetupOpen, setIsYahooSetupOpen] = useState(false);
   const [isYahooConnected, setIsYahooConnected] = useState(false);
+  const [yahooHealth, setYahooHealth] = useState<YahooConnectionHealth | null>(null);
+  const [isYahooReconnectNeeded, setIsYahooReconnectNeeded] = useState(false);
   const [yahooLastUpdated, setYahooLastUpdated] = useState<string | null>(null);
   const [isCheckingYahoo, setIsCheckingYahoo] = useState(true);
   const [isYahooDisconnecting, setIsYahooDisconnecting] = useState(false);
@@ -379,7 +474,7 @@ function LeaguesPageContent() {
   const [isLoadingYahooLeagues, setIsLoadingYahooLeagues] = useState(true);
   const [isRefreshingEspn, setIsRefreshingEspn] = useState(false);
   const [isDiscoveringYahoo, setIsDiscoveringYahoo] = useState(false);
-  const [isRefreshingYahooAuth, setIsRefreshingYahooAuth] = useState(false);
+  const [isReconnectingYahoo, setIsReconnectingYahoo] = useState(false);
   const [sleeperLeagues, setSleeperLeagues] = useState<SleeperLeague[]>([]);
   const [deletingSleeperKey, setDeletingSleeperKey] = useState<string | null>(null);
   const [isSleeperSetupOpen, setIsSleeperSetupOpen] = useState(false);
@@ -430,6 +525,8 @@ function LeaguesPageContent() {
 
   const clearYahooConnectionState = useCallback(() => {
     setIsYahooConnected(false);
+    setYahooHealth(null);
+    setIsYahooReconnectNeeded(false);
     setYahooLastUpdated(null);
     setYahooLeagues([]);
   }, []);
@@ -459,7 +556,7 @@ function LeaguesPageContent() {
     setIsRefreshingEspn(false);
     setEspnAdvancedOpen(false);
     setIsDiscoveringYahoo(false);
-    setIsRefreshingYahooAuth(false);
+    setIsReconnectingYahoo(false);
     setIsYahooDisconnecting(false);
     setIsDiscoveringSleeper(false);
     setIsSleeperDisconnecting(false);
@@ -681,12 +778,15 @@ function LeaguesPageContent() {
       const data = await res.json().catch(() => ({})) as {
         connected?: boolean;
         lastUpdated?: string;
+        health?: unknown;
         error?: string;
       };
       if (res.ok) {
         if (!canApplyState(shouldApply)) return 'unknown';
         const connected = data.connected ?? false;
         setIsYahooConnected(connected);
+        setYahooHealth(connected ? parseYahooConnectionHealth(data.health) : null);
+        setIsYahooReconnectNeeded(false);
         setYahooLastUpdated(connected ? data.lastUpdated || null : null);
         if (!connected) {
           setYahooLeagues([]);
@@ -754,6 +854,47 @@ function LeaguesPageContent() {
       if (canApplyState(shouldApply)) setIsCheckingSleeper(false);
     }
   }, [clearSleeperConnectionState]);
+
+  useEffect(() => {
+    if (!isLoaded || !isSignedIn || !userId) {
+      return;
+    }
+    const refreshState = yahooHealth?.refreshState;
+    const retryAfterSeconds = yahooHealth?.retryAfterSeconds;
+    if (
+      (refreshState !== 'cooldown' && refreshState !== 'in_progress') ||
+      typeof retryAfterSeconds !== 'number' ||
+      retryAfterSeconds <= 0
+    ) {
+      return;
+    }
+
+    let isActive = true;
+    const retryTimer = window.setTimeout(() => {
+      setYahooHealth((current) => {
+        if (
+          current?.refreshState === refreshState &&
+          current.retryAfterSeconds === retryAfterSeconds
+        ) {
+          return { ...current, retryAfterSeconds: undefined };
+        }
+        return current;
+      });
+      void checkYahooStatus(() => isActive);
+    }, Math.ceil(retryAfterSeconds * 1000));
+
+    return () => {
+      isActive = false;
+      window.clearTimeout(retryTimer);
+    };
+  }, [
+    checkYahooStatus,
+    isLoaded,
+    isSignedIn,
+    userId,
+    yahooHealth?.refreshState,
+    yahooHealth?.retryAfterSeconds,
+  ]);
 
   const loadYahooLeagues = useCallback(async (shouldApply?: () => boolean) => {
     if (canApplyState(shouldApply)) setIsLoadingYahooLeagues(true);
@@ -880,25 +1021,40 @@ function LeaguesPageContent() {
           // The opened panel and notice are the reconnect prompt, so skip the error banner.
           setIsYahooSetupOpen(true);
           clearYahooConnectionState();
-          setLeagueNotice('Your Yahoo session has expired. Click Connect Yahoo to sign in again and pull your latest leagues.');
+          setIsYahooReconnectNeeded(true);
+          setLeagueNotice(null);
           shouldCheckYahooStatus = false;
           return;
         }
         if (isYahooTransientAuthResponse(data)) {
+          setIsYahooSetupOpen(true);
           setIsYahooConnected(true);
+          setIsYahooReconnectNeeded(false);
+          if (data.retry_after !== undefined) {
+            setYahooHealth({
+              accessTokenState: 'needs_refresh',
+              refreshState: 'cooldown',
+              retryAfterSeconds: data.retry_after,
+            });
+          }
           setLeagueError(null);
-          setLeagueNotice(getYahooTransientAuthMessage(data));
+          setLeagueNotice(null);
           shouldCheckYahooStatus = false;
           return;
         }
-        throw new Error(data.error_description || data.error || 'Failed to refresh Yahoo leagues');
+        throw new Error(data.error_description || data.error || 'Failed to sync Yahoo leagues');
       }
       didLoadYahooLeagues = true;
+      setYahooHealth({
+        accessTokenState: 'fresh',
+        refreshState: 'idle',
+      });
+      setIsYahooReconnectNeeded(false);
       await loadYahooLeagues(shouldApply);
     } catch (err) {
       if (shouldApply()) {
         console.error('Failed to discover Yahoo leagues:', err);
-        setLeagueError(err instanceof Error ? err.message : 'Failed to refresh Yahoo leagues');
+        setLeagueError(err instanceof Error ? err.message : 'Failed to sync Yahoo leagues');
       }
     } finally {
       if (shouldApply()) {
@@ -915,26 +1071,27 @@ function LeaguesPageContent() {
     }
   }, [checkYahooStatus, clearYahooConnectionState, createAccountGuard, loadYahooLeagues]);
 
-  const refreshYahooAuth = () => {
+  const reconnectYahoo = () => {
     setLeagueError(null);
     setLeagueNotice(null);
-    setIsRefreshingYahooAuth(true);
+    setIsYahooReconnectNeeded(false);
+    setIsReconnectingYahoo(true);
     window.location.href = '/api/connect/yahoo/authorize';
   };
 
   useEffect(() => {
-    if (!isRefreshingYahooAuth) {
+    if (!isReconnectingYahoo) {
       return;
     }
 
-    const resetRefreshState = () => setIsRefreshingYahooAuth(false);
-    const resetTimer = window.setTimeout(resetRefreshState, 15_000);
+    const resetReconnectState = () => setIsReconnectingYahoo(false);
+    const resetTimer = window.setTimeout(resetReconnectState, 15_000);
     const handlePageHide = () => {
       window.clearTimeout(resetTimer);
     };
     const handlePageShow = (event: PageTransitionEvent) => {
       if (event.persisted) {
-        resetRefreshState();
+        resetReconnectState();
       }
     };
 
@@ -946,7 +1103,7 @@ function LeaguesPageContent() {
       window.removeEventListener('pagehide', handlePageHide);
       window.removeEventListener('pageshow', handlePageShow);
     };
-  }, [isRefreshingYahooAuth]);
+  }, [isReconnectingYahoo]);
 
   const disconnectYahoo = useCallback(async () => {
     const shouldApply = createAccountGuard();
@@ -956,9 +1113,7 @@ function LeaguesPageContent() {
     try {
       const res = await fetch('/api/connect/yahoo/disconnect', { method: 'DELETE' });
       if (shouldApply() && res.ok) {
-        setIsYahooConnected(false);
-        setYahooLastUpdated(null);
-        setYahooLeagues([]);
+        clearYahooConnectionState();
       }
     } catch (err) {
       if (shouldApply()) {
@@ -970,7 +1125,7 @@ function LeaguesPageContent() {
         setIsYahooDisconnecting(false);
       }
     }
-  }, [createAccountGuard]);
+  }, [clearYahooConnectionState, createAccountGuard]);
 
   useEffect(() => {
     if (!isLoaded) {
@@ -1036,12 +1191,14 @@ function LeaguesPageContent() {
 
     const yahooError = searchParams.get('error');
     if (yahooError) {
+      const retryAfterParam = searchParams.get('retry_after');
+      const retryAfter = retryAfterParam ? Number(retryAfterParam) : undefined;
       if (isYahooTransientAuthError(yahooError)) {
         setLeagueError(null);
-        setLeagueNotice(getYahooConnectErrorMessage(yahooError, searchParams.get('error_description')));
+        setLeagueNotice(getYahooConnectErrorMessage(yahooError, searchParams.get('error_description'), retryAfter));
       } else {
         setLeagueNotice(null);
-        setLeagueError(getYahooConnectErrorMessage(yahooError, searchParams.get('error_description')));
+        setLeagueError(getYahooConnectErrorMessage(yahooError, searchParams.get('error_description'), retryAfter));
         setIsYahooSetupOpen(true);
       }
       router.replace('/leagues', { scroll: false });
@@ -1051,6 +1208,8 @@ function LeaguesPageContent() {
     if (yahooParam === 'connected') {
       // Just came from OAuth — trust the param, skip status check
       setIsYahooConnected(true);
+      setYahooHealth(null);
+      setIsYahooReconnectNeeded(false);
       setIsCheckingYahoo(false);
       void discoverYahooLeagues();
       router.replace('/leagues', { scroll: false });
@@ -1457,7 +1616,27 @@ function LeaguesPageContent() {
   const isEspnStatusChecking = !isAccountStateCurrent || isCheckingCreds;
   const displayYahooConnected = isAccountStateCurrent && isYahooConnected;
   const displayYahooLastUpdated = isAccountStateCurrent ? yahooLastUpdated : null;
+  const displayYahooHealth = isAccountStateCurrent ? yahooHealth : null;
+  const displayYahooReconnectNeeded = isAccountStateCurrent && isYahooReconnectNeeded;
   const isYahooStatusChecking = !isAccountStateCurrent || isCheckingYahoo;
+  const yahooDisplayState = getYahooDisplayState(
+    isYahooStatusChecking,
+    displayYahooConnected,
+    displayYahooReconnectNeeded,
+    displayYahooHealth
+  );
+  const yahooBadgeCopy = getYahooBadgeCopy(yahooDisplayState);
+  const yahooStatusCopy = getYahooStatusCopy(yahooDisplayState, displayYahooHealth);
+  const hasPositiveYahooRetryAfter =
+    typeof displayYahooHealth?.retryAfterSeconds === 'number' &&
+    displayYahooHealth.retryAfterSeconds > 0;
+  const isYahooSyncTemporarilyBlocked =
+    (yahooDisplayState === 'cooldown' || yahooDisplayState === 'in_progress') &&
+    hasPositiveYahooRetryAfter;
+  const shouldShowYahooStatusAlert =
+    yahooDisplayState === 'cooldown' ||
+    yahooDisplayState === 'in_progress' ||
+    yahooDisplayState === 'reconnect_needed';
   const displaySleeperConnected = isAccountStateCurrent && isSleeperConnected;
   const displaySleeperUsername = isAccountStateCurrent ? sleeperUsername : null;
   const displaySleeperLastUpdated = isAccountStateCurrent ? sleeperLastUpdated : null;
@@ -1499,7 +1678,7 @@ function LeaguesPageContent() {
               <div className="space-y-2">
                 <h2 className="font-medium">What happens here</h2>
                 <ul className="space-y-2 text-sm text-muted-foreground">
-                  <li>Connect your fantasy platforms and refresh league data</li>
+                  <li>Connect your fantasy platforms and sync league data</li>
                   <li>Copy the Flaim MCP name and URL for Claude, ChatGPT, or Perplexity</li>
                   <li>Choose defaults and manage seasons once your account is linked</li>
                 </ul>
@@ -1543,7 +1722,7 @@ function LeaguesPageContent() {
 
         {displayLeagueNotice && (
           <Alert className="bg-info/10 border-info/30 text-info">
-            <CheckCircle2 className="h-4 w-4" />
+            <Info className="h-4 w-4" />
             <AlertDescription>{displayLeagueNotice}</AlertDescription>
           </Alert>
         )}
@@ -1942,7 +2121,7 @@ function LeaguesPageContent() {
               <div className="min-w-0 space-y-2">
                 <CardTitle className="text-lg">1. Connect Platforms</CardTitle>
                 <CardDescription>
-                  Connect, refresh, or manually add leagues from ESPN, Yahoo, and Sleeper here.
+                  Connect, sync, or manually add leagues from ESPN, Yahoo, and Sleeper here.
                 </CardDescription>
               </div>
               <ChevronDown
@@ -2495,7 +2674,14 @@ function LeaguesPageContent() {
               >
                 <div className="flex items-center gap-2">
                   <span className="text-lg">Yahoo</span>
-                  <ConnectionBadge isChecking={isYahooStatusChecking} isConnected={displayYahooConnected} />
+                  <span className={`text-xs px-2 py-0.5 rounded-full ${yahooBadgeCopy.className}`}>
+                    {isYahooStatusChecking ? (
+                      <span className="flex items-center gap-1">
+                        <Loader2 className="h-3 w-3 animate-spin" />
+                        {yahooBadgeCopy.label}
+                      </span>
+                    ) : yahooBadgeCopy.label}
+                  </span>
                 </div>
                 <ChevronDown
                   className={`h-5 w-5 text-muted-foreground transition-transform ${
@@ -2505,11 +2691,17 @@ function LeaguesPageContent() {
               </button>
               {isYahooSetupOpen && (
                 <div id="yahoo-setup-content" className="px-4 pb-4 space-y-3">
-                  <p className="text-sm text-muted-foreground">
-                    {displayYahooConnected
-                      ? 'Refresh pulls your latest leagues using the stored Yahoo connection. If Yahoo reports that access expired, you will be asked to reconnect.'
-                      : 'Connect your Yahoo account to add leagues.'}
-                  </p>
+                  {!shouldShowYahooStatusAlert && (
+                    <p className="text-sm text-muted-foreground">
+                      {yahooStatusCopy}
+                    </p>
+                  )}
+                  {shouldShowYahooStatusAlert && (
+                    <Alert variant={yahooDisplayState === 'reconnect_needed' ? 'destructive' : 'warning'}>
+                      <AlertCircle className="h-4 w-4" />
+                      <AlertDescription>{yahooStatusCopy}</AlertDescription>
+                    </Alert>
+                  )}
                   {isYahooStatusChecking ? (
                     <div className="flex items-center gap-2 text-sm text-muted-foreground">
                       <Loader2 className="h-4 w-4 animate-spin" />
@@ -2522,20 +2714,40 @@ function LeaguesPageContent() {
                           Last updated: {formatLastUpdated(displayYahooLastUpdated)}
                         </p>
                       )}
-                      <div className="flex gap-2">
+                      <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap">
                         <Button
-                          variant="outline"
+                          variant="default"
                           size="sm"
                           onClick={discoverYahooLeagues}
-                          disabled={isDiscoveringYahoo}
+                          disabled={isDiscoveringYahoo || isYahooSyncTemporarilyBlocked}
+                          className="w-full sm:w-auto"
                         >
                           {isDiscoveringYahoo ? (
                             <>
                               <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                              Refreshing...
+                              Syncing...
                             </>
                           ) : (
-                            'Refresh'
+                            <>
+                              <RefreshCw className="mr-2 h-4 w-4" />
+                              Sync leagues
+                            </>
+                          )}
+                        </Button>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={reconnectYahoo}
+                          disabled={isReconnectingYahoo}
+                          className="w-full sm:w-auto"
+                        >
+                          {isReconnectingYahoo ? (
+                            <>
+                              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                              Opening Yahoo...
+                            </>
+                          ) : (
+                            'Reconnect Yahoo'
                           )}
                         </Button>
                         <Button
@@ -2543,7 +2755,7 @@ function LeaguesPageContent() {
                           size="sm"
                           onClick={disconnectYahoo}
                           disabled={isYahooDisconnecting}
-                          className="text-destructive hover:text-destructive"
+                          className="w-full text-destructive hover:text-destructive sm:w-auto"
                         >
                           {isYahooDisconnecting ? (
                             <Loader2 className="h-4 w-4 animate-spin" />
@@ -2556,21 +2768,23 @@ function LeaguesPageContent() {
                   ) : (
                     <div className="p-4 border rounded-lg bg-muted/40 space-y-2">
                       <p className="text-sm text-muted-foreground">
-                        Sign in with Yahoo to connect your fantasy leagues. Uses OAuth — no passwords stored.
+                        {yahooDisplayState === 'reconnect_needed'
+                          ? 'Sign in with Yahoo again to repair your connection. Uses OAuth — no passwords stored.'
+                          : 'Sign in with Yahoo to connect your fantasy leagues. Uses OAuth — no passwords stored.'}
                       </p>
                       <Button
                         variant="outline"
                         className="w-full"
-                        onClick={refreshYahooAuth}
-                        disabled={isRefreshingYahooAuth}
+                        onClick={reconnectYahoo}
+                        disabled={isReconnectingYahoo}
                       >
-                        {isRefreshingYahooAuth ? (
+                        {isReconnectingYahoo ? (
                           <>
                             <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                             Opening Yahoo...
                           </>
                         ) : (
-                          'Connect Yahoo'
+                          yahooDisplayState === 'reconnect_needed' ? 'Reconnect Yahoo' : 'Connect Yahoo'
                         )}
                       </Button>
                     </div>

--- a/web/app/(site)/leagues/page.tsx
+++ b/web/app/(site)/leagues/page.tsx
@@ -165,6 +165,7 @@ const EMPTY_USER_PREFERENCES: UserPreferencesState = {
   defaultBasketball: null,
   defaultHockey: null,
 };
+const YAHOO_STATUS_RECHECK_FALLBACK_SECONDS = 5;
 
 function capitalize(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1);
@@ -290,7 +291,9 @@ function parseYahooConnectionHealth(value: unknown): YahooConnectionHealth | nul
     return null;
   }
 
-  const retryAfterSeconds = typeof record.retryAfterSeconds === 'number' && Number.isFinite(record.retryAfterSeconds)
+  const retryAfterSeconds = typeof record.retryAfterSeconds === 'number' &&
+    Number.isFinite(record.retryAfterSeconds) &&
+    record.retryAfterSeconds > 0
     ? record.retryAfterSeconds
     : undefined;
 
@@ -861,13 +864,12 @@ function LeaguesPageContent() {
     }
     const refreshState = yahooHealth?.refreshState;
     const retryAfterSeconds = yahooHealth?.retryAfterSeconds;
-    if (
-      (refreshState !== 'cooldown' && refreshState !== 'in_progress') ||
-      typeof retryAfterSeconds !== 'number' ||
-      retryAfterSeconds <= 0
-    ) {
+    if (refreshState !== 'cooldown' && refreshState !== 'in_progress') {
       return;
     }
+    const recheckAfterSeconds = typeof retryAfterSeconds === 'number' && retryAfterSeconds > 0
+      ? retryAfterSeconds
+      : YAHOO_STATUS_RECHECK_FALLBACK_SECONDS;
 
     let isActive = true;
     const retryTimer = window.setTimeout(() => {
@@ -881,7 +883,7 @@ function LeaguesPageContent() {
         return current;
       });
       void checkYahooStatus(() => isActive);
-    }, Math.ceil(retryAfterSeconds * 1000));
+    }, Math.ceil(recheckAfterSeconds * 1000));
 
     return () => {
       isActive = false;
@@ -1629,15 +1631,13 @@ function LeaguesPageContent() {
   );
   const yahooBadgeCopy = getYahooBadgeCopy(yahooDisplayState);
   const yahooStatusCopy = getYahooStatusCopy(yahooDisplayState, displayYahooHealth);
-  const hasPositiveYahooRetryAfter =
-    typeof displayYahooHealth?.retryAfterSeconds === 'number' &&
-    displayYahooHealth.retryAfterSeconds > 0;
-  const isYahooSyncTemporarilyBlocked =
-    (yahooDisplayState === 'cooldown' || yahooDisplayState === 'in_progress') &&
-    hasPositiveYahooRetryAfter;
-  const shouldShowYahooStatusAlert =
+  const isYahooTemporarilyBusy =
     yahooDisplayState === 'cooldown' ||
-    yahooDisplayState === 'in_progress' ||
+    yahooDisplayState === 'in_progress';
+  const isYahooSyncTemporarilyBlocked =
+    isYahooTemporarilyBusy;
+  const shouldShowYahooStatusAlert =
+    isYahooTemporarilyBusy ||
     yahooDisplayState === 'reconnect_needed';
   const displaySleeperConnected = isAccountStateCurrent && isSleeperConnected;
   const displaySleeperUsername = isAccountStateCurrent ? sleeperUsername : null;

--- a/web/app/(site)/leagues/page.tsx
+++ b/web/app/(site)/leagues/page.tsx
@@ -47,12 +47,19 @@ import {
 import { useEspnCredentials } from '@/lib/use-espn-credentials';
 import { getDefaultSeasonYear, getPreviousSeasonYear, getSeasonYearOptions } from '@/lib/season-utils';
 import {
-  formatYahooRetryAfter,
+  getYahooBadgeCopy,
+  getYahooDisplayState,
+  getYahooStatusCopy,
+  parseYahooConnectionHealth,
+  type YahooConnectionHealth,
+} from '@/lib/yahoo-connection-display';
+import {
   getYahooConnectErrorMessage,
   isYahooReconnectRequired,
   isYahooTransientAuthError,
   isYahooTransientAuthResponse,
   parseYahooDiscoverErrorResponse,
+  parseYahooRetryAfterSeconds,
 } from '@/lib/yahoo-auth-errors';
 import { CHROME_EXTENSION_URL } from '@/config/constants';
 import { StepConnectAI } from '@/components/site/StepConnectAI';
@@ -261,101 +268,6 @@ function canApplyState(shouldApply?: () => boolean): boolean {
 }
 
 type ConnectionStatusResult = 'connected' | 'disconnected' | 'unknown';
-type YahooAccessTokenState = 'fresh' | 'needs_refresh';
-type YahooRefreshState = 'idle' | 'in_progress' | 'cooldown' | 'expired';
-type YahooDisplayState =
-  | 'checking'
-  | 'not_connected'
-  | 'connected'
-  | 'in_progress'
-  | 'cooldown'
-  | 'reconnect_needed';
-
-interface YahooConnectionHealth {
-  accessTokenState: YahooAccessTokenState;
-  refreshState: YahooRefreshState;
-  retryAfterSeconds?: number;
-}
-
-function parseYahooConnectionHealth(value: unknown): YahooConnectionHealth | null {
-  if (!value || typeof value !== 'object') {
-    return null;
-  }
-
-  const record = value as Record<string, unknown>;
-  const accessTokenState = record.accessTokenState;
-  const refreshState = record.refreshState;
-  if (
-    (accessTokenState !== 'fresh' && accessTokenState !== 'needs_refresh') ||
-    (refreshState !== 'idle' && refreshState !== 'in_progress' && refreshState !== 'cooldown' && refreshState !== 'expired')
-  ) {
-    return null;
-  }
-
-  const retryAfterSeconds = typeof record.retryAfterSeconds === 'number' &&
-    Number.isFinite(record.retryAfterSeconds) &&
-    record.retryAfterSeconds > 0
-    ? record.retryAfterSeconds
-    : undefined;
-
-  return {
-    accessTokenState,
-    refreshState,
-    retryAfterSeconds,
-  };
-}
-
-function getYahooDisplayState(
-  isChecking: boolean,
-  isConnected: boolean,
-  isReconnectNeeded: boolean,
-  health: YahooConnectionHealth | null
-): YahooDisplayState {
-  if (isChecking) return 'checking';
-  if (isReconnectNeeded) return 'reconnect_needed';
-  if (!isConnected) return 'not_connected';
-  if (health?.refreshState === 'cooldown') return 'cooldown';
-  if (health?.refreshState === 'in_progress') return 'in_progress';
-  return 'connected';
-}
-
-function getYahooBadgeCopy(state: YahooDisplayState): { label: string; className: string } {
-  switch (state) {
-    case 'checking':
-      return { label: 'Checking...', className: 'bg-muted text-muted-foreground' };
-    case 'connected':
-      return { label: 'Connected', className: 'bg-success/20 text-success' };
-    case 'cooldown':
-      return { label: 'Yahoo temporarily unavailable', className: 'bg-warning/20 text-warning' };
-    case 'in_progress':
-      return { label: 'Checking Yahoo', className: 'bg-warning/20 text-warning' };
-    case 'reconnect_needed':
-      return { label: 'Reconnect needed', className: 'bg-destructive/10 text-destructive' };
-    case 'not_connected':
-    default:
-      return { label: 'Not connected', className: 'bg-muted text-muted-foreground' };
-  }
-}
-
-function getYahooStatusCopy(state: YahooDisplayState, health: YahooConnectionHealth | null): string {
-  const retryAfter = formatYahooRetryAfter(health?.retryAfterSeconds);
-
-  switch (state) {
-    case 'connected':
-      return 'Sync leagues pulls your latest Yahoo leagues using your current Yahoo connection. Reconnect Yahoo opens Yahoo sign-in again if the connection needs repair.';
-    case 'cooldown':
-      return `Yahoo is temporarily unavailable. ${retryAfter ? `Try syncing leagues again in ${retryAfter}.` : 'Try syncing leagues again in a few minutes.'} If this keeps happening, reconnect Yahoo.`;
-    case 'in_progress':
-      return `Yahoo is finishing a login check from another request. ${retryAfter ? `Try syncing leagues again in ${retryAfter}.` : 'Try syncing leagues again shortly.'}`;
-    case 'reconnect_needed':
-      return 'Yahoo needs you to sign in again before Flaim can sync leagues or answer Yahoo questions.';
-    case 'not_connected':
-      return 'Connect your Yahoo account to add leagues.';
-    case 'checking':
-    default:
-      return 'Checking Yahoo connection...';
-  }
-}
 
 function isSleeperDisconnectedStatus(status: number, data: { error?: string }): boolean {
   return status === 401 || status === 403 || data.error === 'not_connected';
@@ -1194,8 +1106,7 @@ function LeaguesPageContent() {
 
     const yahooError = searchParams.get('error');
     if (yahooError) {
-      const retryAfterParam = searchParams.get('retry_after');
-      const retryAfter = retryAfterParam ? Number(retryAfterParam) : undefined;
+      const retryAfter = parseYahooRetryAfterSeconds(searchParams.get('retry_after'));
       if (isYahooTransientAuthError(yahooError)) {
         setLeagueError(null);
         setLeagueNotice(getYahooConnectErrorMessage(yahooError, searchParams.get('error_description'), retryAfter));

--- a/web/app/(site)/leagues/page.tsx
+++ b/web/app/(site)/leagues/page.tsx
@@ -694,6 +694,7 @@ function LeaguesPageContent() {
       const data = await res.json().catch(() => ({})) as {
         connected?: boolean;
         lastUpdated?: string;
+        // Keep the wire shape loose and validate it before using it in UI state.
         health?: unknown;
         error?: string;
       };

--- a/web/app/(site)/leagues/page.tsx
+++ b/web/app/(site)/leagues/page.tsx
@@ -1027,6 +1027,8 @@ function LeaguesPageContent() {
           return;
         }
         if (isYahooTransientAuthResponse(data)) {
+          // Surface the temporary Yahoo state where the sync/reconnect actions live,
+          // instead of leaving the user with a detached page-level notice.
           setIsYahooSetupOpen(true);
           setIsYahooConnected(true);
           setIsYahooReconnectNeeded(false);

--- a/web/components/site/StepConnectPlatforms.tsx
+++ b/web/components/site/StepConnectPlatforms.tsx
@@ -373,16 +373,16 @@ export function StepConnectPlatforms({ className }: StepConnectPlatformsProps) {
             ) : yahooStatus === 'connected' ? (
               <div className="space-y-2">
                 <Button variant="outline" size="sm" className="w-full" onClick={handleConnectYahoo}>
-                  Refresh Yahoo Auth
+                  Reconnect Yahoo
                 </Button>
                 <div className="flex items-center justify-center gap-2 h-8 rounded-md px-3 text-xs font-medium w-full bg-muted text-muted-foreground">
                   <Check className="h-3.5 w-3.5" />
-                  Auth Connected
+                  Yahoo connected
                 </div>
               </div>
             ) : (
               <Button variant="outline" size="sm" className="w-full" onClick={handleConnectYahoo}>
-                Authenticate Yahoo
+                Connect Yahoo
               </Button>
             )}
           </div>

--- a/web/lib/__tests__/yahoo-auth-errors.test.ts
+++ b/web/lib/__tests__/yahoo-auth-errors.test.ts
@@ -7,6 +7,7 @@ import {
   isYahooReconnectRequired,
   isYahooTransientAuthResponse,
   parseYahooDiscoverErrorResponse,
+  parseYahooRetryAfterSeconds,
 } from '../yahoo-auth-errors';
 
 describe('Yahoo auth error helpers', () => {
@@ -18,6 +19,18 @@ describe('Yahoo auth error helpers', () => {
     expect(formatYahooRetryAfter(-1)).toBeNull();
     expect(formatYahooRetryAfter(undefined)).toBeNull();
     expect(formatYahooRetryAfter(Number.NaN)).toBeNull();
+  });
+
+  it('parses retry-after query params defensively', () => {
+    expect(parseYahooRetryAfterSeconds('45')).toBe(45);
+    expect(parseYahooRetryAfterSeconds(' 45 ')).toBe(45);
+    expect(parseYahooRetryAfterSeconds(null)).toBeUndefined();
+    expect(parseYahooRetryAfterSeconds('')).toBeUndefined();
+    expect(parseYahooRetryAfterSeconds('0')).toBeUndefined();
+    expect(parseYahooRetryAfterSeconds('-1')).toBeUndefined();
+    expect(parseYahooRetryAfterSeconds('1e10')).toBeUndefined();
+    expect(parseYahooRetryAfterSeconds('45 seconds')).toBeUndefined();
+    expect(parseYahooRetryAfterSeconds('Infinity')).toBeUndefined();
   });
 
   it('uses the shared connect-message copy for transient notices', () => {

--- a/web/lib/__tests__/yahoo-auth-errors.test.ts
+++ b/web/lib/__tests__/yahoo-auth-errors.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { YahooAuthWorkerErrorCode } from '@flaim/worker-shared';
 import {
+  formatYahooRetryAfter,
   getYahooConnectErrorMessage,
   getYahooTransientAuthMessage,
   isYahooReconnectRequired,
@@ -9,6 +10,14 @@ import {
 } from '../yahoo-auth-errors';
 
 describe('Yahoo auth error helpers', () => {
+  it('formats retry-after values for user-facing copy', () => {
+    expect(formatYahooRetryAfter(30)).toBe('30 seconds');
+    expect(formatYahooRetryAfter(60)).toBe('about 1 minute');
+    expect(formatYahooRetryAfter(61)).toBe('about 2 minutes');
+    expect(formatYahooRetryAfter(undefined)).toBeNull();
+    expect(formatYahooRetryAfter(Number.NaN)).toBeNull();
+  });
+
   it('uses the shared connect-message copy for transient notices', () => {
     expect(getYahooTransientAuthMessage({ error: 'refresh_temporarily_unavailable' }))
       .toBe(getYahooConnectErrorMessage('refresh_temporarily_unavailable', null));
@@ -44,8 +53,21 @@ describe('Yahoo auth error helpers', () => {
   it('uses the upstream description when a retryable response has no known transient code', () => {
     expect(getYahooTransientAuthMessage({
       error: 'server_timeout',
-      error_description: 'Try the Yahoo refresh again shortly.',
-    })).toBe('Try the Yahoo refresh again shortly.');
+      error_description: 'Try Yahoo again shortly.',
+    })).toBe('Try Yahoo again shortly.');
+  });
+
+  it('adds retry timing to retryable transient messages', () => {
+    expect(getYahooTransientAuthMessage({
+      error: 'refresh_temporarily_unavailable',
+      retry_after: 300,
+    })).toBe('Yahoo is temporarily unavailable. Try again in about 5 minutes.');
+
+    expect(getYahooTransientAuthMessage({
+      error: 'server_timeout',
+      error_description: 'Try syncing Yahoo leagues again shortly.',
+      retry_after: 45,
+    })).toBe('Try syncing Yahoo leagues again shortly. Try again in 45 seconds.');
   });
 
   it('parses retryable worker error bodies defensively', () => {

--- a/web/lib/__tests__/yahoo-auth-errors.test.ts
+++ b/web/lib/__tests__/yahoo-auth-errors.test.ts
@@ -14,6 +14,8 @@ describe('Yahoo auth error helpers', () => {
     expect(formatYahooRetryAfter(30)).toBe('30 seconds');
     expect(formatYahooRetryAfter(60)).toBe('about 1 minute');
     expect(formatYahooRetryAfter(61)).toBe('about 1 minute');
+    expect(formatYahooRetryAfter(0)).toBeNull();
+    expect(formatYahooRetryAfter(-1)).toBeNull();
     expect(formatYahooRetryAfter(undefined)).toBeNull();
     expect(formatYahooRetryAfter(Number.NaN)).toBeNull();
   });

--- a/web/lib/__tests__/yahoo-auth-errors.test.ts
+++ b/web/lib/__tests__/yahoo-auth-errors.test.ts
@@ -15,6 +15,7 @@ describe('Yahoo auth error helpers', () => {
     expect(formatYahooRetryAfter(30)).toBe('30 seconds');
     expect(formatYahooRetryAfter(60)).toBe('about 1 minute');
     expect(formatYahooRetryAfter(61)).toBe('about 1 minute');
+    expect(formatYahooRetryAfter(7200)).toBe('about 2 hours');
     expect(formatYahooRetryAfter(0)).toBeNull();
     expect(formatYahooRetryAfter(-1)).toBeNull();
     expect(formatYahooRetryAfter(undefined)).toBeNull();

--- a/web/lib/__tests__/yahoo-auth-errors.test.ts
+++ b/web/lib/__tests__/yahoo-auth-errors.test.ts
@@ -13,7 +13,7 @@ describe('Yahoo auth error helpers', () => {
   it('formats retry-after values for user-facing copy', () => {
     expect(formatYahooRetryAfter(30)).toBe('30 seconds');
     expect(formatYahooRetryAfter(60)).toBe('about 1 minute');
-    expect(formatYahooRetryAfter(61)).toBe('about 2 minutes');
+    expect(formatYahooRetryAfter(61)).toBe('about 1 minute');
     expect(formatYahooRetryAfter(undefined)).toBeNull();
     expect(formatYahooRetryAfter(Number.NaN)).toBeNull();
   });

--- a/web/lib/__tests__/yahoo-connection-display.test.ts
+++ b/web/lib/__tests__/yahoo-connection-display.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getYahooBadgeCopy,
+  getYahooDisplayState,
+  getYahooStatusCopy,
+  parseYahooConnectionHealth,
+} from '../yahoo-connection-display';
+
+describe('parseYahooConnectionHealth', () => {
+  it('accepts valid health payloads with positive retry timing', () => {
+    expect(parseYahooConnectionHealth({
+      accessTokenState: 'needs_refresh',
+      refreshState: 'cooldown',
+      retryAfterSeconds: 45,
+    })).toEqual({
+      accessTokenState: 'needs_refresh',
+      refreshState: 'cooldown',
+      retryAfterSeconds: 45,
+    });
+  });
+
+  it('rejects malformed health payloads', () => {
+    expect(parseYahooConnectionHealth(null)).toBeNull();
+    expect(parseYahooConnectionHealth({ accessTokenState: 'fresh' })).toBeNull();
+    expect(parseYahooConnectionHealth({ accessTokenState: 'fresh', refreshState: 'unknown' })).toBeNull();
+    expect(parseYahooConnectionHealth({ accessTokenState: 'unknown', refreshState: 'idle' })).toBeNull();
+  });
+
+  it('drops non-positive or non-finite retry timing', () => {
+    expect(parseYahooConnectionHealth({
+      accessTokenState: 'fresh',
+      refreshState: 'idle',
+      retryAfterSeconds: 0,
+    })).toEqual({
+      accessTokenState: 'fresh',
+      refreshState: 'idle',
+      retryAfterSeconds: undefined,
+    });
+    expect(parseYahooConnectionHealth({
+      accessTokenState: 'fresh',
+      refreshState: 'idle',
+      retryAfterSeconds: Number.POSITIVE_INFINITY,
+    })).toEqual({
+      accessTokenState: 'fresh',
+      refreshState: 'idle',
+      retryAfterSeconds: undefined,
+    });
+  });
+});
+
+describe('Yahoo display copy', () => {
+  it('prioritizes checking and reconnect-needed states', () => {
+    expect(getYahooDisplayState(true, true, true, { accessTokenState: 'fresh', refreshState: 'cooldown' })).toBe('checking');
+    expect(getYahooDisplayState(false, true, true, { accessTokenState: 'fresh', refreshState: 'idle' })).toBe('reconnect_needed');
+  });
+
+  it('maps connection health to display state', () => {
+    expect(getYahooDisplayState(false, false, false, null)).toBe('not_connected');
+    expect(getYahooDisplayState(false, true, false, { accessTokenState: 'fresh', refreshState: 'idle' })).toBe('connected');
+    expect(getYahooDisplayState(false, true, false, { accessTokenState: 'needs_refresh', refreshState: 'cooldown' })).toBe('cooldown');
+    expect(getYahooDisplayState(false, true, false, { accessTokenState: 'needs_refresh', refreshState: 'in_progress' })).toBe('in_progress');
+  });
+
+  it('returns badge and status copy for cooldown and reconnect-needed states', () => {
+    expect(getYahooBadgeCopy('cooldown')).toEqual({
+      label: 'Yahoo temporarily unavailable',
+      className: 'bg-warning/20 text-warning',
+    });
+    expect(getYahooStatusCopy('cooldown', {
+      accessTokenState: 'needs_refresh',
+      refreshState: 'cooldown',
+      retryAfterSeconds: 60,
+    })).toContain('Try syncing leagues again in about 1 minute.');
+    expect(getYahooBadgeCopy('reconnect_needed').label).toBe('Reconnect needed');
+    expect(getYahooStatusCopy('reconnect_needed', null)).toContain('sign in again');
+  });
+});

--- a/web/lib/__tests__/yahoo-connection-display.test.ts
+++ b/web/lib/__tests__/yahoo-connection-display.test.ts
@@ -74,6 +74,11 @@ describe('Yahoo display copy', () => {
       refreshState: 'cooldown',
       retryAfterSeconds: 60,
     })).toContain('Try syncing leagues again in about 1 minute.');
+    expect(getYahooStatusCopy('in_progress', {
+      accessTokenState: 'needs_refresh',
+      refreshState: 'in_progress',
+      retryAfterSeconds: 30,
+    })).toContain('Try syncing leagues again in 30 seconds.');
     expect(getYahooBadgeCopy('reconnect_needed').label).toBe('Reconnect needed');
     expect(getYahooStatusCopy('reconnect_needed', null)).toContain('sign in again');
   });

--- a/web/lib/__tests__/yahoo-connection-display.test.ts
+++ b/web/lib/__tests__/yahoo-connection-display.test.ts
@@ -57,6 +57,7 @@ describe('Yahoo display copy', () => {
 
   it('maps connection health to display state', () => {
     expect(getYahooDisplayState(false, false, false, null)).toBe('not_connected');
+    expect(getYahooDisplayState(false, true, false, null)).toBe('connected');
     expect(getYahooDisplayState(false, true, false, { accessTokenState: 'fresh', refreshState: 'idle' })).toBe('connected');
     expect(getYahooDisplayState(false, true, false, { accessTokenState: 'needs_refresh', refreshState: 'expired' })).toBe('connected');
     expect(getYahooDisplayState(false, true, false, { accessTokenState: 'needs_refresh', refreshState: 'cooldown' })).toBe('cooldown');

--- a/web/lib/__tests__/yahoo-connection-display.test.ts
+++ b/web/lib/__tests__/yahoo-connection-display.test.ts
@@ -79,6 +79,9 @@ describe('Yahoo display copy', () => {
       refreshState: 'in_progress',
       retryAfterSeconds: 30,
     })).toContain('Try syncing leagues again in 30 seconds.');
+    expect(getYahooStatusCopy('connected', null)).toContain('Sync leagues');
+    expect(getYahooStatusCopy('not_connected', null)).toContain('Connect your Yahoo account');
+    expect(getYahooStatusCopy('checking', null)).toContain('Checking Yahoo connection');
     expect(getYahooBadgeCopy('reconnect_needed').label).toBe('Reconnect needed');
     expect(getYahooStatusCopy('reconnect_needed', null)).toContain('sign in again');
   });

--- a/web/lib/__tests__/yahoo-connection-display.test.ts
+++ b/web/lib/__tests__/yahoo-connection-display.test.ts
@@ -58,13 +58,14 @@ describe('Yahoo display copy', () => {
   it('maps connection health to display state', () => {
     expect(getYahooDisplayState(false, false, false, null)).toBe('not_connected');
     expect(getYahooDisplayState(false, true, false, { accessTokenState: 'fresh', refreshState: 'idle' })).toBe('connected');
+    expect(getYahooDisplayState(false, true, false, { accessTokenState: 'needs_refresh', refreshState: 'expired' })).toBe('connected');
     expect(getYahooDisplayState(false, true, false, { accessTokenState: 'needs_refresh', refreshState: 'cooldown' })).toBe('cooldown');
     expect(getYahooDisplayState(false, true, false, { accessTokenState: 'needs_refresh', refreshState: 'in_progress' })).toBe('in_progress');
   });
 
   it('returns badge and status copy for cooldown and reconnect-needed states', () => {
     expect(getYahooBadgeCopy('cooldown')).toEqual({
-      label: 'Yahoo temporarily unavailable',
+      label: 'Temporarily unavailable',
       className: 'bg-warning/20 text-warning',
     });
     expect(getYahooStatusCopy('cooldown', {

--- a/web/lib/yahoo-auth-errors.ts
+++ b/web/lib/yahoo-auth-errors.ts
@@ -19,18 +19,48 @@ const YAHOO_TRANSIENT_AUTH_ERRORS = new Set<string>([
 ]);
 
 const YAHOO_TRANSIENT_AUTH_FALLBACK =
-  'Yahoo is temporarily unavailable while refreshing your connection. Please try again in a few minutes.';
+  'Yahoo is temporarily unavailable. Try again in a few minutes.';
 
-export function getYahooConnectErrorMessage(error: string, description: string | null): string {
+export function formatYahooRetryAfter(retryAfterSeconds?: number): string | null {
+  if (typeof retryAfterSeconds !== 'number' || !Number.isFinite(retryAfterSeconds) || retryAfterSeconds <= 0) {
+    return null;
+  }
+
+  if (retryAfterSeconds < 60) {
+    const roundedSeconds = Math.ceil(retryAfterSeconds);
+    return `${roundedSeconds} second${roundedSeconds === 1 ? '' : 's'}`;
+  }
+
+  const roundedMinutes = Math.ceil(retryAfterSeconds / 60);
+  return `about ${roundedMinutes} minute${roundedMinutes === 1 ? '' : 's'}`;
+}
+
+function appendRetryAfter(message: string, retryAfterSeconds?: number): string {
+  const retryAfter = formatYahooRetryAfter(retryAfterSeconds);
+  if (!retryAfter) {
+    return message;
+  }
+
+  const messageWithoutGenericRetry = message
+    .replace(/ Please try again in a few minutes\.$/, '')
+    .replace(/ Try again in a few minutes\.$/, '');
+  return `${messageWithoutGenericRetry} Try again in ${retryAfter}.`;
+}
+
+export function getYahooConnectErrorMessage(
+  error: string,
+  description: string | null,
+  retryAfterSeconds?: number
+): string {
   switch (error) {
     case 'token_refresh_validation_failed':
       return 'Yahoo connection did not complete because the refresh token could not be validated. Please connect Yahoo again.';
     case YahooAuthWorkerErrorCode.REFRESH_TEMPORARILY_UNAVAILABLE:
-      return YAHOO_TRANSIENT_AUTH_FALLBACK;
+      return appendRetryAfter(YAHOO_TRANSIENT_AUTH_FALLBACK, retryAfterSeconds);
     case YahooAuthWorkerErrorCode.TOKEN_REFRESH_VALIDATION_UNAVAILABLE:
-      return 'Yahoo connection could not be validated because Yahoo was temporarily unavailable. Please try again in a few minutes.';
+      return appendRetryAfter('Yahoo connection could not be validated because Yahoo was temporarily unavailable. Try again in a few minutes.', retryAfterSeconds);
     case YahooAuthWorkerErrorCode.TOKEN_EXCHANGE_UNAVAILABLE:
-      return 'Yahoo connection could not be started because Yahoo was temporarily unavailable. Please try again in a few minutes.';
+      return appendRetryAfter('Yahoo connection could not be started because Yahoo was temporarily unavailable. Try again in a few minutes.', retryAfterSeconds);
     case 'token_exchange_failed':
       return description || 'Yahoo connection failed while exchanging the authorization code. Please try again.';
     case 'oauth_denied':
@@ -77,10 +107,10 @@ export function isYahooReconnectRequired(status: number, data: { error?: string;
   );
 }
 
-export function getYahooTransientAuthMessage(data: { error?: string; error_description?: string }): string {
+export function getYahooTransientAuthMessage(data: { error?: string; error_description?: string; retry_after?: number }): string {
   if (data.error && isYahooTransientAuthError(data.error)) {
-    return getYahooConnectErrorMessage(data.error, data.error_description || null);
+    return getYahooConnectErrorMessage(data.error, data.error_description || null, data.retry_after);
   }
 
-  return data.error_description || YAHOO_TRANSIENT_AUTH_FALLBACK;
+  return appendRetryAfter(data.error_description || YAHOO_TRANSIENT_AUTH_FALLBACK, data.retry_after);
 }

--- a/web/lib/yahoo-auth-errors.ts
+++ b/web/lib/yahoo-auth-errors.ts
@@ -35,6 +35,20 @@ export function formatYahooRetryAfter(retryAfterSeconds?: number): string | null
   return `about ${roundedMinutes} minute${roundedMinutes === 1 ? '' : 's'}`;
 }
 
+export function parseYahooRetryAfterSeconds(value: string | null): number | undefined {
+  if (value === null) {
+    return undefined;
+  }
+
+  const trimmedValue = value.trim();
+  if (!/^\d+$/.test(trimmedValue)) {
+    return undefined;
+  }
+
+  const parsed = Number.parseInt(trimmedValue, 10);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
 function retryCopy(retryAfterSeconds?: number): string {
   const retryAfter = formatYahooRetryAfter(retryAfterSeconds);
   return retryAfter ? `Try again in ${retryAfter}.` : YAHOO_GENERIC_RETRY_COPY;

--- a/web/lib/yahoo-auth-errors.ts
+++ b/web/lib/yahoo-auth-errors.ts
@@ -31,6 +31,11 @@ export function formatYahooRetryAfter(retryAfterSeconds?: number): string | null
     return `${roundedSeconds} second${roundedSeconds === 1 ? '' : 's'}`;
   }
 
+  if (retryAfterSeconds >= 60 * 60) {
+    const roundedHours = Math.max(1, Math.round(retryAfterSeconds / (60 * 60)));
+    return `about ${roundedHours} hour${roundedHours === 1 ? '' : 's'}`;
+  }
+
   const roundedMinutes = Math.max(1, Math.round(retryAfterSeconds / 60));
   return `about ${roundedMinutes} minute${roundedMinutes === 1 ? '' : 's'}`;
 }

--- a/web/lib/yahoo-auth-errors.ts
+++ b/web/lib/yahoo-auth-errors.ts
@@ -18,8 +18,8 @@ const YAHOO_TRANSIENT_AUTH_ERRORS = new Set<string>([
   YahooAuthWorkerErrorCode.YAHOO_API_TEMPORARILY_UNAVAILABLE,
 ]);
 
-const YAHOO_TRANSIENT_AUTH_FALLBACK =
-  'Yahoo is temporarily unavailable. Try again in a few minutes.';
+const YAHOO_GENERIC_RETRY_COPY = 'Try again in a few minutes.';
+const YAHOO_TRANSIENT_AUTH_BASE = 'Yahoo is temporarily unavailable.';
 
 export function formatYahooRetryAfter(retryAfterSeconds?: number): string | null {
   if (typeof retryAfterSeconds !== 'number' || !Number.isFinite(retryAfterSeconds) || retryAfterSeconds <= 0) {
@@ -31,20 +31,17 @@ export function formatYahooRetryAfter(retryAfterSeconds?: number): string | null
     return `${roundedSeconds} second${roundedSeconds === 1 ? '' : 's'}`;
   }
 
-  const roundedMinutes = Math.ceil(retryAfterSeconds / 60);
+  const roundedMinutes = Math.max(1, Math.round(retryAfterSeconds / 60));
   return `about ${roundedMinutes} minute${roundedMinutes === 1 ? '' : 's'}`;
 }
 
-function appendRetryAfter(message: string, retryAfterSeconds?: number): string {
+function retryCopy(retryAfterSeconds?: number): string {
   const retryAfter = formatYahooRetryAfter(retryAfterSeconds);
-  if (!retryAfter) {
-    return message;
-  }
+  return retryAfter ? `Try again in ${retryAfter}.` : YAHOO_GENERIC_RETRY_COPY;
+}
 
-  const messageWithoutGenericRetry = message
-    .replace(/ Please try again in a few minutes\.$/, '')
-    .replace(/ Try again in a few minutes\.$/, '');
-  return `${messageWithoutGenericRetry} Try again in ${retryAfter}.`;
+function appendRetryCopy(message: string, retryAfterSeconds?: number): string {
+  return `${message} ${retryCopy(retryAfterSeconds)}`;
 }
 
 export function getYahooConnectErrorMessage(
@@ -56,11 +53,11 @@ export function getYahooConnectErrorMessage(
     case 'token_refresh_validation_failed':
       return 'Yahoo connection did not complete because the refresh token could not be validated. Please connect Yahoo again.';
     case YahooAuthWorkerErrorCode.REFRESH_TEMPORARILY_UNAVAILABLE:
-      return appendRetryAfter(YAHOO_TRANSIENT_AUTH_FALLBACK, retryAfterSeconds);
+      return appendRetryCopy(YAHOO_TRANSIENT_AUTH_BASE, retryAfterSeconds);
     case YahooAuthWorkerErrorCode.TOKEN_REFRESH_VALIDATION_UNAVAILABLE:
-      return appendRetryAfter('Yahoo connection could not be validated because Yahoo was temporarily unavailable. Try again in a few minutes.', retryAfterSeconds);
+      return appendRetryCopy('Yahoo connection could not be validated because Yahoo was temporarily unavailable.', retryAfterSeconds);
     case YahooAuthWorkerErrorCode.TOKEN_EXCHANGE_UNAVAILABLE:
-      return appendRetryAfter('Yahoo connection could not be started because Yahoo was temporarily unavailable. Try again in a few minutes.', retryAfterSeconds);
+      return appendRetryCopy('Yahoo connection could not be started because Yahoo was temporarily unavailable.', retryAfterSeconds);
     case 'token_exchange_failed':
       return description || 'Yahoo connection failed while exchanging the authorization code. Please try again.';
     case 'oauth_denied':
@@ -112,5 +109,11 @@ export function getYahooTransientAuthMessage(data: { error?: string; error_descr
     return getYahooConnectErrorMessage(data.error, data.error_description || null, data.retry_after);
   }
 
-  return appendRetryAfter(data.error_description || YAHOO_TRANSIENT_AUTH_FALLBACK, data.retry_after);
+  if (data.error_description) {
+    return data.retry_after !== undefined
+      ? appendRetryCopy(data.error_description, data.retry_after)
+      : data.error_description;
+  }
+
+  return appendRetryCopy(YAHOO_TRANSIENT_AUTH_BASE, data.retry_after);
 }

--- a/web/lib/yahoo-connection-display.ts
+++ b/web/lib/yahoo-connection-display.ts
@@ -1,0 +1,102 @@
+import { formatYahooRetryAfter } from './yahoo-auth-errors';
+
+export type YahooAccessTokenState = 'fresh' | 'needs_refresh';
+export type YahooRefreshState = 'idle' | 'in_progress' | 'cooldown' | 'expired';
+export type YahooDisplayState =
+  | 'checking'
+  | 'not_connected'
+  | 'connected'
+  | 'in_progress'
+  | 'cooldown'
+  | 'reconnect_needed';
+
+export interface YahooConnectionHealth {
+  accessTokenState: YahooAccessTokenState;
+  refreshState: YahooRefreshState;
+  retryAfterSeconds?: number;
+}
+
+const VALID_YAHOO_ACCESS_TOKEN_STATES = new Set<YahooAccessTokenState>(['fresh', 'needs_refresh']);
+const VALID_YAHOO_REFRESH_STATES = new Set<YahooRefreshState>(['idle', 'in_progress', 'cooldown', 'expired']);
+
+export function parseYahooConnectionHealth(value: unknown): YahooConnectionHealth | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  const accessTokenState = record.accessTokenState;
+  const refreshState = record.refreshState;
+  if (
+    typeof accessTokenState !== 'string' ||
+    typeof refreshState !== 'string' ||
+    !VALID_YAHOO_ACCESS_TOKEN_STATES.has(accessTokenState as YahooAccessTokenState) ||
+    !VALID_YAHOO_REFRESH_STATES.has(refreshState as YahooRefreshState)
+  ) {
+    return null;
+  }
+
+  const retryAfterSeconds = typeof record.retryAfterSeconds === 'number' &&
+    Number.isFinite(record.retryAfterSeconds) &&
+    record.retryAfterSeconds > 0
+    ? record.retryAfterSeconds
+    : undefined;
+
+  return {
+    accessTokenState: accessTokenState as YahooAccessTokenState,
+    refreshState: refreshState as YahooRefreshState,
+    retryAfterSeconds,
+  };
+}
+
+export function getYahooDisplayState(
+  isChecking: boolean,
+  isConnected: boolean,
+  isReconnectNeeded: boolean,
+  health: YahooConnectionHealth | null
+): YahooDisplayState {
+  if (isChecking) return 'checking';
+  if (isReconnectNeeded) return 'reconnect_needed';
+  if (!isConnected) return 'not_connected';
+  if (health?.refreshState === 'cooldown') return 'cooldown';
+  if (health?.refreshState === 'in_progress') return 'in_progress';
+  return 'connected';
+}
+
+export function getYahooBadgeCopy(state: YahooDisplayState): { label: string; className: string } {
+  switch (state) {
+    case 'checking':
+      return { label: 'Checking...', className: 'bg-muted text-muted-foreground' };
+    case 'connected':
+      return { label: 'Connected', className: 'bg-success/20 text-success' };
+    case 'cooldown':
+      return { label: 'Yahoo temporarily unavailable', className: 'bg-warning/20 text-warning' };
+    case 'in_progress':
+      return { label: 'Checking Yahoo', className: 'bg-warning/20 text-warning' };
+    case 'reconnect_needed':
+      return { label: 'Reconnect needed', className: 'bg-destructive/10 text-destructive' };
+    case 'not_connected':
+    default:
+      return { label: 'Not connected', className: 'bg-muted text-muted-foreground' };
+  }
+}
+
+export function getYahooStatusCopy(state: YahooDisplayState, health: YahooConnectionHealth | null): string {
+  const retryAfter = formatYahooRetryAfter(health?.retryAfterSeconds);
+
+  switch (state) {
+    case 'connected':
+      return 'Sync leagues pulls your latest Yahoo leagues using your current Yahoo connection. Reconnect Yahoo opens Yahoo sign-in again if the connection needs repair.';
+    case 'cooldown':
+      return `Yahoo is temporarily unavailable. ${retryAfter ? `Try syncing leagues again in ${retryAfter}.` : 'Try syncing leagues again in a few minutes.'} If this keeps happening, reconnect Yahoo.`;
+    case 'in_progress':
+      return `Yahoo is finishing a login check from another request. ${retryAfter ? `Try syncing leagues again in ${retryAfter}.` : 'Try syncing leagues again shortly.'}`;
+    case 'reconnect_needed':
+      return 'Yahoo needs you to sign in again before Flaim can sync leagues or answer Yahoo questions.';
+    case 'not_connected':
+      return 'Connect your Yahoo account to add leagues.';
+    case 'checking':
+    default:
+      return 'Checking Yahoo connection...';
+  }
+}

--- a/web/lib/yahoo-connection-display.ts
+++ b/web/lib/yahoo-connection-display.ts
@@ -60,6 +60,8 @@ export function getYahooDisplayState(
   if (!isConnected) return 'not_connected';
   if (health?.refreshState === 'cooldown') return 'cooldown';
   if (health?.refreshState === 'in_progress') return 'in_progress';
+  // Expired means a stale refresh lock, not a broken user connection.
+  if (health?.refreshState === 'expired') return 'connected';
   return 'connected';
 }
 
@@ -70,7 +72,7 @@ export function getYahooBadgeCopy(state: YahooDisplayState): { label: string; cl
     case 'connected':
       return { label: 'Connected', className: 'bg-success/20 text-success' };
     case 'cooldown':
-      return { label: 'Yahoo temporarily unavailable', className: 'bg-warning/20 text-warning' };
+      return { label: 'Temporarily unavailable', className: 'bg-warning/20 text-warning' };
     case 'in_progress':
       return { label: 'Checking Yahoo', className: 'bg-warning/20 text-warning' };
     case 'reconnect_needed':

--- a/web/lib/yahoo-connection-display.ts
+++ b/web/lib/yahoo-connection-display.ts
@@ -72,7 +72,7 @@ export function getYahooBadgeCopy(state: YahooDisplayState): { label: string; cl
     case 'cooldown':
       return { label: 'Temporarily unavailable', className: 'bg-warning/20 text-warning' };
     case 'in_progress':
-      return { label: 'Refreshing', className: 'bg-warning/20 text-warning' };
+      return { label: 'Syncing', className: 'bg-warning/20 text-warning' };
     case 'reconnect_needed':
       return { label: 'Reconnect needed', className: 'bg-destructive/10 text-destructive' };
     case 'not_connected':

--- a/web/lib/yahoo-connection-display.ts
+++ b/web/lib/yahoo-connection-display.ts
@@ -1,7 +1,10 @@
+import type {
+  YahooPublicAccessTokenState,
+  YahooPublicCredentialHealth,
+  YahooPublicRefreshState,
+} from '@flaim/worker-shared';
 import { formatYahooRetryAfter } from './yahoo-auth-errors';
 
-export type YahooAccessTokenState = 'fresh' | 'needs_refresh';
-export type YahooRefreshState = 'idle' | 'in_progress' | 'cooldown' | 'expired';
 export type YahooDisplayState =
   | 'checking'
   | 'not_connected'
@@ -10,14 +13,10 @@ export type YahooDisplayState =
   | 'cooldown'
   | 'reconnect_needed';
 
-export interface YahooConnectionHealth {
-  accessTokenState: YahooAccessTokenState;
-  refreshState: YahooRefreshState;
-  retryAfterSeconds?: number;
-}
+export type YahooConnectionHealth = YahooPublicCredentialHealth;
 
-const VALID_YAHOO_ACCESS_TOKEN_STATES = new Set<YahooAccessTokenState>(['fresh', 'needs_refresh']);
-const VALID_YAHOO_REFRESH_STATES = new Set<YahooRefreshState>(['idle', 'in_progress', 'cooldown', 'expired']);
+const VALID_YAHOO_ACCESS_TOKEN_STATES = new Set<YahooPublicAccessTokenState>(['fresh', 'needs_refresh']);
+const VALID_YAHOO_REFRESH_STATES = new Set<YahooPublicRefreshState>(['idle', 'in_progress', 'cooldown', 'expired']);
 
 export function parseYahooConnectionHealth(value: unknown): YahooConnectionHealth | null {
   if (!value || typeof value !== 'object') {
@@ -30,8 +29,8 @@ export function parseYahooConnectionHealth(value: unknown): YahooConnectionHealt
   if (
     typeof accessTokenState !== 'string' ||
     typeof refreshState !== 'string' ||
-    !VALID_YAHOO_ACCESS_TOKEN_STATES.has(accessTokenState as YahooAccessTokenState) ||
-    !VALID_YAHOO_REFRESH_STATES.has(refreshState as YahooRefreshState)
+    !VALID_YAHOO_ACCESS_TOKEN_STATES.has(accessTokenState as YahooPublicAccessTokenState) ||
+    !VALID_YAHOO_REFRESH_STATES.has(refreshState as YahooPublicRefreshState)
   ) {
     return null;
   }
@@ -43,8 +42,8 @@ export function parseYahooConnectionHealth(value: unknown): YahooConnectionHealt
     : undefined;
 
   return {
-    accessTokenState: accessTokenState as YahooAccessTokenState,
-    refreshState: refreshState as YahooRefreshState,
+    accessTokenState: accessTokenState as YahooPublicAccessTokenState,
+    refreshState: refreshState as YahooPublicRefreshState,
     retryAfterSeconds,
   };
 }
@@ -88,7 +87,7 @@ export function getYahooStatusCopy(state: YahooDisplayState, health: YahooConnec
 
   switch (state) {
     case 'connected':
-      return 'Sync leagues pulls your latest Yahoo leagues using your current Yahoo connection. Reconnect Yahoo opens Yahoo sign-in again if the connection needs repair.';
+      return 'Sync leagues pulls your latest Yahoo leagues using your current Yahoo connection. Reconnect Yahoo opens Yahoo sign-in again to repair the connection if it stops working.';
     case 'cooldown':
       return `Yahoo is temporarily unavailable. ${retryAfter ? `Try syncing leagues again in ${retryAfter}.` : 'Try syncing leagues again in a few minutes.'} If this keeps happening, reconnect Yahoo.`;
     case 'in_progress':

--- a/web/lib/yahoo-connection-display.ts
+++ b/web/lib/yahoo-connection-display.ts
@@ -90,9 +90,9 @@ export function getYahooStatusCopy(state: YahooDisplayState, health: YahooConnec
     case 'cooldown':
       return `Yahoo is temporarily unavailable. ${retryAfter ? `Try syncing leagues again in ${retryAfter}.` : 'Try syncing leagues again in a few minutes.'} If this keeps happening, reconnect Yahoo.`;
     case 'in_progress':
-      return `Yahoo is finishing a login check from another request. ${retryAfter ? `Try syncing leagues again in ${retryAfter}.` : 'Try syncing leagues again shortly.'}`;
+      return `Yahoo is refreshing credentials from another request. ${retryAfter ? `Try syncing leagues again in ${retryAfter}.` : 'Try syncing leagues again shortly.'}`;
     case 'reconnect_needed':
-      return 'Yahoo needs you to sign in again before Flaim can sync leagues or answer Yahoo questions.';
+      return 'Yahoo needs you to sign in again before Flaim can sync leagues.';
     case 'not_connected':
       return 'Connect your Yahoo account to add leagues.';
     case 'checking':

--- a/web/lib/yahoo-connection-display.ts
+++ b/web/lib/yahoo-connection-display.ts
@@ -64,6 +64,7 @@ export function getYahooDisplayState(
 }
 
 export function getYahooBadgeCopy(state: YahooDisplayState): { label: string; className: string } {
+  // Keep badge classes as literal strings so Tailwind includes them in production CSS.
   switch (state) {
     case 'checking':
       return { label: 'Checking...', className: 'bg-muted text-muted-foreground' };

--- a/web/lib/yahoo-connection-display.ts
+++ b/web/lib/yahoo-connection-display.ts
@@ -59,8 +59,7 @@ export function getYahooDisplayState(
   if (!isConnected) return 'not_connected';
   if (health?.refreshState === 'cooldown') return 'cooldown';
   if (health?.refreshState === 'in_progress') return 'in_progress';
-  // Expired means a stale refresh lock, not a broken user connection.
-  if (health?.refreshState === 'expired') return 'connected';
+  // Idle and expired states are usable; expired only means a stale refresh lock.
   return 'connected';
 }
 
@@ -73,7 +72,7 @@ export function getYahooBadgeCopy(state: YahooDisplayState): { label: string; cl
     case 'cooldown':
       return { label: 'Temporarily unavailable', className: 'bg-warning/20 text-warning' };
     case 'in_progress':
-      return { label: 'Checking Yahoo', className: 'bg-warning/20 text-warning' };
+      return { label: 'Refreshing', className: 'bg-warning/20 text-warning' };
     case 'reconnect_needed':
       return { label: 'Reconnect needed', className: 'bg-destructive/10 text-destructive' };
     case 'not_connected':

--- a/web/lib/yahoo-connection-display.ts
+++ b/web/lib/yahoo-connection-display.ts
@@ -91,7 +91,7 @@ export function getYahooStatusCopy(state: YahooDisplayState, health: YahooConnec
     case 'cooldown':
       return `Yahoo is temporarily unavailable. ${retryAfter ? `Try syncing leagues again in ${retryAfter}.` : 'Try syncing leagues again in a few minutes.'} If this keeps happening, reconnect Yahoo.`;
     case 'in_progress':
-      return `Yahoo is refreshing credentials from another request. ${retryAfter ? `Try syncing leagues again in ${retryAfter}.` : 'Try syncing leagues again shortly.'}`;
+      return `Yahoo is refreshing credentials. ${retryAfter ? `Try syncing leagues again in ${retryAfter}.` : 'Try syncing leagues again shortly.'}`;
     case 'reconnect_needed':
       return 'Yahoo needs you to sign in again before Flaim can sync leagues.';
     case 'not_connected':

--- a/web/lib/yahoo-connection-display.ts
+++ b/web/lib/yahoo-connection-display.ts
@@ -91,7 +91,7 @@ export function getYahooStatusCopy(state: YahooDisplayState, health: YahooConnec
     case 'cooldown':
       return `Yahoo is temporarily unavailable. ${retryAfter ? `Try syncing leagues again in ${retryAfter}.` : 'Try syncing leagues again in a few minutes.'} If this keeps happening, reconnect Yahoo.`;
     case 'in_progress':
-      return `Yahoo is refreshing credentials. ${retryAfter ? `Try syncing leagues again in ${retryAfter}.` : 'Try syncing leagues again shortly.'}`;
+      return `Yahoo is refreshing credentials. ${retryAfter ? `Try syncing leagues again in ${retryAfter}.` : 'Try syncing leagues again shortly.'} If this keeps happening, reconnect Yahoo.`;
     case 'reconnect_needed':
       return 'Yahoo needs you to sign in again before Flaim can sync leagues.';
     case 'not_connected':

--- a/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
@@ -1339,11 +1339,10 @@ describe('yahoo-connect-handlers', () => {
   describe('handleYahooStatus', () => {
     it('returns connected=true with league count and lastUpdated when credentials exist', async () => {
       const mockUpdatedAt = new Date('2026-01-25T12:00:00Z');
-      mockStorage.getYahooCredentials.mockResolvedValue({
+      mockStorage.getYahooCredentialHealth.mockResolvedValue({
         clerkUserId: 'user_123',
-        accessToken: 'access',
-        refreshToken: 'refresh',
-        expiresAt: new Date(),
+        expiresAt: new Date('2026-01-25T13:00:00Z'),
+        yahooGuidPresent: true,
         needsRefresh: false,
         updatedAt: mockUpdatedAt,
       });
@@ -1359,10 +1358,51 @@ describe('yahoo-connect-handlers', () => {
       expect(body.connected).toBe(true);
       expect(body.leagueCount).toBe(2);
       expect(body.lastUpdated).toBe(mockUpdatedAt.toISOString());
+      expect(body.health).toEqual({
+        accessTokenState: 'fresh',
+        refreshState: 'idle',
+      });
+      expect(JSON.stringify(body)).not.toContain('access-token');
+      expect(JSON.stringify(body)).not.toContain('refresh-token');
+    });
+
+    it('returns coarse cooldown health without exposing diagnostic fields', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-05-12T01:30:00Z'));
+      try {
+        mockStorage.getYahooCredentialHealth.mockResolvedValue({
+          clerkUserId: 'user_123',
+          expiresAt: new Date('2026-05-12T01:31:00Z'),
+          yahooGuidPresent: true,
+          needsRefresh: true,
+          refreshLeaseOwner: 'cooldown:owner-1',
+          refreshLeaseExpiresAt: new Date('2026-05-12T01:35:00Z'),
+        });
+        mockStorage.getYahooLeagues.mockResolvedValue([]);
+
+        const response = await handleYahooStatus(env, 'user_123', corsHeaders);
+
+        expect(response.status).toBe(200);
+        const body = (await response.json()) as Record<string, unknown>;
+        expect(body).toMatchObject({
+          connected: true,
+          leagueCount: 0,
+          health: {
+            accessTokenState: 'needs_refresh',
+            refreshState: 'cooldown',
+            retryAfterSeconds: 300,
+          },
+        });
+        expect(JSON.stringify(body)).not.toContain('owner-1');
+        expect(JSON.stringify(body)).not.toContain('yahooGuidPresent');
+        expect(JSON.stringify(body)).not.toContain('expiresAt');
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('returns connected=false when no credentials exist', async () => {
-      mockStorage.getYahooCredentials.mockResolvedValue(null);
+      mockStorage.getYahooCredentialHealth.mockResolvedValue(null);
       mockStorage.getYahooLeagues.mockResolvedValue([]);
 
       const response = await handleYahooStatus(env, 'user_123', corsHeaders);
@@ -1372,6 +1412,7 @@ describe('yahoo-connect-handlers', () => {
       expect(body.connected).toBe(false);
       expect(body.leagueCount).toBe(0);
       expect(body.lastUpdated).toBeUndefined();
+      expect(body.health).toBeUndefined();
     });
   });
 

--- a/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
@@ -48,6 +48,26 @@ function yahooRefreshDiagnostics(spy: { mock: { calls: unknown[][] } }): Array<R
     .filter((entry): entry is Record<string, unknown> => entry?.component === 'yahoo-connect');
 }
 
+function expectNoRawYahooTokenFields(value: unknown): void {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      expectNoRawYahooTokenFields(item);
+    }
+    return;
+  }
+
+  if (!value || typeof value !== 'object') {
+    return;
+  }
+
+  const record = value as Record<string, unknown>;
+  expect(Object.keys(record)).not.toContain('accessToken');
+  expect(Object.keys(record)).not.toContain('refreshToken');
+  for (const item of Object.values(record)) {
+    expectNoRawYahooTokenFields(item);
+  }
+}
+
 describe('yahoo-connect-handlers', () => {
   let mockStorage: {
     createPlatformOAuthState: ReturnType<typeof vi.fn>;
@@ -1362,8 +1382,7 @@ describe('yahoo-connect-handlers', () => {
         accessTokenState: 'fresh',
         refreshState: 'idle',
       });
-      expect(JSON.stringify(body)).not.toContain('access-token');
-      expect(JSON.stringify(body)).not.toContain('refresh-token');
+      expectNoRawYahooTokenFields(body);
     });
 
     it('returns coarse cooldown health without exposing diagnostic fields', async () => {
@@ -1393,6 +1412,7 @@ describe('yahoo-connect-handlers', () => {
             retryAfterSeconds: 300,
           },
         });
+        expectNoRawYahooTokenFields(body);
         expect(JSON.stringify(body)).not.toContain('owner-1');
         expect(JSON.stringify(body)).not.toContain('yahooGuidPresent');
         expect(JSON.stringify(body)).not.toContain('expiresAt');

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -17,7 +17,7 @@
  * For the PROVIDER side (issuing tokens TO AI clients), see oauth-handlers.ts.
  */
 
-import { YahooStorage, type YahooCredentials } from './yahoo-storage';
+import { YahooStorage, type YahooCredentialHealth, type YahooCredentials } from './yahoo-storage';
 import { getFrontendUrl, resolvePreviewOrigin } from './preview-url';
 import {
   YAHOO_DEFAULT_TRANSIENT_RETRY_AFTER_SECONDS,
@@ -61,6 +61,7 @@ interface YahooTokenResponse {
 }
 
 type YahooCredentialRefreshState = 'none' | 'in_progress' | 'cooldown' | 'expired';
+type YahooPublicRefreshState = 'idle' | 'in_progress' | 'cooldown' | 'expired';
 type YahooTokenBodyClass =
   | 'empty'
   | 'json_error'
@@ -179,6 +180,31 @@ function yahooRefreshState(
   return credentials.refreshLeaseOwner.startsWith(REFRESH_COOLDOWN_OWNER_PREFIX)
     ? 'cooldown'
     : 'in_progress';
+}
+
+function publicYahooRefreshState(refreshState: YahooCredentialRefreshState): YahooPublicRefreshState {
+  return refreshState === 'none' ? 'idle' : refreshState;
+}
+
+function buildPublicYahooHealth(credentials: YahooCredentialHealth, nowMs = Date.now()): {
+  accessTokenState: 'fresh' | 'needs_refresh';
+  refreshState: YahooPublicRefreshState;
+  retryAfterSeconds?: number;
+} {
+  const refreshState = yahooRefreshState(credentials, nowMs);
+  const health: {
+    accessTokenState: 'fresh' | 'needs_refresh';
+    refreshState: YahooPublicRefreshState;
+    retryAfterSeconds?: number;
+  } = {
+    accessTokenState: credentials.needsRefresh ? 'needs_refresh' : 'fresh',
+    refreshState: publicYahooRefreshState(refreshState),
+  };
+  const retryAfterSeconds = boundedPositiveSecondsUntil(credentials.refreshLeaseExpiresAt, nowMs);
+  if ((refreshState === 'cooldown' || refreshState === 'in_progress') && retryAfterSeconds !== undefined) {
+    health.retryAfterSeconds = retryAfterSeconds;
+  }
+  return health;
 }
 
 function logYahooRefreshDiagnostic(event: string, fields: YahooRefreshDiagnosticFields = {}): void {
@@ -1276,7 +1302,7 @@ export async function handleYahooCredentialHealth(
     const checkedAtNowMs = checkedAtDate.getTime();
     const refreshState = yahooRefreshState(credentials, checkedAtNowMs);
     // Keep the internal lease-state enum distinct from the external diagnostic contract.
-    const responseRefreshState = refreshState === 'none' ? 'idle' : refreshState;
+    const responseRefreshState = publicYahooRefreshState(refreshState);
     const leaseRemainingSeconds = boundedPositiveSecondsUntil(credentials.refreshLeaseExpiresAt, checkedAtNowMs);
     const refresh: { state: string; leaseExpiresAt?: string; retryAfterSeconds?: number } = {
       state: responseRefreshState,
@@ -1396,17 +1422,19 @@ export async function handleYahooStatus(
   try {
     const storage = YahooStorage.fromEnvironment(env);
 
-    // Get credentials (includes updatedAt) and leagues in parallel
+    // Public status exposes only coarse, non-secret health for the web UI.
     const [credentials, leagues] = await Promise.all([
-      storage.getYahooCredentials(userId),
+      storage.getYahooCredentialHealth(userId),
       storage.getYahooLeagues(userId),
     ]);
+    const checkedAtNowMs = Date.now();
 
     return new Response(
       JSON.stringify({
         connected: !!credentials,
         leagueCount: leagues.length,
         lastUpdated: credentials?.updatedAt?.toISOString(),
+        health: credentials ? buildPublicYahooHealth(credentials, checkedAtNowMs) : undefined,
       }),
       {
         status: 200,

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -27,6 +27,8 @@ import {
   isYahooTransientHttpStatus,
   parseRetryAfterSeconds,
   YahooAuthWorkerErrorCode,
+  type YahooPublicCredentialHealth,
+  type YahooPublicRefreshState,
 } from '@flaim/worker-shared';
 
 // =============================================================================
@@ -61,7 +63,6 @@ interface YahooTokenResponse {
 }
 
 type YahooCredentialRefreshState = 'none' | 'in_progress' | 'cooldown' | 'expired';
-type YahooPublicRefreshState = 'idle' | 'in_progress' | 'cooldown' | 'expired';
 type YahooTokenBodyClass =
   | 'empty'
   | 'json_error'
@@ -186,17 +187,12 @@ function publicYahooRefreshState(refreshState: YahooCredentialRefreshState): Yah
   return refreshState === 'none' ? 'idle' : refreshState;
 }
 
-function buildPublicYahooHealth(credentials: YahooCredentialHealth, nowMs = Date.now()): {
-  accessTokenState: 'fresh' | 'needs_refresh';
-  refreshState: YahooPublicRefreshState;
-  retryAfterSeconds?: number;
-} {
+function buildPublicYahooHealth(
+  credentials: YahooCredentialHealth,
+  nowMs = Date.now()
+): YahooPublicCredentialHealth {
   const refreshState = yahooRefreshState(credentials, nowMs);
-  const health: {
-    accessTokenState: 'fresh' | 'needs_refresh';
-    refreshState: YahooPublicRefreshState;
-    retryAfterSeconds?: number;
-  } = {
+  const health: YahooPublicCredentialHealth = {
     accessTokenState: credentials.needsRefresh ? 'needs_refresh' : 'fresh',
     refreshState: publicYahooRefreshState(refreshState),
   };

--- a/workers/shared/src/browser.ts
+++ b/workers/shared/src/browser.ts
@@ -28,3 +28,8 @@ export type { SeasonSport } from './season';
 
 export { YahooAuthWorkerErrorCode } from './errors';
 export type { YahooAuthWorkerErrorCodeValue } from './errors';
+export type {
+  YahooPublicAccessTokenState,
+  YahooPublicCredentialHealth,
+  YahooPublicRefreshState,
+} from './yahoo';

--- a/workers/shared/src/index.ts
+++ b/workers/shared/src/index.ts
@@ -46,6 +46,13 @@ export type {
   YahooApiFailureKind,
 } from './http.js';
 
+// Yahoo public API contract types
+export type {
+  YahooPublicAccessTokenState,
+  YahooPublicCredentialHealth,
+  YahooPublicRefreshState,
+} from './yahoo.js';
+
 // Season utilities
 export {
   getDefaultSeasonYear,

--- a/workers/shared/src/yahoo.ts
+++ b/workers/shared/src/yahoo.ts
@@ -1,0 +1,8 @@
+export type YahooPublicAccessTokenState = 'fresh' | 'needs_refresh';
+export type YahooPublicRefreshState = 'idle' | 'in_progress' | 'cooldown' | 'expired';
+
+export interface YahooPublicCredentialHealth {
+  accessTokenState: YahooPublicAccessTokenState;
+  refreshState: YahooPublicRefreshState;
+  retryAfterSeconds?: number;
+}


### PR DESCRIPTION
## Summary
- separate Yahoo Sync leagues from Reconnect Yahoo in the /leagues UI
- expose only coarse Yahoo credential health on the public status endpoint for temporary-unavailable/reconnect-needed states
- add retry-after copy/tests and update Yahoo setup docs/changelog

## Verification
- corepack pnpm --dir web run test
- corepack pnpm --dir web exec tsc --noEmit
- corepack pnpm --dir web run lint
- corepack pnpm --dir workers/auth-worker run test
- corepack pnpm --dir workers/auth-worker run type-check
- git diff --check

Browser smoke note: attempted Browser plugin smoke against localhost:3000, but the plugin blocked localhost in this session under its security policy, so no browser workaround was used.