### PR TITLE
[codex] Test Yahoo refresh without redirect URI

### DIFF
--- a/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
@@ -258,7 +258,11 @@ describe('yahoo-connect-handlers', () => {
 
       const request = new Request('https://api.flaim.app/connect/yahoo/callback?code=auth_code&state=user_abc123:nonce');
 
-      const response = await handleYahooCallback(request, env, corsHeaders);
+      const response = await handleYahooCallback(
+        request,
+        { ...env, YAHOO_REFRESH_GRANT_REDIRECT_URI: 'omit' },
+        corsHeaders
+      );
 
       expect(response.status).toBe(302);
       const location = response.headers.get('Location')!;
@@ -567,6 +571,55 @@ describe('yahoo-connect-handlers', () => {
           refreshToken: 'new-refresh-token',
         }),
         expect.any(String)
+      );
+    });
+
+    it('omits redirect_uri from refresh grant when experiment flag is enabled', async () => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+      mockStorage.getYahooCredentials.mockResolvedValue({
+        clerkUserId: 'user_123',
+        accessToken: 'old-access-token',
+        refreshToken: 'refresh-token',
+        expiresAt: new Date(Date.now() + 2 * 60 * 1000),
+        needsRefresh: true,
+      });
+
+      mockFetch.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            access_token: 'new-access-token',
+            refresh_token: 'new-refresh-token',
+            expires_in: 3600,
+          }),
+          { status: 200 }
+        )
+      );
+
+      const response = await handleYahooCredentials(
+        { ...env, YAHOO_REFRESH_GRANT_REDIRECT_URI: 'omit' },
+        'user_123',
+        corsHeaders,
+        'req_omit_redirect'
+      );
+
+      expect(response.status).toBe(200);
+
+      const refreshRequest = mockFetch.mock.calls[0][1] as RequestInit;
+      const refreshBody = new URLSearchParams(refreshRequest.body as string);
+      expect(refreshBody.get('grant_type')).toBe('refresh_token');
+      expect(refreshBody.get('refresh_token')).toBe('refresh-token');
+      expect(refreshBody.has('redirect_uri')).toBe(false);
+
+      expect(yahooRefreshDiagnostics(logSpy)).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            event: 'refresh_request_started',
+            correlation_id: 'req_omit_redirect',
+            token_grant_type: 'refresh_token',
+            request_has_redirect_uri: false,
+            callback_url: 'https://api.flaim.app/auth/connect/yahoo/callback',
+          }),
+        ])
       );
     });
 

--- a/workers/auth-worker/src/index-hono.ts
+++ b/workers/auth-worker/src/index-hono.ts
@@ -88,6 +88,7 @@ export interface Env {
   // Yahoo OAuth
   YAHOO_CLIENT_ID?: string;
   YAHOO_CLIENT_SECRET?: string;
+  YAHOO_REFRESH_GRANT_REDIRECT_URI?: 'include' | 'omit';
   // Eval/CI API key auth (Cloudflare secrets)
   EVAL_API_KEY?: string;   // Static API key for eval/CI
   EVAL_USER_ID?: string;   // Clerk user ID that the API key resolves to

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -41,6 +41,7 @@ export interface YahooConnectEnv {
   SUPABASE_SERVICE_KEY: string;
   YAHOO_CLIENT_ID: string;
   YAHOO_CLIENT_SECRET: string;
+  YAHOO_REFRESH_GRANT_REDIRECT_URI?: 'include' | 'omit';
   ENVIRONMENT?: string;
   NODE_ENV?: string;
   FRONTEND_URL?: string;
@@ -617,11 +618,16 @@ function yahooAuthorizationCodeTokenBody(code: string, env: YahooConnectEnv): UR
 }
 
 function yahooRefreshTokenBody(refreshToken: string, env: YahooConnectEnv): URLSearchParams {
-  return new URLSearchParams({
+  const body = new URLSearchParams({
     grant_type: 'refresh_token',
-    redirect_uri: getCallbackUrl(env),
     refresh_token: refreshToken,
   });
+
+  if (env.YAHOO_REFRESH_GRANT_REDIRECT_URI !== 'omit') {
+    body.set('redirect_uri', getCallbackUrl(env));
+  }
+
+  return body;
 }
 
 function isAbortError(error: unknown): boolean {

--- a/workers/auth-worker/wrangler.jsonc
+++ b/workers/auth-worker/wrangler.jsonc
@@ -18,6 +18,7 @@
   // - YAHOO_CLIENT_SECRET  (Yahoo Developer App)
   // Optional vars:
   // - OAUTH_REFRESH_TOKEN_TTL_SECONDS (defaults to 31536000 in code; set only to override)
+  // - YAHOO_REFRESH_GRANT_REDIRECT_URI ("include" by default; "omit" to test Yahoo refresh compatibility)
 
   // Environment configurations
   "env": {
@@ -75,7 +76,8 @@
       "vars": {
         "NODE_ENV": "production",
         "ENVIRONMENT": "prod",
-        "FRONTEND_URL": "https://flaim.app"
+        "FRONTEND_URL": "https://flaim.app",
+        "YAHOO_REFRESH_GRANT_REDIRECT_URI": "omit"
       }
     },
     // Preview environment (remote dev/staging)
@@ -112,7 +114,8 @@
       "vars": {
         "NODE_ENV": "production",
         "ENVIRONMENT": "preview",
-        "FRONTEND_URL": "https://preview.flaim.app"
+        "FRONTEND_URL": "https://preview.flaim.app",
+        "YAHOO_REFRESH_GRANT_REDIRECT_URI": "omit"
       }
     },
     // Development environment (local)


### PR DESCRIPTION
## Summary
- add a Yahoo refresh-token grant switch that keeps redirect_uri included by default but allows omitting it with YAHOO_REFRESH_GRANT_REDIRECT_URI=omit
- set auth-worker prod and preview Wrangler vars to omit redirect_uri so the next deploy actively tests the refresh regression hypothesis
- keep authorization-code token exchange pinned to include redirect_uri and add refresh tests/diagnostics for omit mode

## Why
Yahoo docs include redirect_uri on refresh-token exchanges, but RFC 6749 does not require it. The April 24 hardening change that added redirect_uri is the only recent change that altered the Yahoo refresh request body, and live diagnostics show the failing request currently has request_has_redirect_uri=true. This PR makes the hypothesis reversible and observable.

## Validation
- corepack pnpm --dir workers/auth-worker exec vitest run src/__tests__/yahoo-connect-handlers.test.ts
- corepack pnpm --dir workers/auth-worker run type-check
- git diff --check

## Rollback
Remove the YAHOO_REFRESH_GRANT_REDIRECT_URI=omit vars or set them to include to return to Yahoo-documented refresh request shape without changing code.