### PR TITLE
[codex] Harden Yahoo lazy refresh

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,7 @@ Follow Keep a Changelog; stamp a version when submitting to directories.
 - **Fixed**: Removed stale dev-only chat framing and cleaned unresolved merge-conflict markers from `docs/ARCHITECTURE.md`.
 
 ### Yahoo Connection Reliability
-- **Added**: Yahoo token-refresh diagnostics now emit structured non-secret refresh events and expose an internal credential-health endpoint for production incident triage.
+- **Added**: Yahoo token-refresh diagnostics now emit structured non-secret refresh events with failure classes, outcomes, request-timeout/lease-budget fields, and an internal credential-health endpoint for production incident triage.
 - **Added**: Yahoo connection management on `/leagues` now separates **Sync leagues** from **Reconnect Yahoo** and shows coarse temporary-unavailable/reconnect-needed states.
 - **Changed**: Yahoo lazy token refresh now gives the lease owner one short retry for retryable non-rate-limit token-endpoint failures before setting a shared cooldown.
 - **Changed**: Yahoo reconnect now stores the authorization-code token response directly instead of immediately making a second refresh-token validation request, reducing token-endpoint pressure.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ Follow Keep a Changelog; stamp a version when submitting to directories.
 ### Yahoo Connection Reliability
 - **Added**: Yahoo token-refresh diagnostics now emit structured non-secret refresh events and expose an internal credential-health endpoint for production incident triage.
 - **Added**: Yahoo connection management on `/leagues` now separates **Sync leagues** from **Reconnect Yahoo** and shows coarse temporary-unavailable/reconnect-needed states.
+- **Changed**: Yahoo lazy token refresh now gives the lease owner one short retry for retryable non-rate-limit token-endpoint failures before setting a shared cooldown.
 - **Changed**: Yahoo reconnect now stores the authorization-code token response directly instead of immediately making a second refresh-token validation request, reducing token-endpoint pressure.
 - **Changed**: Yahoo **Sync leagues** on `/leagues` now uses the stored connection to rediscover leagues instead of starting a fresh OAuth flow every time.
 - **Changed**: Yahoo refresh lease waiters now return an explicit retryable response before the MCP gateway timeout budget is exhausted.

--- a/workers/auth-worker/README.md
+++ b/workers/auth-worker/README.md
@@ -65,6 +65,8 @@ These endpoints manage the OAuth 2.0 client flow with Yahoo Fantasy.
 
 Yahoo callback stores the authorization-code token response directly after a successful reconnect. Access-token refresh is deferred until the token is stale and then runs through the backend per-user lease/cooldown path, which keeps Yahoo refresh tokens off the browser and avoids an extra token-endpoint call during reconnect. If Yahoo ever returns a bad refresh token with an otherwise successful reconnect, that failure will surface on the first lazy refresh instead of during the callback.
 
+Lazy refresh uses a single per-user lease. The lease owner may retry one short-lived transient, non-rate-limit Yahoo token-endpoint failure before converting the lease into a shared cooldown; other callers wait for the winner or receive retry metadata instead of stampeding Yahoo.
+
 `/internal/connect/yahoo/credential-health` returns no access or refresh tokens. Its `refresh.state` can be `idle`, `in_progress`, `cooldown`, or `expired`; `leaseExpiresAt` is included when a lease owner and timestamp exist, including past timestamps for `expired` leases, while `retryAfterSeconds` is only included for active `in_progress` or `cooldown` waits. `lastUpdated` is `null` when the credential row has no update timestamp.
 
 ### Sleeper Connect

--- a/workers/auth-worker/README.md
+++ b/workers/auth-worker/README.md
@@ -67,6 +67,8 @@ Yahoo callback stores the authorization-code token response directly after a suc
 
 Lazy refresh uses a single per-user lease. The lease owner may retry one short-lived transient, non-rate-limit Yahoo token-endpoint failure before converting the lease into a shared cooldown; other callers wait for the winner or receive retry metadata instead of stampeding Yahoo.
 
+Refresh diagnostics are emitted as structured, non-secret `yahoo-connect` log events with correlation IDs. The refresh path classifies failures with `diagnostic_class` values such as `yahoo_rate_limit`, `yahoo_transient_http`, `yahoo_transient_text`, `fetch_error`, `timeout`, `lease_wait_timeout`, and `lease_budget_exhausted`, plus `outcome`, retry delay, request-timeout, and lease-budget fields where relevant. These fields are intended for production incident triage without exposing access or refresh tokens.
+
 `/internal/connect/yahoo/credential-health` returns no access or refresh tokens. Its `refresh.state` can be `idle`, `in_progress`, `cooldown`, or `expired`; `leaseExpiresAt` is included when a lease owner and timestamp exist, including past timestamps for `expired` leases, while `retryAfterSeconds` is only included for active `in_progress` or `cooldown` waits. `lastUpdated` is `null` when the credential row has no update timestamp.
 
 ### Sleeper Connect

