### PR TITLE
[codex] Disable Yahoo refresh cooldown for diagnostics

### DIFF
--- a/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
@@ -1583,6 +1583,13 @@ describe('yahoo-connect-handlers', () => {
               lease_remaining_seconds: 45,
             }),
             expect.objectContaining({
+              event: 'cooldown_bypass_release_failed',
+              correlation_id: 'req_bypass_cooldown',
+              diagnostic_class: 'cooldown_disabled',
+              reason: 'release_failed',
+              cooldown_mode: 'disabled',
+            }),
+            expect.objectContaining({
               event: 'refresh_request_started',
               correlation_id: 'req_bypass_cooldown',
             }),

--- a/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
@@ -781,6 +781,51 @@ describe('yahoo-connect-handlers', () => {
       );
     });
 
+    it('releases the lease instead of marking cooldown when cooldown mode is disabled', async () => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+      mockStorage.getYahooCredentials.mockResolvedValue({
+        clerkUserId: 'user_123',
+        accessToken: 'old-access-token',
+        refreshToken: 'refresh-token',
+        expiresAt: new Date(Date.now() + 2 * 60 * 1000),
+        needsRefresh: true,
+      });
+
+      let capturedOwnerId: string | undefined;
+      mockStorage.acquireRefreshLease.mockImplementation(
+        (_userId: string, ownerId: string) => {
+          capturedOwnerId = ownerId;
+          return Promise.resolve(true);
+        }
+      );
+      mockFetch.mockImplementation(() => Promise.resolve(new Response('Too many requests to Yahoo token endpoint', {
+          status: 400,
+          headers: { 'Content-Type': 'text/plain' },
+        })));
+
+      const response = await handleYahooCredentials(
+        { ...env, YAHOO_REFRESH_COOLDOWN_MODE: 'disabled' },
+        'user_123',
+        corsHeaders,
+        'req_no_cooldown'
+      );
+
+      expect(response.status).toBe(503);
+      expect(mockStorage.markRefreshCooldown).not.toHaveBeenCalled();
+      expect(mockStorage.releaseRefreshLease).toHaveBeenCalledWith('user_123', capturedOwnerId);
+      expect(yahooRefreshDiagnostics(logSpy)).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            event: 'cooldown_mark_skipped',
+            correlation_id: 'req_no_cooldown',
+            outcome: 'cooldown_bypassed',
+            diagnostic_class: 'cooldown_disabled',
+            reason: 'disabled',
+          }),
+        ])
+      );
+    });
+
     it('does not treat permanent token failures as retryable just because the body says too many', async () => {
       mockStorage.getYahooCredentials.mockResolvedValue({
         clerkUserId: 'user_123',
@@ -1468,6 +1513,66 @@ describe('yahoo-connect-handlers', () => {
         expect(mockStorage.acquireRefreshLease).not.toHaveBeenCalled();
         expect(mockFetch).not.toHaveBeenCalled();
         expect(mockStorage.markRefreshCooldown).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('bypasses active refresh cooldown and attempts refresh when cooldown mode is disabled', async () => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-05-11T18:15:00Z'));
+      try {
+        mockStorage.getYahooCredentials.mockResolvedValue({
+          clerkUserId: 'user_123',
+          accessToken: 'old-access-token',
+          refreshToken: 'refresh-token',
+          expiresAt: new Date(Date.now() + 2 * 60 * 1000),
+          needsRefresh: true,
+          refreshLeaseOwner: 'cooldown:owner-1',
+          refreshLeaseExpiresAt: new Date(Date.now() + 45_000),
+        });
+        mockFetch.mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              access_token: 'new-access-token',
+              refresh_token: 'new-refresh-token',
+              expires_in: 3600,
+            }),
+            { status: 200 }
+          )
+        );
+
+        const response = await handleYahooCredentials(
+          { ...env, YAHOO_REFRESH_COOLDOWN_MODE: 'disabled' },
+          'user_123',
+          corsHeaders,
+          'req_bypass_cooldown'
+        );
+
+        expect(response.status).toBe(200);
+        const body = (await response.json()) as Record<string, unknown>;
+        expect(body.access_token).toBe('new-access-token');
+        expect(mockStorage.releaseRefreshLease).toHaveBeenCalledWith('user_123', 'cooldown:owner-1');
+        expect(mockStorage.acquireRefreshLease).toHaveBeenCalledWith('user_123', expect.any(String), 30_000, 'refresh-token');
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        expect(mockStorage.markRefreshCooldown).not.toHaveBeenCalled();
+        expect(yahooRefreshDiagnostics(logSpy)).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              event: 'cooldown_bypassed',
+              correlation_id: 'req_bypass_cooldown',
+              outcome: 'cooldown_bypassed',
+              diagnostic_class: 'cooldown_disabled',
+              refresh_state: 'cooldown',
+              lease_remaining_seconds: 45,
+            }),
+            expect.objectContaining({
+              event: 'refresh_request_started',
+              correlation_id: 'req_bypass_cooldown',
+            }),
+          ])
+        );
       } finally {
         vi.useRealTimers();
       }

