### PR TITLE
[codex] Reduce Yahoo reconnect token pressure

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ Follow Keep a Changelog; stamp a version when submitting to directories.
 ### Yahoo Connection Reliability
 - **Added**: Yahoo token-refresh diagnostics now emit structured non-secret refresh events and expose an internal credential-health endpoint for production incident triage.
 - **Added**: Yahoo connection management on `/leagues` now separates **Sync leagues** from **Reconnect Yahoo** and shows coarse temporary-unavailable/reconnect-needed states.
+- **Changed**: Yahoo reconnect now stores the authorization-code token response directly instead of immediately making a second refresh-token validation request, reducing token-endpoint pressure.
 - **Changed**: Yahoo **Sync leagues** on `/leagues` now uses the stored connection to rediscover leagues instead of starting a fresh OAuth flow every time.
 - **Changed**: Yahoo refresh lease waiters now return an explicit retryable response before the MCP gateway timeout budget is exhausted.
 - **Fixed**: Yahoo league discovery rate limits (`429`/`999`) and transient upstream failures now return retryable responses with `Retry-After` instead of generic refresh failures.

--- a/web/lib/yahoo-auth-errors.ts
+++ b/web/lib/yahoo-auth-errors.ts
@@ -13,7 +13,6 @@ const YAHOO_RECONNECT_ERRORS = new Set<string>(['not_connected', 'refresh_failed
 // Includes OAuth callback redirect codes; yahoo-client's credentials API classifier is intentionally narrower.
 const YAHOO_TRANSIENT_AUTH_ERRORS = new Set<string>([
   YahooAuthWorkerErrorCode.REFRESH_TEMPORARILY_UNAVAILABLE,
-  YahooAuthWorkerErrorCode.TOKEN_REFRESH_VALIDATION_UNAVAILABLE,
   YahooAuthWorkerErrorCode.TOKEN_EXCHANGE_UNAVAILABLE,
   YahooAuthWorkerErrorCode.YAHOO_API_TEMPORARILY_UNAVAILABLE,
 ]);
@@ -69,12 +68,8 @@ export function getYahooConnectErrorMessage(
   retryAfterSeconds?: number
 ): string {
   switch (error) {
-    case 'token_refresh_validation_failed':
-      return 'Yahoo connection did not complete because the refresh token could not be validated. Please connect Yahoo again.';
     case YahooAuthWorkerErrorCode.REFRESH_TEMPORARILY_UNAVAILABLE:
       return appendRetryCopy(YAHOO_TRANSIENT_AUTH_BASE, retryAfterSeconds);
-    case YahooAuthWorkerErrorCode.TOKEN_REFRESH_VALIDATION_UNAVAILABLE:
-      return appendRetryCopy('Yahoo connection could not be validated because Yahoo was temporarily unavailable.', retryAfterSeconds);
     case YahooAuthWorkerErrorCode.TOKEN_EXCHANGE_UNAVAILABLE:
       return appendRetryCopy('Yahoo connection could not be started because Yahoo was temporarily unavailable.', retryAfterSeconds);
     case 'token_exchange_failed':

--- a/workers/auth-worker/README.md
+++ b/workers/auth-worker/README.md
@@ -63,7 +63,7 @@ These endpoints manage the OAuth 2.0 client flow with Yahoo Fantasy.
 | `GET /internal/leagues/yahoo` | Internal + Clerk JWT / OAuth / Eval key | Get stored Yahoo leagues for internal workers |
 | `DELETE /leagues/yahoo/:id` | Clerk JWT | Delete a Yahoo league |
 
-Yahoo callback stores the authorization-code token response directly after a successful reconnect. Access-token refresh is deferred until the token is stale and then runs through the backend per-user lease/cooldown path, which keeps Yahoo refresh tokens off the browser and avoids an extra token-endpoint call during reconnect.
+Yahoo callback stores the authorization-code token response directly after a successful reconnect. Access-token refresh is deferred until the token is stale and then runs through the backend per-user lease/cooldown path, which keeps Yahoo refresh tokens off the browser and avoids an extra token-endpoint call during reconnect. If Yahoo ever returns a bad refresh token with an otherwise successful reconnect, that failure will surface on the first lazy refresh instead of during the callback.
 
 `/internal/connect/yahoo/credential-health` returns no access or refresh tokens. Its `refresh.state` can be `idle`, `in_progress`, `cooldown`, or `expired`; `leaseExpiresAt` is included when a lease owner and timestamp exist, including past timestamps for `expired` leases, while `retryAfterSeconds` is only included for active `in_progress` or `cooldown` waits. `lastUpdated` is `null` when the credential row has no update timestamp.
 

--- a/workers/auth-worker/README.md
+++ b/workers/auth-worker/README.md
@@ -63,6 +63,8 @@ These endpoints manage the OAuth 2.0 client flow with Yahoo Fantasy.
 | `GET /internal/leagues/yahoo` | Internal + Clerk JWT / OAuth / Eval key | Get stored Yahoo leagues for internal workers |
 | `DELETE /leagues/yahoo/:id` | Clerk JWT | Delete a Yahoo league |
 
+Yahoo callback stores the authorization-code token response directly after a successful reconnect. Access-token refresh is deferred until the token is stale and then runs through the backend per-user lease/cooldown path, which keeps Yahoo refresh tokens off the browser and avoids an extra token-endpoint call during reconnect.
+
 `/internal/connect/yahoo/credential-health` returns no access or refresh tokens. Its `refresh.state` can be `idle`, `in_progress`, `cooldown`, or `expired`; `leaseExpiresAt` is included when a lease owner and timestamp exist, including past timestamps for `expired` leases, while `retryAfterSeconds` is only included for active `in_progress` or `cooldown` waits. `lastUpdated` is `null` when the credential row has no update timestamp.
 
 ### Sleeper Connect

--- a/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
@@ -244,30 +244,17 @@ describe('yahoo-connect-handlers', () => {
         redirectAfter: undefined,
       });
 
-      // Mock successful token exchange, then the callback's immediate refresh validation
-      mockFetch
-        .mockResolvedValueOnce(
-          new Response(
-            JSON.stringify({
-              access_token: 'yahoo-access-token',
-              refresh_token: 'yahoo-refresh-token',
-              expires_in: 3600,
-              xoauth_yahoo_guid: 'yahoo-guid-123',
-            }),
-            { status: 200 }
-          )
+      mockFetch.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            access_token: 'yahoo-access-token',
+            refresh_token: 'yahoo-refresh-token',
+            expires_in: 3600,
+            xoauth_yahoo_guid: 'yahoo-guid-123',
+          }),
+          { status: 200 }
         )
-        .mockResolvedValueOnce(
-          new Response(
-            JSON.stringify({
-              access_token: 'validated-access-token',
-              refresh_token: 'validated-refresh-token',
-              expires_in: 3600,
-              xoauth_yahoo_guid: 'yahoo-guid-123',
-            }),
-            { status: 200 }
-          )
-        );
+      );
 
       const request = new Request('https://api.flaim.app/connect/yahoo/callback?code=auth_code&state=user_abc123:nonce');
 
@@ -282,93 +269,34 @@ describe('yahoo-connect-handlers', () => {
       expect(mockStorage.saveYahooCredentials).toHaveBeenCalledWith(
         expect.objectContaining({
           clerkUserId: 'user_abc123',
-          accessToken: 'validated-access-token',
-          refreshToken: 'validated-refresh-token',
+          accessToken: 'yahoo-access-token',
+          refreshToken: 'yahoo-refresh-token',
           yahooGuid: 'yahoo-guid-123',
         })
       );
+      expect(mockFetch).toHaveBeenCalledTimes(1);
 
       const exchangeRequest = mockFetch.mock.calls[0][1] as RequestInit;
       const exchangeBody = new URLSearchParams(exchangeRequest.body as string);
       expect(exchangeBody.get('grant_type')).toBe('authorization_code');
       expect(exchangeBody.get('redirect_uri')).toBe('https://api.flaim.app/auth/connect/yahoo/callback');
-
-      const validationRequest = mockFetch.mock.calls[1][1] as RequestInit;
-      const validationBody = new URLSearchParams(validationRequest.body as string);
-      expect(validationBody.get('grant_type')).toBe('refresh_token');
-      expect(validationBody.get('refresh_token')).toBe('yahoo-refresh-token');
-      expect(validationBody.get('redirect_uri')).toBe('https://api.flaim.app/auth/connect/yahoo/callback');
     });
 
-    it('keeps the original refresh token when callback validation does not rotate it', async () => {
+    it('does not save credentials when token exchange omits a refresh token', async () => {
       mockStorage.consumePlatformOAuthState.mockResolvedValue({
         clerkUserId: 'user_abc123',
         platform: 'yahoo',
-        redirectAfter: undefined,
       });
 
-      mockFetch
-        .mockResolvedValueOnce(
-          new Response(
-            JSON.stringify({
-              access_token: 'yahoo-access-token',
-              refresh_token: 'yahoo-refresh-token',
-              expires_in: 3600,
-              xoauth_yahoo_guid: 'yahoo-guid-123',
-            }),
-            { status: 200 }
-          )
+      mockFetch.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            access_token: 'yahoo-access-token',
+            expires_in: 3600,
+          }),
+          { status: 200 }
         )
-        .mockResolvedValueOnce(
-          new Response(
-            JSON.stringify({
-              access_token: 'validated-access-token',
-              expires_in: 3600,
-              xoauth_yahoo_guid: 'yahoo-guid-123',
-            }),
-            { status: 200 }
-          )
-        );
-
-      const request = new Request('https://api.flaim.app/connect/yahoo/callback?code=auth_code&state=user_abc123:nonce');
-
-      const response = await handleYahooCallback(request, env, corsHeaders);
-
-      expect(response.status).toBe(302);
-      expect(mockStorage.saveYahooCredentials).toHaveBeenCalledWith(
-        expect.objectContaining({
-          accessToken: 'validated-access-token',
-          refreshToken: 'yahoo-refresh-token',
-        })
       );
-    });
-
-    it('returns error redirect when refresh validation fails after token exchange', async () => {
-      mockStorage.consumePlatformOAuthState.mockResolvedValue({
-        clerkUserId: 'user_abc123',
-        platform: 'yahoo',
-      });
-
-      mockFetch
-        .mockResolvedValueOnce(
-          new Response(
-            JSON.stringify({
-              access_token: 'yahoo-access-token',
-              refresh_token: 'bad-refresh-token',
-              expires_in: 3600,
-            }),
-            { status: 200 }
-          )
-        )
-        .mockResolvedValueOnce(
-          new Response(
-            JSON.stringify({
-              error: 'invalid_grant',
-              error_description: 'Refresh token rejected',
-            }),
-            { status: 400 }
-          )
-        );
 
       const request = new Request('https://api.flaim.app/connect/yahoo/callback?code=auth_code&state=user_abc123:nonce');
 
@@ -376,36 +304,25 @@ describe('yahoo-connect-handlers', () => {
 
       expect(response.status).toBe(302);
       const location = response.headers.get('Location')!;
-      expect(location).toContain('error=token_refresh_validation_failed');
+      expect(location).toContain('error=token_exchange_failed');
       expect(mockStorage.saveYahooCredentials).not.toHaveBeenCalled();
+      expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
-    it('returns temporary error redirect when refresh validation has a transient Yahoo error', async () => {
+    it('does not save credentials when token exchange omits usable token fields', async () => {
       mockStorage.consumePlatformOAuthState.mockResolvedValue({
         clerkUserId: 'user_abc123',
         platform: 'yahoo',
       });
 
-      mockFetch
-        .mockResolvedValueOnce(
-          new Response(
-            JSON.stringify({
-              access_token: 'yahoo-access-token',
-              refresh_token: 'yahoo-refresh-token',
-              expires_in: 3600,
-            }),
-            { status: 200 }
-          )
+      mockFetch.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            refresh_token: 'yahoo-refresh-token',
+          }),
+          { status: 200 }
         )
-        .mockResolvedValueOnce(
-          new Response(
-            JSON.stringify({
-              error: 'temporarily_unavailable',
-              error_description: 'Try again later',
-            }),
-            { status: 503 }
-          )
-        );
+      );
 
       const request = new Request('https://api.flaim.app/connect/yahoo/callback?code=auth_code&state=user_abc123:nonce');
 
@@ -413,108 +330,9 @@ describe('yahoo-connect-handlers', () => {
 
       expect(response.status).toBe(302);
       const location = response.headers.get('Location')!;
-      expect(location).toContain('error=token_refresh_validation_unavailable');
+      expect(location).toContain('error=token_exchange_failed');
       expect(mockStorage.saveYahooCredentials).not.toHaveBeenCalled();
-    });
-
-    it('returns temporary error redirect when refresh validation returns non-JSON Too many body', async () => {
-      mockStorage.consumePlatformOAuthState.mockResolvedValue({
-        clerkUserId: 'user_abc123',
-        platform: 'yahoo',
-      });
-
-      mockFetch
-        .mockResolvedValueOnce(
-          new Response(
-            JSON.stringify({
-              access_token: 'yahoo-access-token',
-              refresh_token: 'yahoo-refresh-token',
-              expires_in: 3600,
-            }),
-            { status: 200 }
-          )
-        )
-        .mockResolvedValueOnce(
-          new Response('Too many requests to Yahoo token endpoint', {
-            status: 400,
-            headers: { 'Content-Type': 'text/plain' },
-          })
-        );
-
-      const request = new Request('https://api.flaim.app/connect/yahoo/callback?code=auth_code&state=user_abc123:nonce');
-
-      const response = await handleYahooCallback(request, env, corsHeaders);
-
-      expect(response.status).toBe(302);
-      const location = response.headers.get('Location')!;
-      expect(location).toContain('error=token_refresh_validation_unavailable');
-      expect(mockStorage.saveYahooCredentials).not.toHaveBeenCalled();
-    });
-
-    it('returns temporary error redirect when refresh validation aborts', async () => {
-      mockStorage.consumePlatformOAuthState.mockResolvedValue({
-        clerkUserId: 'user_abc123',
-        platform: 'yahoo',
-      });
-
-      const abortError = new DOMException('The operation was aborted', 'AbortError');
-      mockFetch
-        .mockResolvedValueOnce(
-          new Response(
-            JSON.stringify({
-              access_token: 'yahoo-access-token',
-              refresh_token: 'yahoo-refresh-token',
-              expires_in: 3600,
-            }),
-            { status: 200 }
-          )
-        )
-        .mockRejectedValueOnce(abortError);
-
-      const request = new Request('https://api.flaim.app/connect/yahoo/callback?code=auth_code&state=user_abc123:nonce');
-
-      const response = await handleYahooCallback(request, env, corsHeaders);
-
-      expect(response.status).toBe(302);
-      const location = response.headers.get('Location')!;
-      expect(location).toContain('error=token_refresh_validation_unavailable');
-      expect(mockStorage.saveYahooCredentials).not.toHaveBeenCalled();
-    });
-
-    it('returns error redirect when refresh validation omits expires_in', async () => {
-      mockStorage.consumePlatformOAuthState.mockResolvedValue({
-        clerkUserId: 'user_abc123',
-        platform: 'yahoo',
-      });
-
-      mockFetch
-        .mockResolvedValueOnce(
-          new Response(
-            JSON.stringify({
-              access_token: 'yahoo-access-token',
-              refresh_token: 'yahoo-refresh-token',
-              expires_in: 3600,
-            }),
-            { status: 200 }
-          )
-        )
-        .mockResolvedValueOnce(
-          new Response(
-            JSON.stringify({
-              access_token: 'validated-access-token',
-            }),
-            { status: 200 }
-          )
-        );
-
-      const request = new Request('https://api.flaim.app/connect/yahoo/callback?code=auth_code&state=user_abc123:nonce');
-
-      const response = await handleYahooCallback(request, env, corsHeaders);
-
-      expect(response.status).toBe(302);
-      const location = response.headers.get('Location')!;
-      expect(location).toContain('error=token_refresh_validation_failed');
-      expect(mockStorage.saveYahooCredentials).not.toHaveBeenCalled();
+      expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
     it('returns error redirect when token exchange fails', async () => {
@@ -719,6 +537,9 @@ describe('yahoo-connect-handlers', () => {
       const body = (await response.json()) as Record<string, unknown>;
       expect(body.error).toBe('refresh_failed');
       expect(body.error_description).toBe('Refresh token expired');
+      expect(mockStorage.updateYahooCredentials).not.toHaveBeenCalled();
+      expect(mockStorage.markRefreshCooldown).not.toHaveBeenCalled();
+      expect(mockStorage.releaseRefreshLease).toHaveBeenCalledWith('user_123', expect.any(String));
     });
 
     it('classifies unexpected Yahoo refresh errors without retry metadata', async () => {
@@ -1653,6 +1474,35 @@ describe('yahoo-connect-handlers', () => {
   // ===========================================================================
 
   describe('handleYahooDiscover (refresh lease)', () => {
+    it('uses fresh callback credentials for discovery without refreshing first', async () => {
+      mockStorage.getYahooCredentials.mockResolvedValue({
+        clerkUserId: 'user_123',
+        accessToken: 'callback-access-token',
+        refreshToken: 'callback-refresh-token',
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+        needsRefresh: false,
+      });
+
+      mockFetch.mockResolvedValue(
+        new Response(
+          JSON.stringify({ fantasy_content: { users: { count: 0 } } }),
+          { status: 200 }
+        )
+      );
+
+      const response = await handleYahooDiscover(env, 'user_123', corsHeaders);
+
+      expect(response.status).toBe(200);
+      expect(mockStorage.acquireRefreshLease).not.toHaveBeenCalled();
+      expect(mockStorage.updateYahooCredentials).not.toHaveBeenCalled();
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch.mock.calls[0][0]).toContain('/users;use_login=1/games/leagues');
+      const yahooApiRequest = mockFetch.mock.calls[0][1] as RequestInit;
+      expect(yahooApiRequest.body).toBeUndefined();
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.success).toBe(true);
+    });
+
     it('loser waits and proceeds with fresh token after winner finishes', async () => {
       const stale = {
         clerkUserId: 'user_123',

--- a/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
@@ -282,6 +282,42 @@ describe('yahoo-connect-handlers', () => {
       expect(exchangeBody.get('redirect_uri')).toBe('https://api.flaim.app/auth/connect/yahoo/callback');
     });
 
+    it('saves credentials when token exchange omits the optional Yahoo GUID', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      mockStorage.consumePlatformOAuthState.mockResolvedValue({
+        clerkUserId: 'user_abc123',
+        platform: 'yahoo',
+        redirectAfter: undefined,
+      });
+
+      mockFetch.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            access_token: 'yahoo-access-token',
+            refresh_token: 'yahoo-refresh-token',
+            expires_in: 3600,
+          }),
+          { status: 200 }
+        )
+      );
+
+      const request = new Request('https://api.flaim.app/connect/yahoo/callback?code=auth_code&state=user_abc123:nonce');
+
+      const response = await handleYahooCallback(request, env, corsHeaders);
+
+      expect(response.status).toBe(302);
+      expect(mockStorage.saveYahooCredentials).toHaveBeenCalledWith(
+        expect.objectContaining({
+          clerkUserId: 'user_abc123',
+          accessToken: 'yahoo-access-token',
+          refreshToken: 'yahoo-refresh-token',
+          yahooGuid: undefined,
+        })
+      );
+      expect(warnSpy).toHaveBeenCalledWith('[yahoo-connect] Yahoo token exchange omitted GUID for user user_abc...');
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
     it('does not save credentials when token exchange omits a refresh token', async () => {
       mockStorage.consumePlatformOAuthState.mockResolvedValue({
         clerkUserId: 'user_abc123',

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -1113,10 +1113,19 @@ export async function handleYahooCallback(
       );
     }
 
+    if (!hasUsableTokenFields(tokenResponse)) {
+      console.error('[yahoo-connect] Token exchange returned unusable token fields');
+      return errorRedirect('token_exchange_failed', 'Yahoo did not return usable token fields');
+    }
+
     // Validate refresh token is present
     if (!tokenResponse.refresh_token) {
       console.error('[yahoo-connect] Yahoo did not return a refresh token');
       return errorRedirect('token_exchange_failed', 'Yahoo did not provide a refresh token');
+    }
+
+    if (!tokenResponse.xoauth_yahoo_guid) {
+      console.warn(`[yahoo-connect] Yahoo token exchange omitted GUID for user ${maskUserId(clerkUserId)}`);
     }
 
     // Yahoo's authorization-code response is the authorization proof. Avoid an

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -1119,66 +1119,18 @@ export async function handleYahooCallback(
       return errorRedirect('token_exchange_failed', 'Yahoo did not provide a refresh token');
     }
 
-    // This intentional second Yahoo call proves the refresh path works now,
-    // so reconnect cannot look successful and then fail after access-token expiry.
-    const validationController = new AbortController();
-    const validationTimer = setTimeout(() => validationController.abort(), YAHOO_TOKEN_REQUEST_TIMEOUT_MS);
-    let validatedTokenResponse: YahooTokenResponse;
-    try {
-      validatedTokenResponse = await refreshAccessToken(
-        tokenResponse.refresh_token,
-        env,
-        validationController.signal
-      );
-    } catch (error) {
-      clearTimeout(validationTimer);
-      console.error(
-        '[yahoo-connect] Refresh token validation failed after Yahoo callback:',
-        error instanceof Error ? error.message : error
-      );
-      return errorRedirect(
-        YahooAuthWorkerErrorCode.TOKEN_REFRESH_VALIDATION_UNAVAILABLE,
-        'Yahoo refresh token validation is temporarily unavailable. Please try again.'
-      );
-    }
-    clearTimeout(validationTimer);
-
-    if (validatedTokenResponse.error) {
-      const statusSuffix = validatedTokenResponse.status ? ` (HTTP ${validatedTokenResponse.status})` : '';
-      const isTransient = isTransientYahooTokenFailure(validatedTokenResponse);
-      console.error(
-        `[yahoo-connect] Refresh token validation failed after Yahoo callback: ${validatedTokenResponse.error}${statusSuffix}` +
-          (validatedTokenResponse.error_description ? ` - ${validatedTokenResponse.error_description}` : '')
-      );
-      return errorRedirect(
-        isTransient ? YahooAuthWorkerErrorCode.TOKEN_REFRESH_VALIDATION_UNAVAILABLE : 'token_refresh_validation_failed',
-        isTransient
-          ? 'Yahoo refresh token validation is temporarily unavailable. Please try again.'
-          : 'Yahoo refresh token validation failed'
-      );
-    }
-
-    if (!hasUsableTokenFields(validatedTokenResponse)) {
-      console.error('[yahoo-connect] Refresh token validation returned an invalid token response after Yahoo callback');
-      return errorRedirect(
-        'token_refresh_validation_failed',
-        'Yahoo refresh token validation failed'
-      );
-    }
-
-    const refreshToken = validatedTokenResponse.refresh_token || tokenResponse.refresh_token;
-    const yahooGuid = validatedTokenResponse.xoauth_yahoo_guid || tokenResponse.xoauth_yahoo_guid;
-
-    // Calculate token expiration from the validated refresh response.
-    const expiresAt = new Date(Date.now() + validatedTokenResponse.expires_in * 1000);
+    // Yahoo's authorization-code response is the authorization proof. Avoid an
+    // immediate refresh-token validation call here; lazy refresh is still
+    // protected by the per-user lease/cooldown path when the token later ages.
+    const expiresAt = new Date(Date.now() + tokenResponse.expires_in * 1000);
 
     // Save credentials
     await storage.saveYahooCredentials({
       clerkUserId,
-      accessToken: validatedTokenResponse.access_token,
-      refreshToken,
+      accessToken: tokenResponse.access_token,
+      refreshToken: tokenResponse.refresh_token,
       expiresAt,
-      yahooGuid,
+      yahooGuid: tokenResponse.xoauth_yahoo_guid,
     });
 
     console.log(`[yahoo-connect] Successfully connected user ${maskUserId(clerkUserId)} to Yahoo`);

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -1118,7 +1118,8 @@ export async function handleYahooCallback(
       return errorRedirect('token_exchange_failed', 'Yahoo did not return usable token fields');
     }
 
-    // Validate refresh token is present
+    // hasUsableTokenFields validates the access-token shape; reconnect must
+    // also return a refresh token for future lazy refreshes.
     if (!tokenResponse.refresh_token) {
       console.error('[yahoo-connect] Yahoo did not return a refresh token');
       return errorRedirect('token_exchange_failed', 'Yahoo did not provide a refresh token');

--- a/workers/shared/src/__tests__/errors.test.ts
+++ b/workers/shared/src/__tests__/errors.test.ts
@@ -30,7 +30,6 @@ describe('error utilities', () => {
 
   it('Yahoo auth-worker error codes include transient auth failures', () => {
     expect(YahooAuthWorkerErrorCode.REFRESH_TEMPORARILY_UNAVAILABLE).toBe('refresh_temporarily_unavailable');
-    expect(YahooAuthWorkerErrorCode.TOKEN_REFRESH_VALIDATION_UNAVAILABLE).toBe('token_refresh_validation_unavailable');
     expect(YahooAuthWorkerErrorCode.TOKEN_EXCHANGE_UNAVAILABLE).toBe('token_exchange_unavailable');
   });
 });

--- a/workers/shared/src/errors.ts
+++ b/workers/shared/src/errors.ts
@@ -68,7 +68,6 @@ export const ErrorCode = {
 // public MCP-level ErrorCode values above, such as YAHOO_AUTH_UNAVAILABLE.
 export const YahooAuthWorkerErrorCode = {
   REFRESH_TEMPORARILY_UNAVAILABLE: 'refresh_temporarily_unavailable',
-  TOKEN_REFRESH_VALIDATION_UNAVAILABLE: 'token_refresh_validation_unavailable',
   TOKEN_EXCHANGE_UNAVAILABLE: 'token_exchange_unavailable',
   YAHOO_API_ERROR: 'yahoo_api_error',
   YAHOO_API_TEMPORARILY_UNAVAILABLE: 'yahoo_api_temporarily_unavailable',

--- a/workers/yahoo-client/src/shared/auth.ts
+++ b/workers/yahoo-client/src/shared/auth.ts
@@ -30,8 +30,7 @@ async function throwYahooAuthWorkerError(response: Response): Promise<never> {
     response.status === 429 ||
     response.status === 503 ||
     errorData.retryable === true ||
-    errorData.error === YahooAuthWorkerErrorCode.REFRESH_TEMPORARILY_UNAVAILABLE ||
-    errorData.error === YahooAuthWorkerErrorCode.TOKEN_REFRESH_VALIDATION_UNAVAILABLE;
+    errorData.error === YahooAuthWorkerErrorCode.REFRESH_TEMPORARILY_UNAVAILABLE;
 
   if (isTransientAuthFailure) {
     throw new YahooClientError({


### PR DESCRIPTION
## Summary

Fixes FLA-125 by reducing Yahoo OAuth token-endpoint pressure during reconnect.

- stores the Yahoo authorization-code token response directly on callback
- removes the immediate post-callback refresh-token validation request
- keeps lazy backend refresh behind the existing per-user lease/cooldown path
- updates tests and docs to make the deferred-refresh behavior explicit

## Why

Recent production failures showed Yahoo returning token-endpoint rate limits/cooldowns. Git history review identified PR #63 as a likely contributor because a successful reconnect made two Yahoo token endpoint calls: the normal authorization-code exchange plus an immediate refresh-token validation call. That validation was not a security boundary; Yahoo returning tokens for the authorization code is the authorization proof.

This change keeps refreshes server-side, but defers refresh-token use until the access token is stale and a real Yahoo operation needs it.

## Scope

This intentionally does not change MCP OAuth token lifetimes, Durable Objects, background refreshes, provider abstractions, or database schema. The schema-backed refresh-health expansion needs a migration-first rollout and is better handled separately.

## Validation

- `git diff --check`
- `corepack pnpm --dir workers/auth-worker run test`
- `corepack pnpm --dir workers/auth-worker run type-check`

Local validation emitted the existing engine warning because this shell is on Node `v26.0.0` while the repo asks for Node `24.x`; checks still passed.