--- a/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
@@ -812,16 +812,23 @@ describe('yahoo-connect-handlers', () => {
           expect.objectContaining({
             event: 'refresh_response_error',
             correlation_id: 'req_429',
+            phase: 'refresh_response',
+            outcome: 'rate_limited',
+            diagnostic_class: 'yahoo_rate_limit',
             upstream_status: 429,
             token_error: 'rate_limited',
             failure_kind: 'transient_http',
           }),
           expect.objectContaining({
             event: 'refresh_transient_failure',
+            outcome: 'rate_limited',
+            diagnostic_class: 'yahoo_rate_limit',
             retry_after: 900,
           }),
           expect.objectContaining({
             event: 'cooldown_mark_attempted',
+            outcome: 'cooldown_marked',
+            diagnostic_class: 'cooldown_mark',
             retry_after: 900,
             cooldown_marked: true,
           }),
@@ -979,6 +986,9 @@ describe('yahoo-connect-handlers', () => {
             expect.objectContaining({
               event: 'refresh_owner_retry_scheduled',
               correlation_id: 'req_retry_success',
+              phase: 'refresh_response',
+              outcome: 'retry_scheduled',
+              diagnostic_class: 'yahoo_transient_text',
               retry_attempt: 1,
               retry_delay_ms: 250,
               failure_kind: 'transient_text',
@@ -986,6 +996,8 @@ describe('yahoo-connect-handlers', () => {
             expect.objectContaining({
               event: 'credential_update_succeeded',
               correlation_id: 'req_retry_success',
+              phase: 'credential_update',
+              outcome: 'success',
             }),
           ])
         );
@@ -1044,6 +1056,9 @@ describe('yahoo-connect-handlers', () => {
             expect.objectContaining({
               event: 'refresh_owner_retry_scheduled',
               correlation_id: 'req_retry_503_success',
+              phase: 'refresh_response',
+              outcome: 'retry_scheduled',
+              diagnostic_class: 'yahoo_transient_http',
               retry_attempt: 1,
               retry_delay_ms: 250,
               upstream_status: 503,
@@ -1052,6 +1067,8 @@ describe('yahoo-connect-handlers', () => {
             expect.objectContaining({
               event: 'credential_update_succeeded',
               correlation_id: 'req_retry_503_success',
+              phase: 'credential_update',
+              outcome: 'success',
             }),
           ])
         );
@@ -1102,6 +1119,9 @@ describe('yahoo-connect-handlers', () => {
             expect.objectContaining({
               event: 'refresh_owner_retry_scheduled',
               correlation_id: 'req_retry_fetch_error',
+              phase: 'refresh_request',
+              outcome: 'retry_scheduled',
+              diagnostic_class: 'fetch_error',
               reason: 'fetch_error',
               retry_attempt: 1,
               retry_delay_ms: 250,
@@ -1109,6 +1129,8 @@ describe('yahoo-connect-handlers', () => {
             expect.objectContaining({
               event: 'credential_update_succeeded',
               correlation_id: 'req_retry_fetch_error',
+              phase: 'credential_update',
+              outcome: 'success',
             }),
           ])
         );
@@ -1157,6 +1179,7 @@ describe('yahoo-connect-handlers', () => {
     });
 
     it('winner: marks cooldown without calling Yahoo when lease acquisition consumes the retry budget', async () => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
       vi.useFakeTimers();
       const start = new Date('2026-05-11T18:15:00Z');
       vi.setSystemTime(start);
@@ -1184,6 +1207,18 @@ describe('yahoo-connect-handlers', () => {
         expect(mockFetch).not.toHaveBeenCalled();
         expect(mockStorage.markRefreshCooldown).toHaveBeenCalledWith('user_123', expect.any(String), 300);
         expect(mockStorage.updateYahooCredentials).not.toHaveBeenCalled();
+        expect(yahooRefreshDiagnostics(logSpy)).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              event: 'refresh_request_exception',
+              correlation_id: 'req_acquire_budget',
+              phase: 'refresh_request',
+              outcome: 'lease_budget_exhausted',
+              diagnostic_class: 'lease_budget_exhausted',
+              lease_budget_remaining_ms: 0,
+            }),
+          ])
+        );
       } finally {
         vi.useRealTimers();
       }
@@ -1914,6 +1949,9 @@ describe('yahoo-connect-handlers', () => {
             expect.objectContaining({
               event: 'lease_wait_timeout',
               correlation_id: 'req_wait_timeout',
+              phase: 'waiter',
+              outcome: 'retryable_failure',
+              diagnostic_class: 'lease_wait_timeout',
               retry_after: 5,
             }),
           ])

--- a/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
@@ -422,12 +422,12 @@ describe('yahoo-connect-handlers', () => {
         platform: 'yahoo',
       });
 
-      mockFetch.mockResolvedValue(
+      mockFetch.mockImplementation(() => Promise.resolve(
         new Response('Too many requests to Yahoo token endpoint', {
           status: 400,
           headers: { 'Content-Type': 'text/plain' },
         })
-      );
+      ));
 
       const request = new Request('https://api.flaim.app/connect/yahoo/callback?code=auth_code&state=user_abc123:nonce');
 
@@ -573,6 +573,7 @@ describe('yahoo-connect-handlers', () => {
       const body = (await response.json()) as Record<string, unknown>;
       expect(body.error).toBe('refresh_failed');
       expect(body.error_description).toBe('Refresh token expired');
+      expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(mockStorage.updateYahooCredentials).not.toHaveBeenCalled();
       expect(mockStorage.markRefreshCooldown).not.toHaveBeenCalled();
       expect(mockStorage.releaseRefreshLease).toHaveBeenCalledWith('user_123', expect.any(String));
@@ -654,12 +655,12 @@ describe('yahoo-connect-handlers', () => {
         }
       );
 
-      mockFetch.mockResolvedValue(
+      mockFetch.mockImplementation(() => Promise.resolve(
         new Response('Too many requests to Yahoo token endpoint', {
           status: 400,
           headers: { 'Content-Type': 'text/plain' },
         })
-      );
+      ));
 
       const response = await handleYahooCredentials(env, 'user_123', corsHeaders);
 
@@ -670,6 +671,7 @@ describe('yahoo-connect-handlers', () => {
       expect(body.retryable).toBe(true);
       expect(body.retry_after).toBe(60);
       expect(response.headers.get('Retry-After')).toBe('60');
+      expect(mockFetch).toHaveBeenCalledTimes(2);
       expect(mockStorage.markRefreshCooldown).toHaveBeenCalledWith('user_123', capturedOwnerId, 60);
       expect(mockStorage.releaseRefreshLease).not.toHaveBeenCalled();
       expect(mockStorage.updateYahooCredentials).not.toHaveBeenCalled();
@@ -699,10 +701,11 @@ describe('yahoo-connect-handlers', () => {
       expect(body.error).toBe('refresh_failed');
       expect(body.error_description).toBe('Failed to refresh access token');
       expect(body.retryable).toBeUndefined();
+      expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(mockStorage.updateYahooCredentials).not.toHaveBeenCalled();
     });
 
-    it('does not treat mixed permanent and transient token response fields as retryable', async () => {
+    it('does not treat mixed permanent and transient token response fields as retryable even on HTTP 5xx', async () => {
       mockStorage.getYahooCredentials.mockResolvedValue({
         clerkUserId: 'user_123',
         accessToken: 'old-access-token',
@@ -718,7 +721,7 @@ describe('yahoo-connect-handlers', () => {
             error: 'temporarily_unavailable',
             error_description: 'Refresh token permanently revoked',
           }),
-          { status: 400 }
+          { status: 503 }
         )
       );
 
@@ -729,7 +732,9 @@ describe('yahoo-connect-handlers', () => {
       expect(body.error).toBe('refresh_failed');
       expect(body.error_description).toBe('Refresh token permanently revoked');
       expect(body.retryable).toBeUndefined();
+      expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(mockStorage.updateYahooCredentials).not.toHaveBeenCalled();
+      expect(mockStorage.markRefreshCooldown).not.toHaveBeenCalled();
     });
 
     it('returns retryable 503 when Yahoo returns a transient refresh status', async () => {
@@ -742,7 +747,7 @@ describe('yahoo-connect-handlers', () => {
       });
       mockStorage.acquireRefreshLease.mockResolvedValue(true);
 
-      mockFetch.mockResolvedValue(
+      mockFetch.mockImplementation(() => Promise.resolve(
         new Response(
           JSON.stringify({
             error: 'temporarily_unavailable',
@@ -750,7 +755,7 @@ describe('yahoo-connect-handlers', () => {
           }),
           { status: 503 }
         )
-      );
+      ));
 
       const response = await handleYahooCredentials(env, 'user_123', corsHeaders);
 
@@ -761,6 +766,7 @@ describe('yahoo-connect-handlers', () => {
       expect(body.retryable).toBe(true);
       expect(body.retry_after).toBe(300);
       expect(body.upstream_status).toBe(503);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
       expect(mockStorage.markRefreshCooldown).toHaveBeenCalledWith('user_123', expect.any(String), 300);
       expect(mockStorage.updateYahooCredentials).not.toHaveBeenCalled();
     });
@@ -795,6 +801,7 @@ describe('yahoo-connect-handlers', () => {
       expect(body.retryable).toBe(true);
       expect(body.retry_after).toBe(900);
       expect(body.upstream_status).toBe(429);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(mockStorage.markRefreshCooldown).toHaveBeenCalledWith('user_123', expect.any(String), 900);
       expect(mockStorage.updateYahooCredentials).not.toHaveBeenCalled();
 
@@ -822,6 +829,40 @@ describe('yahoo-connect-handlers', () => {
       const serialized = JSON.stringify(diagnostics);
       expect(serialized).not.toContain('old-access-token');
       expect(serialized).not.toContain('refresh-token');
+    });
+
+    it('returns retryable 503 without owner retry when Yahoo returns HTTP 999 during refresh', async () => {
+      mockStorage.getYahooCredentials.mockResolvedValue({
+        clerkUserId: 'user_123',
+        accessToken: 'old-access-token',
+        refreshToken: 'refresh-token',
+        expiresAt: new Date(Date.now() + 2 * 60 * 1000),
+        needsRefresh: true,
+      });
+      mockStorage.acquireRefreshLease.mockResolvedValue(true);
+
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 999,
+        headers: new Headers(),
+        text: vi.fn().mockResolvedValue(JSON.stringify({
+          error: 'rate_limited',
+          error_description: 'Yahoo token endpoint returned 999',
+        })),
+      } as unknown as Response);
+
+      const response = await handleYahooCredentials(env, 'user_123', corsHeaders, 'req_999');
+
+      expect(response.status).toBe(503);
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.error).toBe('refresh_temporarily_unavailable');
+      expect(body.error_description).toBe('Yahoo token endpoint returned 999');
+      expect(body.retryable).toBe(true);
+      expect(body.retry_after).toBe(900);
+      expect(body.upstream_status).toBe(999);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockStorage.markRefreshCooldown).toHaveBeenCalledWith('user_123', expect.any(String), 900);
+      expect(mockStorage.updateYahooCredentials).not.toHaveBeenCalled();
     });
 
     it('uses newer stored credentials when a concurrent refresh already succeeded', async () => {
@@ -888,6 +929,140 @@ describe('yahoo-connect-handlers', () => {
       expect(body.access_token).toBe('winner-token');
       expect(mockStorage.acquireRefreshLease).toHaveBeenCalledTimes(1);
       expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('winner: retries one transient Yahoo refresh response before marking cooldown', async () => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+      vi.useFakeTimers();
+
+      mockStorage.getYahooCredentials.mockResolvedValue({
+        clerkUserId: 'user_123',
+        accessToken: 'old-access-token',
+        refreshToken: 'refresh-token',
+        expiresAt: new Date(Date.now() + 2 * 60 * 1000),
+        needsRefresh: true,
+      });
+      mockStorage.acquireRefreshLease.mockResolvedValue(true);
+      mockStorage.updateYahooCredentials.mockResolvedValue(true);
+      mockFetch
+        .mockResolvedValueOnce(
+          new Response('Yahoo token endpoint is temporarily unavailable', {
+            status: 400,
+            headers: { 'Content-Type': 'text/plain' },
+          })
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({ access_token: 'retry-winner-token', refresh_token: 'new-refresh', expires_in: 3600 }),
+            { status: 200 }
+          )
+        );
+
+      try {
+        const responsePromise = handleYahooCredentials(env, 'user_123', corsHeaders, 'req_retry_success');
+        await vi.advanceTimersByTimeAsync(251);
+        const response = await responsePromise;
+
+        expect(response.status).toBe(200);
+        const body = (await response.json()) as Record<string, unknown>;
+        expect(body.access_token).toBe('retry-winner-token');
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+        expect(mockStorage.markRefreshCooldown).not.toHaveBeenCalled();
+        expect(mockStorage.updateYahooCredentials).toHaveBeenCalledWith(
+          'user_123',
+          expect.objectContaining({ accessToken: 'retry-winner-token', refreshToken: 'new-refresh' }),
+          expect.any(String)
+        );
+        expect(yahooRefreshDiagnostics(logSpy)).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              event: 'refresh_owner_retry_scheduled',
+              correlation_id: 'req_retry_success',
+              retry_attempt: 1,
+              retry_delay_ms: 250,
+              failure_kind: 'transient_text',
+            }),
+            expect.objectContaining({
+              event: 'credential_update_succeeded',
+              correlation_id: 'req_retry_success',
+            }),
+          ])
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('winner: does not retry a transient refresh response when the lease budget is too tight', async () => {
+      vi.useFakeTimers();
+      const start = new Date('2026-05-11T18:15:00Z');
+      vi.setSystemTime(start);
+
+      try {
+        mockStorage.getYahooCredentials.mockResolvedValue({
+          clerkUserId: 'user_123',
+          accessToken: 'old-access-token',
+          refreshToken: 'refresh-token',
+          expiresAt: new Date(Date.now() + 2 * 60 * 1000),
+          needsRefresh: true,
+        });
+        mockStorage.acquireRefreshLease.mockResolvedValue(true);
+        mockFetch.mockImplementation(() => {
+          vi.setSystemTime(new Date(start.getTime() + 28_800));
+          return Promise.resolve(
+            new Response('Yahoo token endpoint is temporarily unavailable', {
+              status: 400,
+              headers: { 'Content-Type': 'text/plain' },
+            })
+          );
+        });
+
+        const response = await handleYahooCredentials(env, 'user_123', corsHeaders, 'req_budget_tight');
+
+        expect(response.status).toBe(503);
+        const body = (await response.json()) as Record<string, unknown>;
+        expect(body.error).toBe('refresh_temporarily_unavailable');
+        expect(body.retryable).toBe(true);
+        expect(body.retry_after).toBe(60);
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        expect(mockStorage.markRefreshCooldown).toHaveBeenCalledWith('user_123', expect.any(String), 60);
+        expect(mockStorage.updateYahooCredentials).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('winner: marks cooldown without calling Yahoo when lease acquisition consumes the retry budget', async () => {
+      vi.useFakeTimers();
+      const start = new Date('2026-05-11T18:15:00Z');
+      vi.setSystemTime(start);
+
+      try {
+        mockStorage.getYahooCredentials.mockResolvedValue({
+          clerkUserId: 'user_123',
+          accessToken: 'old-access-token',
+          refreshToken: 'refresh-token',
+          expiresAt: new Date(Date.now() + 2 * 60 * 1000),
+          needsRefresh: true,
+        });
+        mockStorage.acquireRefreshLease.mockImplementation(() => {
+          vi.setSystemTime(new Date(start.getTime() + 29_100));
+          return Promise.resolve(true);
+        });
+
+        const response = await handleYahooCredentials(env, 'user_123', corsHeaders, 'req_acquire_budget');
+
+        expect(response.status).toBe(503);
+        const body = (await response.json()) as Record<string, unknown>;
+        expect(body.error).toBe('refresh_temporarily_unavailable');
+        expect(body.retryable).toBe(true);
+        expect(body.retry_after).toBe(300);
+        expect(mockFetch).not.toHaveBeenCalled();
+        expect(mockStorage.markRefreshCooldown).toHaveBeenCalledWith('user_123', expect.any(String), 300);
+        expect(mockStorage.updateYahooCredentials).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('winner: Yahoo timeout (AbortError) marks cooldown and returns retryable temporary error', async () => {
@@ -1661,12 +1836,12 @@ describe('yahoo-connect-handlers', () => {
         needsRefresh: true,
       });
       mockStorage.acquireRefreshLease.mockResolvedValue(true);
-      mockFetch.mockResolvedValue(
+      mockFetch.mockImplementation(() => Promise.resolve(
         new Response('Too many requests to Yahoo token endpoint', {
           status: 400,
           headers: { 'Content-Type': 'text/plain' },
         })
-      );
+      ));
 
       const response = await handleYahooDiscover(env, 'user_123', corsHeaders, 'req_discover');
 
@@ -1676,6 +1851,7 @@ describe('yahoo-connect-handlers', () => {
       expect(body.error_description).toBe('Failed to refresh access token');
       expect(body.retryable).toBe(true);
       expect(body.retry_after).toBe(60);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
       expect(mockStorage.markRefreshCooldown).toHaveBeenCalledWith('user_123', expect.any(String), 60);
       expect(mockStorage.updateYahooCredentials).not.toHaveBeenCalled();
       expect(mockStorage.upsertYahooLeague).not.toHaveBeenCalled();

--- a/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
@@ -993,6 +993,63 @@ describe('yahoo-connect-handlers', () => {
       }
     });
 
+    it('winner: retries one non-abort Yahoo refresh fetch exception before marking cooldown', async () => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+      vi.useFakeTimers();
+
+      mockStorage.getYahooCredentials.mockResolvedValue({
+        clerkUserId: 'user_123',
+        accessToken: 'old-access-token',
+        refreshToken: 'refresh-token',
+        expiresAt: new Date(Date.now() + 2 * 60 * 1000),
+        needsRefresh: true,
+      });
+      mockStorage.acquireRefreshLease.mockResolvedValue(true);
+      mockStorage.updateYahooCredentials.mockResolvedValue(true);
+      mockFetch
+        .mockRejectedValueOnce(new Error('Yahoo network blip'))
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({ access_token: 'retry-after-fetch-error', refresh_token: 'new-refresh', expires_in: 3600 }),
+            { status: 200 }
+          )
+        );
+
+      try {
+        const responsePromise = handleYahooCredentials(env, 'user_123', corsHeaders, 'req_retry_fetch_error');
+        await vi.advanceTimersByTimeAsync(251);
+        const response = await responsePromise;
+
+        expect(response.status).toBe(200);
+        const body = (await response.json()) as Record<string, unknown>;
+        expect(body.access_token).toBe('retry-after-fetch-error');
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+        expect(mockStorage.markRefreshCooldown).not.toHaveBeenCalled();
+        expect(mockStorage.updateYahooCredentials).toHaveBeenCalledWith(
+          'user_123',
+          expect.objectContaining({ accessToken: 'retry-after-fetch-error', refreshToken: 'new-refresh' }),
+          expect.any(String)
+        );
+        expect(yahooRefreshDiagnostics(logSpy)).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              event: 'refresh_owner_retry_scheduled',
+              correlation_id: 'req_retry_fetch_error',
+              reason: 'fetch_error',
+              retry_attempt: 1,
+              retry_delay_ms: 250,
+            }),
+            expect.objectContaining({
+              event: 'credential_update_succeeded',
+              correlation_id: 'req_retry_fetch_error',
+            }),
+          ])
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('winner: does not retry a transient refresh response when the lease budget is too tight', async () => {
       vi.useFakeTimers();
       const start = new Date('2026-05-11T18:15:00Z');

--- a/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
@@ -737,7 +737,7 @@ describe('yahoo-connect-handlers', () => {
       expect(mockStorage.markRefreshCooldown).not.toHaveBeenCalled();
     });
 
-    it('returns retryable 503 when Yahoo returns a transient refresh status', async () => {
+    it('retries one transient refresh HTTP 5xx, then marks cooldown on the second transient failure', async () => {
       mockStorage.getYahooCredentials.mockResolvedValue({
         clerkUserId: 'user_123',
         accessToken: 'old-access-token',
@@ -767,6 +767,7 @@ describe('yahoo-connect-handlers', () => {
       expect(body.retry_after).toBe(300);
       expect(body.upstream_status).toBe(503);
       expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockStorage.markRefreshCooldown).toHaveBeenCalledTimes(1);
       expect(mockStorage.markRefreshCooldown).toHaveBeenCalledWith('user_123', expect.any(String), 300);
       expect(mockStorage.updateYahooCredentials).not.toHaveBeenCalled();
     });

--- a/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
@@ -993,6 +993,72 @@ describe('yahoo-connect-handlers', () => {
       }
     });
 
+    it('winner: retries one transient Yahoo refresh HTTP 5xx before marking cooldown', async () => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+      vi.useFakeTimers();
+
+      mockStorage.getYahooCredentials.mockResolvedValue({
+        clerkUserId: 'user_123',
+        accessToken: 'old-access-token',
+        refreshToken: 'refresh-token',
+        expiresAt: new Date(Date.now() + 2 * 60 * 1000),
+        needsRefresh: true,
+      });
+      mockStorage.acquireRefreshLease.mockResolvedValue(true);
+      mockStorage.updateYahooCredentials.mockResolvedValue(true);
+      mockFetch
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              error: 'temporarily_unavailable',
+              error_description: 'Try again later',
+            }),
+            { status: 503 }
+          )
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({ access_token: 'retry-after-503-token', refresh_token: 'new-refresh', expires_in: 3600 }),
+            { status: 200 }
+          )
+        );
+
+      try {
+        const responsePromise = handleYahooCredentials(env, 'user_123', corsHeaders, 'req_retry_503_success');
+        await vi.advanceTimersByTimeAsync(251);
+        const response = await responsePromise;
+
+        expect(response.status).toBe(200);
+        const body = (await response.json()) as Record<string, unknown>;
+        expect(body.access_token).toBe('retry-after-503-token');
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+        expect(mockStorage.markRefreshCooldown).not.toHaveBeenCalled();
+        expect(mockStorage.updateYahooCredentials).toHaveBeenCalledWith(
+          'user_123',
+          expect.objectContaining({ accessToken: 'retry-after-503-token', refreshToken: 'new-refresh' }),
+          expect.any(String)
+        );
+        expect(yahooRefreshDiagnostics(logSpy)).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              event: 'refresh_owner_retry_scheduled',
+              correlation_id: 'req_retry_503_success',
+              retry_attempt: 1,
+              retry_delay_ms: 250,
+              upstream_status: 503,
+              failure_kind: 'transient_http',
+            }),
+            expect.objectContaining({
+              event: 'credential_update_succeeded',
+              correlation_id: 'req_retry_503_success',
+            }),
+          ])
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('winner: retries one non-abort Yahoo refresh fetch exception before marking cooldown', async () => {
       const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
       vi.useFakeTimers();

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -75,16 +75,53 @@ type YahooTokenFailureDiagnosticKind =
   | 'transient_text'
   | 'permanent'
   | 'unexpected';
+type YahooRefreshDiagnosticPhase =
+  | 'lease'
+  | 'refresh_request'
+  | 'refresh_response'
+  | 'cooldown'
+  | 'credential_update'
+  | 'waiter';
+type YahooRefreshDiagnosticOutcome =
+  | 'attempt_started'
+  | 'success'
+  | 'retry_scheduled'
+  | 'retryable_failure'
+  | 'permanent_failure'
+  | 'rate_limited'
+  | 'timeout'
+  | 'fetch_error'
+  | 'cooldown_active'
+  | 'cooldown_marked'
+  | 'lease_budget_exhausted';
+type YahooRefreshDiagnosticClass =
+  | 'yahoo_rate_limit'
+  | 'yahoo_transient_http'
+  | 'yahoo_transient_text'
+  | 'yahoo_permanent'
+  | 'yahoo_unexpected_response'
+  | 'fetch_error'
+  | 'timeout'
+  | 'cooldown_active'
+  | 'cooldown_mark'
+  | 'cooldown_mark_failed'
+  | 'lease_wait_timeout'
+  | 'lease_budget_exhausted';
 
 interface YahooRefreshDiagnosticFields {
   correlationId?: string;
   userId?: string;
   attempt?: number;
+  phase?: YahooRefreshDiagnosticPhase;
+  outcome?: YahooRefreshDiagnosticOutcome;
+  diagnosticClass?: YahooRefreshDiagnosticClass;
   reason?: string;
   refreshState?: YahooCredentialRefreshState;
   accessTokenExpiresInSeconds?: number;
   accessTokenLifetimeSeconds?: number;
   leaseRemainingSeconds?: number;
+  leaseBudgetRemainingMs?: number;
+  requestTimeoutMs?: number;
   retryAfter?: number;
   upstreamStatus?: number;
   tokenError?: string;
@@ -218,11 +255,16 @@ function logYahooRefreshDiagnostic(event: string, fields: YahooRefreshDiagnostic
   if (fields.userId) payload.user_id = maskUserId(fields.userId);
   if (fields.correlationId) payload.correlation_id = fields.correlationId;
   if (fields.attempt !== undefined) payload.attempt = fields.attempt;
+  if (fields.phase !== undefined) payload.phase = fields.phase;
+  if (fields.outcome !== undefined) payload.outcome = fields.outcome;
+  if (fields.diagnosticClass !== undefined) payload.diagnostic_class = fields.diagnosticClass;
   if (fields.reason !== undefined) payload.reason = fields.reason;
   if (fields.refreshState !== undefined) payload.refresh_state = fields.refreshState;
   if (fields.accessTokenExpiresInSeconds !== undefined) payload.access_token_expires_in_seconds = fields.accessTokenExpiresInSeconds;
   if (fields.accessTokenLifetimeSeconds !== undefined) payload.access_token_lifetime_seconds = fields.accessTokenLifetimeSeconds;
   if (fields.leaseRemainingSeconds !== undefined) payload.lease_remaining_seconds = fields.leaseRemainingSeconds;
+  if (fields.leaseBudgetRemainingMs !== undefined) payload.lease_budget_remaining_ms = fields.leaseBudgetRemainingMs;
+  if (fields.requestTimeoutMs !== undefined) payload.request_timeout_ms = fields.requestTimeoutMs;
   if (fields.retryAfter !== undefined) payload.retry_after = fields.retryAfter;
   if (fields.upstreamStatus !== undefined) payload.upstream_status = fields.upstreamStatus;
   if (fields.tokenError !== undefined) payload.token_error = fields.tokenError;
@@ -469,6 +511,9 @@ function yahooRefreshCooldownResult(credentials: YahooCredentials, correlationId
   logYahooRefreshDiagnostic('active_cooldown_returned', {
     correlationId,
     userId: credentials.clerkUserId,
+    phase: 'cooldown',
+    outcome: 'cooldown_active',
+    diagnosticClass: 'cooldown_active',
     retryAfter,
     leaseRemainingSeconds,
     refreshState: yahooRefreshState(credentials),
@@ -508,10 +553,53 @@ function shouldOwnerRetryYahooTokenResult(
     || (failureKind === 'transient_http' && typeof status === 'number' && status >= 500);
 }
 
+function yahooTokenFailureDiagnosticClass(
+  result: Pick<YahooTokenResponse, 'status'>,
+  failureKind: YahooTokenFailureDiagnosticKind
+): YahooRefreshDiagnosticClass {
+  if (isYahooRateLimitStatus(result.status)) {
+    return 'yahoo_rate_limit';
+  }
+
+  if (failureKind === 'transient_http') {
+    return 'yahoo_transient_http';
+  }
+
+  if (failureKind === 'transient_text') {
+    return 'yahoo_transient_text';
+  }
+
+  if (failureKind === 'permanent') {
+    return 'yahoo_permanent';
+  }
+
+  return 'yahoo_unexpected_response';
+}
+
+function yahooTokenFailureOutcome(
+  result: Pick<YahooTokenResponse, 'status'>,
+  failureKind: YahooTokenFailureDiagnosticKind
+): YahooRefreshDiagnosticOutcome {
+  if (isYahooRateLimitStatus(result.status)) {
+    return 'rate_limited';
+  }
+
+  return failureKind === 'permanent' || failureKind === 'unexpected'
+    ? 'permanent_failure'
+    : 'retryable_failure';
+}
+
+function ownerRetryBudgetRemainingMs(leaseDeadlineMs: number, delayMs = 0): number {
+  return Math.max(
+    0,
+    leaseDeadlineMs - Date.now() - delayMs - YAHOO_OWNER_RETRY_LEASE_SAFETY_MS
+  );
+}
+
 function ownerRetryTimeoutBudgetMs(leaseDeadlineMs: number, delayMs = 0): number {
   return Math.min(
     YAHOO_TOKEN_REQUEST_TIMEOUT_MS,
-    leaseDeadlineMs - Date.now() - delayMs - YAHOO_OWNER_RETRY_LEASE_SAFETY_MS
+    ownerRetryBudgetRemainingMs(leaseDeadlineMs, delayMs)
   );
 }
 
@@ -535,6 +623,9 @@ async function markYahooRefreshCooldown(
     logYahooRefreshDiagnostic('cooldown_mark_attempted', {
       correlationId,
       userId,
+      phase: 'cooldown',
+      outcome: 'cooldown_marked',
+      diagnosticClass: 'cooldown_mark',
       retryAfter: retryAfterSeconds,
       cooldownMarked: marked,
     });
@@ -545,6 +636,9 @@ async function markYahooRefreshCooldown(
     logYahooRefreshDiagnostic('cooldown_mark_failed', {
       correlationId,
       userId,
+      phase: 'cooldown',
+      outcome: 'retryable_failure',
+      diagnosticClass: 'cooldown_mark_failed',
       retryAfter: retryAfterSeconds,
       reason: 'storage_error',
     });
@@ -576,6 +670,9 @@ async function waitForFreshCredentialsOrLeaseClear(
       logYahooRefreshDiagnostic('lease_wait_timeout', {
         correlationId,
         userId,
+        phase: 'waiter',
+        outcome: 'retryable_failure',
+        diagnosticClass: 'lease_wait_timeout',
         retryAfter: YAHOO_REFRESH_IN_PROGRESS_RETRY_AFTER_SECONDS,
         refreshState: yahooRefreshState(latest),
         leaseRemainingSeconds: boundedPositiveSecondsUntil(latest.refreshLeaseExpiresAt),
@@ -749,7 +846,11 @@ async function getValidYahooAccessToken(
           userId,
           attempt,
           retryAttempt,
+          phase: 'refresh_request',
+          outcome: 'lease_budget_exhausted',
+          diagnosticClass: 'lease_budget_exhausted',
           reason: 'lease_budget_exhausted',
+          leaseBudgetRemainingMs: ownerRetryBudgetRemainingMs(leaseDeadlineMs),
           retryAfter: YAHOO_DEFAULT_TRANSIENT_RETRY_AFTER_SECONDS,
         });
         await markYahooRefreshCooldown(
@@ -770,7 +871,15 @@ async function getValidYahooAccessToken(
       const requestTimeoutMs = ownerRetryTimeoutBudgetMs(leaseDeadlineMs);
       const timer = setTimeout(() => controller.abort(), requestTimeoutMs);
       try {
-        logDiagnostic('refresh_request_started', { userId, attempt, retryAttempt });
+        logDiagnostic('refresh_request_started', {
+          userId,
+          attempt,
+          retryAttempt,
+          phase: 'refresh_request',
+          outcome: 'attempt_started',
+          requestTimeoutMs,
+          leaseBudgetRemainingMs: ownerRetryBudgetRemainingMs(leaseDeadlineMs),
+        });
         result = await refreshAccessToken(credentials.refreshToken, env, controller.signal);
       } catch (error) {
         clearTimeout(timer);
@@ -780,9 +889,13 @@ async function getValidYahooAccessToken(
           logDiagnostic('refresh_owner_retry_scheduled', {
             userId,
             attempt,
+            phase: 'refresh_request',
+            outcome: 'retry_scheduled',
+            diagnosticClass: 'fetch_error',
             reason: 'fetch_error',
             retryAttempt: nextRetryAttempt,
             retryDelayMs: YAHOO_OWNER_RETRY_DELAY_MS,
+            leaseBudgetRemainingMs: ownerRetryBudgetRemainingMs(leaseDeadlineMs, YAHOO_OWNER_RETRY_DELAY_MS),
           });
           retryAttempt = nextRetryAttempt;
           await sleep(YAHOO_OWNER_RETRY_DELAY_MS);
@@ -793,7 +906,12 @@ async function getValidYahooAccessToken(
           userId,
           attempt,
           retryAttempt,
+          phase: 'refresh_request',
+          outcome: isAbort ? 'timeout' : 'fetch_error',
+          diagnosticClass: isAbort ? 'timeout' : 'fetch_error',
           reason: isAbort ? 'abort' : 'fetch_error',
+          requestTimeoutMs,
+          leaseBudgetRemainingMs: ownerRetryBudgetRemainingMs(leaseDeadlineMs),
           retryAfter: YAHOO_DEFAULT_TRANSIENT_RETRY_AFTER_SECONDS,
         });
         console.error(
@@ -823,11 +941,16 @@ async function getValidYahooAccessToken(
       }
 
       const failureKind = classifyYahooTokenFailure(result);
+      const diagnosticClass = yahooTokenFailureDiagnosticClass(result, failureKind);
+      const diagnosticOutcome = yahooTokenFailureOutcome(result, failureKind);
       const statusSuffix = result.status ? ` (HTTP ${result.status})` : '';
       logDiagnostic('refresh_response_error', {
         userId,
         attempt,
         retryAttempt,
+        phase: 'refresh_response',
+        outcome: diagnosticOutcome,
+        diagnosticClass,
         upstreamStatus: result.status,
         tokenError: result.error,
         failureKind,
@@ -864,8 +987,12 @@ async function getValidYahooAccessToken(
           logDiagnostic('refresh_owner_retry_scheduled', {
             userId,
             attempt,
+            phase: 'refresh_response',
+            outcome: 'retry_scheduled',
+            diagnosticClass,
             retryAttempt: nextRetryAttempt,
             retryDelayMs: YAHOO_OWNER_RETRY_DELAY_MS,
+            leaseBudgetRemainingMs: ownerRetryBudgetRemainingMs(leaseDeadlineMs, YAHOO_OWNER_RETRY_DELAY_MS),
             upstreamStatus: result.status,
             tokenError: result.error,
             failureKind,
@@ -880,6 +1007,9 @@ async function getValidYahooAccessToken(
           userId,
           attempt,
           retryAttempt,
+          phase: 'refresh_response',
+          outcome: diagnosticOutcome,
+          diagnosticClass,
           retryAfter,
         });
         await markYahooRefreshCooldown(storage, userId, ownerId, retryAfter, correlationId);
@@ -900,6 +1030,9 @@ async function getValidYahooAccessToken(
         userId,
         attempt,
         retryAttempt,
+        phase: 'refresh_response',
+        outcome: diagnosticOutcome,
+        diagnosticClass,
         upstreamStatus: result.status,
         tokenError: result.error,
         failureKind,
@@ -947,6 +1080,8 @@ async function getValidYahooAccessToken(
       logDiagnostic('credential_update_succeeded', {
         userId,
         attempt,
+        phase: 'credential_update',
+        outcome: 'success',
         accessTokenLifetimeSeconds: result.expires_in,
       });
       console.log(`[yahoo-connect] Token refreshed for user ${maskUserId(userId)}`);

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -491,18 +491,19 @@ function isAbortError(error: unknown): boolean {
   return error instanceof Error && error.name === 'AbortError';
 }
 
-function isNonRateLimitYahooServerError(status?: number): boolean {
-  return typeof status === 'number' && status >= 500 && !isYahooRateLimitStatus(status);
-}
-
 function shouldOwnerRetryYahooTokenResult(
   result: Pick<YahooTokenResponse, 'status' | 'error' | 'error_description' | 'upstream_error_text'>,
   failureKind: YahooTokenFailureDiagnosticKind
 ): boolean {
-  if (isYahooRateLimitStatus(result.status)) {
+  const status = result.status;
+  if (isYahooRateLimitStatus(status)) {
     return false;
   }
-  return failureKind === 'transient_text' || isNonRateLimitYahooServerError(result.status);
+
+  // This intentionally mirrors the current Yahoo transient-status classifier:
+  // non-rate-limit transient HTTP failures are server-side 5xx responses.
+  return failureKind === 'transient_text'
+    || (failureKind === 'transient_http' && typeof status === 'number' && status >= 500);
 }
 
 function ownerRetryTimeoutBudgetMs(leaseDeadlineMs: number, delayMs = 0): number {
@@ -773,14 +774,15 @@ async function getValidYahooAccessToken(
         clearTimeout(timer);
         const isAbort = isAbortError(error);
         if (!isAbort && retryAttempt === 0 && canScheduleOwnerRetry(leaseDeadlineMs)) {
+          const nextRetryAttempt = retryAttempt + 1;
           logDiagnostic('refresh_owner_retry_scheduled', {
             userId,
             attempt,
             reason: 'fetch_error',
-            retryAttempt: retryAttempt + 1,
+            retryAttempt: nextRetryAttempt,
             retryDelayMs: YAHOO_OWNER_RETRY_DELAY_MS,
           });
-          retryAttempt += 1;
+          retryAttempt = nextRetryAttempt;
           await sleep(YAHOO_OWNER_RETRY_DELAY_MS);
           continue;
         }
@@ -856,16 +858,17 @@ async function getValidYahooAccessToken(
           && shouldOwnerRetryYahooTokenResult(result, failureKind)
           && canScheduleOwnerRetry(leaseDeadlineMs)
         ) {
+          const nextRetryAttempt = retryAttempt + 1;
           logDiagnostic('refresh_owner_retry_scheduled', {
             userId,
             attempt,
-            retryAttempt: retryAttempt + 1,
+            retryAttempt: nextRetryAttempt,
             retryDelayMs: YAHOO_OWNER_RETRY_DELAY_MS,
             upstreamStatus: result.status,
             tokenError: result.error,
             failureKind,
           });
-          retryAttempt += 1;
+          retryAttempt = nextRetryAttempt;
           await sleep(YAHOO_OWNER_RETRY_DELAY_MS);
           continue;
         }
@@ -906,6 +909,8 @@ async function getValidYahooAccessToken(
       };
     }
 
+    // The loop only breaks after a defined non-error result; this guard keeps
+    // TypeScript and future refactors honest without changing runtime behavior.
     if (!result) {
       logDiagnostic('refresh_invalid_response', { userId, attempt });
       return { error: 'refresh_failed', errorDescription: 'Failed to refresh access token' };

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -502,6 +502,8 @@ function shouldOwnerRetryYahooTokenResult(
 
   // This intentionally mirrors the current Yahoo transient-status classifier:
   // non-rate-limit transient HTTP failures are server-side 5xx responses.
+  // Transient text is separate because Yahoo can send plain-text "Too many
+  // token requests" as HTTP 400 even when the refresh token is still usable.
   return failureKind === 'transient_text'
     || (failureKind === 'transient_http' && typeof status === 'number' && status >= 500);
 }
@@ -913,7 +915,7 @@ async function getValidYahooAccessToken(
     // TypeScript and future refactors honest without changing runtime behavior.
     if (!result) {
       logDiagnostic('refresh_invalid_response', { userId, attempt, retryAttempt });
-      return { error: 'refresh_failed', errorDescription: 'Failed to refresh access token' };
+      throw new Error('Invariant violation: Yahoo refresh result missing after success loop');
     }
 
     if (!hasUsableTokenFields(result)) {

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -24,6 +24,7 @@ import {
   YAHOO_REFRESH_IN_PROGRESS_RETRY_AFTER_SECONDS,
   classifyYahooApiFailure,
   defaultYahooRetryAfterSeconds,
+  isYahooRateLimitStatus,
   isYahooTransientHttpStatus,
   parseRetryAfterSeconds,
   YahooAuthWorkerErrorCode,
@@ -92,6 +93,8 @@ interface YahooRefreshDiagnosticFields {
   hasRetryAfter?: boolean;
   hasUpstreamErrorText?: boolean;
   cooldownMarked?: boolean;
+  retryDelayMs?: number;
+  retryAttempt?: number;
 }
 
 // Internal annotation from the Yahoo token endpoint parser. This is consumed by
@@ -120,6 +123,8 @@ const REFRESH_COOLDOWN_OWNER_PREFIX = 'cooldown:';
 // Plain-text "too many token requests" deserves a short pause; network
 // timeouts use the longer generic Yahoo transient cooldown.
 const YAHOO_TOKEN_TEXT_TRANSIENT_RETRY_AFTER_SECONDS = 60;
+const YAHOO_OWNER_RETRY_DELAY_MS = 250;
+const YAHOO_OWNER_RETRY_LEASE_SAFETY_MS = 1_000;
 
 /**
  * Get the OAuth callback URL based on environment
@@ -226,6 +231,8 @@ function logYahooRefreshDiagnostic(event: string, fields: YahooRefreshDiagnostic
   if (fields.hasRetryAfter !== undefined) payload.has_retry_after = fields.hasRetryAfter;
   if (fields.hasUpstreamErrorText !== undefined) payload.has_upstream_error_text = fields.hasUpstreamErrorText;
   if (fields.cooldownMarked !== undefined) payload.cooldown_marked = fields.cooldownMarked;
+  if (fields.retryDelayMs !== undefined) payload.retry_delay_ms = fields.retryDelayMs;
+  if (fields.retryAttempt !== undefined) payload.retry_attempt = fields.retryAttempt;
 
   console.log(JSON.stringify(payload));
 }
@@ -308,14 +315,14 @@ function hasTransientYahooTokenFailureSignal(text: string): boolean {
 function classifyYahooTokenFailure(
   response: Pick<YahooTokenResponse, 'status' | 'error' | 'error_description' | 'upstream_error_text'>
 ): YahooTokenFailureDiagnosticKind {
-  if (isTransientYahooTokenError(response.status)) {
-    return 'transient_http';
-  }
-
   const text = normalizeYahooTokenErrorText(response);
   // Permanent signals win over transient-looking text so revoked/expired tokens still trigger reconnect.
   if (hasPermanentYahooTokenFailureSignal(text)) {
     return 'permanent';
+  }
+
+  if (isTransientYahooTokenError(response.status)) {
+    return 'transient_http';
   }
 
   // After permanent signals are ruled out, allow token-endpoint text matching on any error status.
@@ -480,6 +487,39 @@ function retryAfterForTransientYahooTokenFailure(response: Pick<YahooTokenRespon
     ?? YAHOO_TOKEN_TEXT_TRANSIENT_RETRY_AFTER_SECONDS;
 }
 
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
+}
+
+function isNonRateLimitYahooServerError(status?: number): boolean {
+  return typeof status === 'number' && status >= 500 && !isYahooRateLimitStatus(status);
+}
+
+function shouldOwnerRetryYahooTokenResult(
+  result: Pick<YahooTokenResponse, 'status' | 'error' | 'error_description' | 'upstream_error_text'>,
+  failureKind: YahooTokenFailureDiagnosticKind
+): boolean {
+  if (isYahooRateLimitStatus(result.status)) {
+    return false;
+  }
+  return failureKind === 'transient_text' || isNonRateLimitYahooServerError(result.status);
+}
+
+function ownerRetryTimeoutBudgetMs(leaseDeadlineMs: number, delayMs = 0): number {
+  return Math.min(
+    YAHOO_TOKEN_REQUEST_TIMEOUT_MS,
+    leaseDeadlineMs - Date.now() - delayMs - YAHOO_OWNER_RETRY_LEASE_SAFETY_MS
+  );
+}
+
+function canScheduleOwnerRetry(leaseDeadlineMs: number): boolean {
+  return ownerRetryTimeoutBudgetMs(leaseDeadlineMs, YAHOO_OWNER_RETRY_DELAY_MS) > 0;
+}
+
+function hasOwnerRequestBudget(leaseDeadlineMs: number): boolean {
+  return ownerRetryTimeoutBudgetMs(leaseDeadlineMs) > 0;
+}
+
 async function markYahooRefreshCooldown(
   storage: YahooStorage,
   userId: string,
@@ -636,6 +676,7 @@ async function getValidYahooAccessToken(
       accessTokenExpiresInSeconds: secondsUntil(credentials.expiresAt),
       refreshState: yahooRefreshState(credentials),
     });
+    const leaseAttemptStartedAt = Date.now();
     const won = await storage.acquireRefreshLease(
       userId,
       ownerId,
@@ -695,49 +736,94 @@ async function getValidYahooAccessToken(
       attempt,
       accessTokenExpiresInSeconds: secondsUntil(credentials.expiresAt),
     });
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), YAHOO_TOKEN_REQUEST_TIMEOUT_MS);
-    let result: YahooTokenDiagnosticResponse;
-    try {
-      logDiagnostic('refresh_request_started', { userId, attempt });
-      result = await refreshAccessToken(credentials.refreshToken, env, controller.signal);
-    } catch (error) {
-      clearTimeout(timer);
-      const isAbort = error instanceof Error && error.name === 'AbortError';
-      logDiagnostic('refresh_request_exception', {
-        userId,
-        attempt,
-        reason: isAbort ? 'abort' : 'fetch_error',
-        retryAfter: YAHOO_DEFAULT_TRANSIENT_RETRY_AFTER_SECONDS,
-      });
-      console.error(
-        `[yahoo-connect] Yahoo token refresh request failed for user ${maskUserId(userId)}:`,
-        error instanceof Error ? error.message : error
-      );
-      await markYahooRefreshCooldown(
-        storage,
-        userId,
-        ownerId,
-        YAHOO_DEFAULT_TRANSIENT_RETRY_AFTER_SECONDS,
-        correlationId
-      );
-      return {
-        error: YahooAuthWorkerErrorCode.REFRESH_TEMPORARILY_UNAVAILABLE,
-        errorDescription: isAbort
-          ? 'Yahoo token refresh timed out. Please try again later.'
-          : 'Yahoo token refresh is temporarily unavailable. Please try again later.',
-        retryable: true,
-        retryAfter: YAHOO_DEFAULT_TRANSIENT_RETRY_AFTER_SECONDS,
-      };
-    }
-    clearTimeout(timer);
+    const leaseDeadlineMs = leaseAttemptStartedAt + LEASE_TTL_MS;
+    let result: YahooTokenDiagnosticResponse | undefined;
+    let retryAttempt = 0;
 
-    if (result.error) {
+    while (true) {
+      if (!hasOwnerRequestBudget(leaseDeadlineMs)) {
+        logDiagnostic('refresh_request_exception', {
+          userId,
+          attempt,
+          retryAttempt,
+          reason: 'lease_budget_exhausted',
+          retryAfter: YAHOO_DEFAULT_TRANSIENT_RETRY_AFTER_SECONDS,
+        });
+        await markYahooRefreshCooldown(
+          storage,
+          userId,
+          ownerId,
+          YAHOO_DEFAULT_TRANSIENT_RETRY_AFTER_SECONDS,
+          correlationId
+        );
+        return {
+          error: YahooAuthWorkerErrorCode.REFRESH_TEMPORARILY_UNAVAILABLE,
+          errorDescription: 'Yahoo token refresh is temporarily unavailable. Please try again later.',
+          retryable: true,
+          retryAfter: YAHOO_DEFAULT_TRANSIENT_RETRY_AFTER_SECONDS,
+        };
+      }
+      const controller = new AbortController();
+      const requestTimeoutMs = ownerRetryTimeoutBudgetMs(leaseDeadlineMs);
+      const timer = setTimeout(() => controller.abort(), requestTimeoutMs);
+      try {
+        logDiagnostic('refresh_request_started', { userId, attempt, retryAttempt });
+        result = await refreshAccessToken(credentials.refreshToken, env, controller.signal);
+      } catch (error) {
+        clearTimeout(timer);
+        const isAbort = isAbortError(error);
+        if (!isAbort && retryAttempt === 0 && canScheduleOwnerRetry(leaseDeadlineMs)) {
+          logDiagnostic('refresh_owner_retry_scheduled', {
+            userId,
+            attempt,
+            reason: 'fetch_error',
+            retryAttempt: retryAttempt + 1,
+            retryDelayMs: YAHOO_OWNER_RETRY_DELAY_MS,
+          });
+          retryAttempt += 1;
+          await sleep(YAHOO_OWNER_RETRY_DELAY_MS);
+          continue;
+        }
+
+        logDiagnostic('refresh_request_exception', {
+          userId,
+          attempt,
+          retryAttempt,
+          reason: isAbort ? 'abort' : 'fetch_error',
+          retryAfter: YAHOO_DEFAULT_TRANSIENT_RETRY_AFTER_SECONDS,
+        });
+        console.error(
+          `[yahoo-connect] Yahoo token refresh request failed for user ${maskUserId(userId)}:`,
+          error instanceof Error ? error.message : error
+        );
+        await markYahooRefreshCooldown(
+          storage,
+          userId,
+          ownerId,
+          YAHOO_DEFAULT_TRANSIENT_RETRY_AFTER_SECONDS,
+          correlationId
+        );
+        return {
+          error: YahooAuthWorkerErrorCode.REFRESH_TEMPORARILY_UNAVAILABLE,
+          errorDescription: isAbort
+            ? 'Yahoo token refresh timed out. Please try again later.'
+            : 'Yahoo token refresh is temporarily unavailable. Please try again later.',
+          retryable: true,
+          retryAfter: YAHOO_DEFAULT_TRANSIENT_RETRY_AFTER_SECONDS,
+        };
+      }
+      clearTimeout(timer);
+
+      if (!result.error) {
+        break;
+      }
+
       const failureKind = classifyYahooTokenFailure(result);
       const statusSuffix = result.status ? ` (HTTP ${result.status})` : '';
       logDiagnostic('refresh_response_error', {
         userId,
         attempt,
+        retryAttempt,
         upstreamStatus: result.status,
         tokenError: result.error,
         failureKind,
@@ -765,10 +851,30 @@ async function getValidYahooAccessToken(
         return toTokenResult(latest);
       }
       if (failureKind === 'transient_http' || failureKind === 'transient_text') {
+        if (
+          retryAttempt === 0
+          && shouldOwnerRetryYahooTokenResult(result, failureKind)
+          && canScheduleOwnerRetry(leaseDeadlineMs)
+        ) {
+          logDiagnostic('refresh_owner_retry_scheduled', {
+            userId,
+            attempt,
+            retryAttempt: retryAttempt + 1,
+            retryDelayMs: YAHOO_OWNER_RETRY_DELAY_MS,
+            upstreamStatus: result.status,
+            tokenError: result.error,
+            failureKind,
+          });
+          retryAttempt += 1;
+          await sleep(YAHOO_OWNER_RETRY_DELAY_MS);
+          continue;
+        }
+
         const retryAfter = retryAfterForTransientYahooTokenFailure(result);
         logDiagnostic('refresh_transient_failure', {
           userId,
           attempt,
+          retryAttempt,
           retryAfter,
         });
         await markYahooRefreshCooldown(storage, userId, ownerId, retryAfter, correlationId);
@@ -788,6 +894,7 @@ async function getValidYahooAccessToken(
       logDiagnostic('refresh_permanent_failure', {
         userId,
         attempt,
+        retryAttempt,
         upstreamStatus: result.status,
         tokenError: result.error,
         failureKind,
@@ -799,10 +906,16 @@ async function getValidYahooAccessToken(
       };
     }
 
+    if (!result) {
+      logDiagnostic('refresh_invalid_response', { userId, attempt });
+      return { error: 'refresh_failed', errorDescription: 'Failed to refresh access token' };
+    }
+
     if (!hasUsableTokenFields(result)) {
       logDiagnostic('refresh_invalid_response', {
         userId,
         attempt,
+        retryAttempt,
         upstreamStatus: result.status,
         bodyClass: result.upstream_body_class,
         hasRetryAfter: result.retry_after !== undefined,

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -160,6 +160,7 @@ const REFRESH_COOLDOWN_OWNER_PREFIX = 'cooldown:';
 // Plain-text "too many token requests" deserves a short pause; network
 // timeouts use the longer generic Yahoo transient cooldown.
 const YAHOO_TOKEN_TEXT_TRANSIENT_RETRY_AFTER_SECONDS = 60;
+const YAHOO_OWNER_MAX_RETRIES = 1;
 const YAHOO_OWNER_RETRY_DELAY_MS = 250;
 const YAHOO_OWNER_RETRY_LEASE_SAFETY_MS = 1_000;
 
@@ -776,6 +777,8 @@ async function getValidYahooAccessToken(
       accessTokenExpiresInSeconds: secondsUntil(credentials.expiresAt),
       refreshState: yahooRefreshState(credentials),
     });
+    // Include lease acquisition time in the owner budget so slow storage never
+    // leaves the refresh request racing the actual DB lease expiry.
     const leaseAttemptStartedAt = Date.now();
     const won = await storage.acquireRefreshLease(
       userId,
@@ -884,7 +887,7 @@ async function getValidYahooAccessToken(
       } catch (error) {
         clearTimeout(timer);
         const isAbort = isAbortError(error);
-        if (!isAbort && retryAttempt === 0 && canScheduleOwnerRetry(leaseDeadlineMs)) {
+        if (!isAbort && retryAttempt < YAHOO_OWNER_MAX_RETRIES && canScheduleOwnerRetry(leaseDeadlineMs)) {
           const nextRetryAttempt = retryAttempt + 1;
           logDiagnostic('refresh_owner_retry_scheduled', {
             userId,
@@ -979,7 +982,7 @@ async function getValidYahooAccessToken(
       }
       if (failureKind === 'transient_http' || failureKind === 'transient_text') {
         if (
-          retryAttempt === 0
+          retryAttempt < YAHOO_OWNER_MAX_RETRIES
           && shouldOwnerRetryYahooTokenResult(result, failureKind)
           && canScheduleOwnerRetry(leaseDeadlineMs)
         ) {

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -912,7 +912,7 @@ async function getValidYahooAccessToken(
     // The loop only breaks after a defined non-error result; this guard keeps
     // TypeScript and future refactors honest without changing runtime behavior.
     if (!result) {
-      logDiagnostic('refresh_invalid_response', { userId, attempt });
+      logDiagnostic('refresh_invalid_response', { userId, attempt, retryAttempt });
       return { error: 'refresh_failed', errorDescription: 'Failed to refresh access token' };
     }
 

--- a/workers/auth-worker/wrangler.jsonc
+++ b/workers/auth-worker/wrangler.jsonc
@@ -17,7 +17,7 @@
   // - YAHOO_CLIENT_ID      (Yahoo Developer App)
   // - YAHOO_CLIENT_SECRET  (Yahoo Developer App)
   // Optional vars:
-  // - OAUTH_REFRESH_TOKEN_TTL_SECONDS (defaults to 7776000 in code; set only to override)
+  // - OAUTH_REFRESH_TOKEN_TTL_SECONDS (defaults to 31536000 in code; set only to override)
 
   // Environment configurations
   "env": {


### PR DESCRIPTION
## Summary
- Give the Yahoo refresh lease owner one short retry for retryable non-rate-limit token-endpoint failures before setting cooldown.
- Keep permanent refresh-token failures and explicit Yahoo rate limits (429/999) on the no-retry path.
- Classify permanent token-failure signals before transient HTTP status so revoked/expired refresh tokens do not get hidden behind a temporary cooldown.
- Add non-secret structured Yahoo refresh diagnostics with phase/outcome/failure class, request timeout, lease budget, retry delay, and correlation fields.
- Bound retry timing to the original lease window and document the lazy-refresh behavior.

## Why
Yahoo access tokens are provider-controlled and expire hourly. The production symptom is that a single transient failure during the backend lazy refresh can put the connection into cooldown for all MCP calls. This keeps refresh backend-owned, avoids extra user/browser refresh pressure, and gives one guarded recovery attempt before surfacing retry metadata.

The diagnostic layer is intentionally logs-first: it improves incident triage without adding a schema migration, user-facing token state, or another persistence path in this reliability PR.

## Tests
- corepack pnpm --dir workers/auth-worker exec vitest run src/__tests__/yahoo-connect-handlers.test.ts
- corepack pnpm --dir workers/auth-worker run type-check
- corepack pnpm --dir workers/auth-worker run test
- git diff --check

Refs FLA-125.