--- a/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
@@ -1549,6 +1549,7 @@ describe('yahoo-connect-handlers', () => {
             { status: 200 }
           )
         );
+        mockStorage.releaseRefreshLease.mockRejectedValueOnce(new Error('release failed'));
 
         const response = await handleYahooCredentials(
           { ...env, YAHOO_REFRESH_COOLDOWN_MODE: 'disabled' },

--- a/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
@@ -802,6 +802,7 @@ describe('yahoo-connect-handlers', () => {
           status: 400,
           headers: { 'Content-Type': 'text/plain' },
         })));
+      mockStorage.releaseRefreshLease.mockRejectedValueOnce(new Error('release failed'));
 
       const response = await handleYahooCredentials(
         { ...env, YAHOO_REFRESH_COOLDOWN_MODE: 'disabled' },
@@ -828,6 +829,13 @@ describe('yahoo-connect-handlers', () => {
             outcome: 'cooldown_bypassed',
             diagnostic_class: 'cooldown_disabled',
             reason: 'disabled',
+          }),
+          expect.objectContaining({
+            event: 'cooldown_mark_skipped_release_failed',
+            correlation_id: 'req_no_cooldown',
+            diagnostic_class: 'cooldown_disabled',
+            reason: 'release_failed',
+            cooldown_mode: 'disabled',
           }),
         ])
       );

--- a/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
@@ -816,6 +816,13 @@ describe('yahoo-connect-handlers', () => {
       expect(yahooRefreshDiagnostics(logSpy)).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
+            event: 'cooldown_mode_disabled',
+            correlation_id: 'req_no_cooldown',
+            diagnostic_class: 'cooldown_disabled',
+            reason: 'env_disabled',
+            cooldown_mode: 'disabled',
+          }),
+          expect.objectContaining({
             event: 'cooldown_mark_skipped',
             correlation_id: 'req_no_cooldown',
             outcome: 'cooldown_bypassed',
@@ -1559,6 +1566,13 @@ describe('yahoo-connect-handlers', () => {
         expect(mockStorage.markRefreshCooldown).not.toHaveBeenCalled();
         expect(yahooRefreshDiagnostics(logSpy)).toEqual(
           expect.arrayContaining([
+            expect.objectContaining({
+              event: 'cooldown_mode_disabled',
+              correlation_id: 'req_bypass_cooldown',
+              diagnostic_class: 'cooldown_disabled',
+              reason: 'env_disabled',
+              cooldown_mode: 'disabled',
+            }),
             expect.objectContaining({
               event: 'cooldown_bypassed',
               correlation_id: 'req_bypass_cooldown',

--- a/workers/auth-worker/src/index-hono.ts
+++ b/workers/auth-worker/src/index-hono.ts
@@ -89,6 +89,7 @@ export interface Env {
   YAHOO_CLIENT_ID?: string;
   YAHOO_CLIENT_SECRET?: string;
   YAHOO_REFRESH_GRANT_REDIRECT_URI?: 'include' | 'omit';
+  YAHOO_REFRESH_COOLDOWN_MODE?: 'enabled' | 'disabled';
   // Eval/CI API key auth (Cloudflare secrets)
   EVAL_API_KEY?: string;   // Static API key for eval/CI
   EVAL_USER_ID?: string;   // Clerk user ID that the API key resolves to

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -761,7 +761,11 @@ async function markYahooRefreshCooldown(
       retryAfter: retryAfterSeconds,
       reason: 'disabled',
     });
-    await storage.releaseRefreshLease(userId, ownerId);
+    try {
+      await storage.releaseRefreshLease(userId, ownerId);
+    } catch (releaseError) {
+      console.warn('[yahoo-connect] Failed to release Yahoo refresh lease when cooldown disabled:', releaseError);
+    }
     return;
   }
 

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -152,6 +152,7 @@ interface YahooRefreshDiagnosticFields {
   requestHasRedirectUri?: boolean;
   yahooClientIdPresent?: boolean;
   yahooClientSecretPresent?: boolean;
+  cooldownMode?: 'enabled' | 'disabled';
   authType?: string;
 }
 
@@ -306,6 +307,7 @@ function logYahooRefreshDiagnostic(event: string, fields: YahooRefreshDiagnostic
   if (fields.requestHasRedirectUri !== undefined) payload.request_has_redirect_uri = fields.requestHasRedirectUri;
   if (fields.yahooClientIdPresent !== undefined) payload.yahoo_client_id_present = fields.yahooClientIdPresent;
   if (fields.yahooClientSecretPresent !== undefined) payload.yahoo_client_secret_present = fields.yahooClientSecretPresent;
+  if (fields.cooldownMode !== undefined) payload.cooldown_mode = fields.cooldownMode;
   if (fields.authType !== undefined) payload.auth_type = fields.authType;
 
   console.log(JSON.stringify(payload));
@@ -912,6 +914,17 @@ async function getValidYahooAccessToken(
     return { error: 'not_connected' };
   }
 
+  const cooldownEnabled = yahooRefreshCooldownEnabled(env);
+  if (!cooldownEnabled) {
+    logDiagnostic('cooldown_mode_disabled', {
+      userId,
+      phase: 'cooldown',
+      diagnosticClass: 'cooldown_disabled',
+      reason: 'env_disabled',
+      cooldownMode: 'disabled',
+    });
+  }
+
   for (let attempt = 0; attempt < MAX_REFRESH_ATTEMPTS; attempt++) {
     if (!credentials.needsRefresh) {
       logDiagnostic('token_fresh_returned', {
@@ -923,7 +936,7 @@ async function getValidYahooAccessToken(
       return toTokenResult(credentials);
     }
     if (isRefreshCooldown(credentials)) {
-      if (yahooRefreshCooldownEnabled(env)) {
+      if (cooldownEnabled) {
         return yahooRefreshCooldownResult(credentials, correlationId);
       }
       credentials = await clearDisabledYahooRefreshCooldown(storage, credentials, correlationId);
@@ -967,7 +980,7 @@ async function getValidYahooAccessToken(
         return toTokenResult(latest);
       }
       if (isRefreshCooldown(latest)) {
-        if (yahooRefreshCooldownEnabled(env)) {
+        if (cooldownEnabled) {
           return yahooRefreshCooldownResult(latest, correlationId);
         }
         credentials = await clearDisabledYahooRefreshCooldown(storage, latest, correlationId);

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -42,6 +42,7 @@ export interface YahooConnectEnv {
   YAHOO_CLIENT_ID: string;
   YAHOO_CLIENT_SECRET: string;
   YAHOO_REFRESH_GRANT_REDIRECT_URI?: 'include' | 'omit';
+  YAHOO_REFRESH_COOLDOWN_MODE?: 'enabled' | 'disabled';
   ENVIRONMENT?: string;
   NODE_ENV?: string;
   FRONTEND_URL?: string;
@@ -98,6 +99,7 @@ type YahooRefreshDiagnosticOutcome =
   | 'fetch_error'
   | 'cooldown_active'
   | 'cooldown_marked'
+  | 'cooldown_bypassed'
   | 'lease_budget_exhausted';
 type YahooRefreshDiagnosticClass =
   | 'yahoo_rate_limit'
@@ -110,6 +112,7 @@ type YahooRefreshDiagnosticClass =
   | 'cooldown_active'
   | 'cooldown_mark'
   | 'cooldown_mark_failed'
+  | 'cooldown_disabled'
   | 'lease_wait_timeout'
   | 'lease_budget_exhausted';
 
@@ -540,6 +543,37 @@ function isRefreshCooldown(credentials: { refreshLeaseOwner?: string; refreshLea
     && !leaseExpired(credentials);
 }
 
+function yahooRefreshCooldownEnabled(env: YahooConnectEnv): boolean {
+  return env.YAHOO_REFRESH_COOLDOWN_MODE !== 'disabled';
+}
+
+async function clearDisabledYahooRefreshCooldown(
+  storage: YahooStorage,
+  credentials: YahooCredentials,
+  correlationId?: string
+): Promise<YahooCredentials> {
+  if (!credentials.refreshLeaseOwner?.startsWith(REFRESH_COOLDOWN_OWNER_PREFIX)) {
+    return credentials;
+  }
+
+  logYahooRefreshDiagnostic('cooldown_bypassed', {
+    correlationId,
+    userId: credentials.clerkUserId,
+    phase: 'cooldown',
+    outcome: 'cooldown_bypassed',
+    diagnosticClass: 'cooldown_disabled',
+    leaseRemainingSeconds: retryAfterFromLease(credentials),
+    refreshState: yahooRefreshState(credentials),
+  });
+
+  await storage.releaseRefreshLease(credentials.clerkUserId, credentials.refreshLeaseOwner);
+  return {
+    ...credentials,
+    refreshLeaseOwner: undefined,
+    refreshLeaseExpiresAt: undefined,
+  };
+}
+
 function retryAfterFromLease(credentials: { refreshLeaseExpiresAt?: Date } | null): number | undefined {
   return boundedPositiveSecondsUntil(credentials?.refreshLeaseExpiresAt);
 }
@@ -714,8 +748,23 @@ async function markYahooRefreshCooldown(
   userId: string,
   ownerId: string,
   retryAfterSeconds: number,
+  env: YahooConnectEnv,
   correlationId?: string
 ): Promise<void> {
+  if (!yahooRefreshCooldownEnabled(env)) {
+    logYahooRefreshDiagnostic('cooldown_mark_skipped', {
+      correlationId,
+      userId,
+      phase: 'cooldown',
+      outcome: 'cooldown_bypassed',
+      diagnosticClass: 'cooldown_disabled',
+      retryAfter: retryAfterSeconds,
+      reason: 'disabled',
+    });
+    await storage.releaseRefreshLease(userId, ownerId);
+    return;
+  }
+
   try {
     const marked = await storage.markRefreshCooldown(userId, ownerId, retryAfterSeconds);
     logYahooRefreshDiagnostic('cooldown_mark_attempted', {
@@ -752,6 +801,7 @@ async function markYahooRefreshCooldown(
 async function waitForFreshCredentialsOrLeaseClear(
   storage: YahooStorage,
   userId: string,
+  env: YahooConnectEnv,
   credentials: YahooCredentials,
   correlationId?: string
 ): Promise<RetryTokenResult> {
@@ -760,7 +810,11 @@ async function waitForFreshCredentialsOrLeaseClear(
 
   while (latest && !leaseExpired(latest)) {
     if (isRefreshCooldown(latest)) {
-      return yahooRefreshCooldownResult(latest, correlationId);
+      if (yahooRefreshCooldownEnabled(env)) {
+        return yahooRefreshCooldownResult(latest, correlationId);
+      }
+      latest = await clearDisabledYahooRefreshCooldown(storage, latest, correlationId);
+      return { retry: true, credentials: latest };
     }
 
     const remainingMs = deadline - Date.now();
@@ -865,7 +919,10 @@ async function getValidYahooAccessToken(
       return toTokenResult(credentials);
     }
     if (isRefreshCooldown(credentials)) {
-      return yahooRefreshCooldownResult(credentials, correlationId);
+      if (yahooRefreshCooldownEnabled(env)) {
+        return yahooRefreshCooldownResult(credentials, correlationId);
+      }
+      credentials = await clearDisabledYahooRefreshCooldown(storage, credentials, correlationId);
     }
 
     const ownerId = crypto.randomUUID();
@@ -906,7 +963,11 @@ async function getValidYahooAccessToken(
         return toTokenResult(latest);
       }
       if (isRefreshCooldown(latest)) {
-        return yahooRefreshCooldownResult(latest, correlationId);
+        if (yahooRefreshCooldownEnabled(env)) {
+          return yahooRefreshCooldownResult(latest, correlationId);
+        }
+        credentials = await clearDisabledYahooRefreshCooldown(storage, latest, correlationId);
+        continue;
       }
       if (leaseExpired(latest)) {
         logDiagnostic('lease_loss_found_expired_lease_retrying', {
@@ -921,6 +982,7 @@ async function getValidYahooAccessToken(
       const loserResult = await waitForFreshCredentialsOrLeaseClear(
         storage,
         userId,
+        env,
         latest,
         correlationId
       );
@@ -959,6 +1021,7 @@ async function getValidYahooAccessToken(
           userId,
           ownerId,
           YAHOO_DEFAULT_TRANSIENT_RETRY_AFTER_SECONDS,
+          env,
           correlationId
         );
         return {
@@ -1027,6 +1090,7 @@ async function getValidYahooAccessToken(
           userId,
           ownerId,
           YAHOO_DEFAULT_TRANSIENT_RETRY_AFTER_SECONDS,
+          env,
           correlationId
         );
         return {
@@ -1126,7 +1190,7 @@ async function getValidYahooAccessToken(
           bodyClass: result.upstream_body_class,
           hasUpstreamRetryAfter: result.retry_after_source === 'upstream_header',
         });
-        await markYahooRefreshCooldown(storage, userId, ownerId, retryAfter, correlationId);
+        await markYahooRefreshCooldown(storage, userId, ownerId, retryAfter, env, correlationId);
         return {
           error: YahooAuthWorkerErrorCode.REFRESH_TEMPORARILY_UNAVAILABLE,
           errorDescription: result.error_description || 'Yahoo token refresh is temporarily unavailable',

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -572,6 +572,15 @@ async function clearDisabledYahooRefreshCooldown(
     await storage.releaseRefreshLease(credentials.clerkUserId, credentials.refreshLeaseOwner);
   } catch (releaseError) {
     console.warn('[yahoo-connect] Failed to release active Yahoo refresh cooldown while cooldown mode disabled:', releaseError);
+    logYahooRefreshDiagnostic('cooldown_bypass_release_failed', {
+      correlationId,
+      userId: credentials.clerkUserId,
+      phase: 'cooldown',
+      outcome: 'cooldown_bypassed',
+      diagnosticClass: 'cooldown_disabled',
+      reason: 'release_failed',
+      cooldownMode: 'disabled',
+    });
   }
   return {
     ...credentials,
@@ -988,6 +997,15 @@ async function getValidYahooAccessToken(
           return yahooRefreshCooldownResult(latest, correlationId);
         }
         credentials = await clearDisabledYahooRefreshCooldown(storage, latest, correlationId);
+        logDiagnostic('cooldown_cleared_retrying', {
+          userId,
+          attempt,
+          phase: 'cooldown',
+          outcome: 'cooldown_bypassed',
+          diagnosticClass: 'cooldown_disabled',
+          refreshState: 'cooldown',
+          cooldownMode: 'disabled',
+        });
         continue;
       }
       if (leaseExpired(latest)) {

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -568,7 +568,11 @@ async function clearDisabledYahooRefreshCooldown(
     refreshState: yahooRefreshState(credentials),
   });
 
-  await storage.releaseRefreshLease(credentials.clerkUserId, credentials.refreshLeaseOwner);
+  try {
+    await storage.releaseRefreshLease(credentials.clerkUserId, credentials.refreshLeaseOwner);
+  } catch (releaseError) {
+    console.warn('[yahoo-connect] Failed to release active Yahoo refresh cooldown while cooldown mode disabled:', releaseError);
+  }
   return {
     ...credentials,
     refreshLeaseOwner: undefined,

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -780,6 +780,15 @@ async function markYahooRefreshCooldown(
       await storage.releaseRefreshLease(userId, ownerId);
     } catch (releaseError) {
       console.warn('[yahoo-connect] Failed to release Yahoo refresh lease when cooldown disabled:', releaseError);
+      logYahooRefreshDiagnostic('cooldown_mark_skipped_release_failed', {
+        correlationId,
+        userId,
+        phase: 'cooldown',
+        outcome: 'cooldown_bypassed',
+        diagnosticClass: 'cooldown_disabled',
+        reason: 'release_failed',
+        cooldownMode: 'disabled',
+      });
     }
     return;
   }

--- a/workers/auth-worker/wrangler.jsonc
+++ b/workers/auth-worker/wrangler.jsonc
@@ -78,6 +78,7 @@
         "NODE_ENV": "production",
         "ENVIRONMENT": "prod",
         "FRONTEND_URL": "https://flaim.app",
+        // Temporary Yahoo auth diagnostic mode. Track and revert through FLA-127.
         "YAHOO_REFRESH_GRANT_REDIRECT_URI": "omit",
         "YAHOO_REFRESH_COOLDOWN_MODE": "disabled"
       }
@@ -117,6 +118,7 @@
         "NODE_ENV": "production",
         "ENVIRONMENT": "preview",
         "FRONTEND_URL": "https://preview.flaim.app",
+        // Temporary Yahoo auth diagnostic mode. Track and revert through FLA-127.
         "YAHOO_REFRESH_GRANT_REDIRECT_URI": "omit",
         "YAHOO_REFRESH_COOLDOWN_MODE": "disabled"
       }

--- a/workers/auth-worker/wrangler.jsonc
+++ b/workers/auth-worker/wrangler.jsonc
@@ -78,7 +78,7 @@
         "NODE_ENV": "production",
         "ENVIRONMENT": "prod",
         "FRONTEND_URL": "https://flaim.app",
-        // Temporary Yahoo auth diagnostic mode. Track and revert through FLA-127.
+        // TODO(FLA-127): temporary Yahoo auth diagnostic mode; revert when resolved.
         "YAHOO_REFRESH_GRANT_REDIRECT_URI": "omit",
         "YAHOO_REFRESH_COOLDOWN_MODE": "disabled"
       }
@@ -118,7 +118,7 @@
         "NODE_ENV": "production",
         "ENVIRONMENT": "preview",
         "FRONTEND_URL": "https://preview.flaim.app",
-        // Temporary Yahoo auth diagnostic mode. Track and revert through FLA-127.
+        // TODO(FLA-127): temporary Yahoo auth diagnostic mode; revert when resolved.
         "YAHOO_REFRESH_GRANT_REDIRECT_URI": "omit",
         "YAHOO_REFRESH_COOLDOWN_MODE": "disabled"
       }

--- a/workers/auth-worker/wrangler.jsonc
+++ b/workers/auth-worker/wrangler.jsonc
@@ -19,6 +19,7 @@
   // Optional vars:
   // - OAUTH_REFRESH_TOKEN_TTL_SECONDS (defaults to 31536000 in code; set only to override)
   // - YAHOO_REFRESH_GRANT_REDIRECT_URI ("include" by default; "omit" to test Yahoo refresh compatibility)
+  // - YAHOO_REFRESH_COOLDOWN_MODE ("enabled" by default; "disabled" bypasses transient cooldown gates)
 
   // Environment configurations
   "env": {
@@ -77,7 +78,8 @@
         "NODE_ENV": "production",
         "ENVIRONMENT": "prod",
         "FRONTEND_URL": "https://flaim.app",
-        "YAHOO_REFRESH_GRANT_REDIRECT_URI": "omit"
+        "YAHOO_REFRESH_GRANT_REDIRECT_URI": "omit",
+        "YAHOO_REFRESH_COOLDOWN_MODE": "disabled"
       }
     },
     // Preview environment (remote dev/staging)
@@ -115,7 +117,8 @@
         "NODE_ENV": "production",
         "ENVIRONMENT": "preview",
         "FRONTEND_URL": "https://preview.flaim.app",
-        "YAHOO_REFRESH_GRANT_REDIRECT_URI": "omit"
+        "YAHOO_REFRESH_GRANT_REDIRECT_URI": "omit",
+        "YAHOO_REFRESH_COOLDOWN_MODE": "disabled"
       }
     },
     // Development environment (local)


### PR DESCRIPTION
## Summary
- add YAHOO_REFRESH_COOLDOWN_MODE so Yahoo refresh cooldowns can be bypassed without removing the single-flight refresh lease
- set prod and preview to disabled for the current Yahoo refresh debugging window
- when disabled, clear existing cooldown markers before attempting refresh and release the lease instead of writing a new cooldown after transient failures

## Why
We now believe the issue is not actual user-volume overload. The cooldown layer is making diagnosis harder by turning one failed refresh attempt into several minutes of active_cooldown_returned responses. This keeps the per-user lease protection while letting each manual test exercise the real Yahoo token endpoint.

## Validation
- corepack pnpm --dir workers/auth-worker exec vitest run src/__tests__/yahoo-connect-handlers.test.ts
- corepack pnpm --dir workers/auth-worker run type-check
- git diff --check

## Rollback
Set YAHOO_REFRESH_COOLDOWN_MODE back to enabled or remove the var to restore cooldown behavior.