### PR TITLE
[codex] Allow Clerk webhook through CSRF middleware

### DIFF
--- a/web/lib/__tests__/middleware.test.ts
+++ b/web/lib/__tests__/middleware.test.ts
@@ -1,0 +1,69 @@
+import { NextRequest } from "next/server";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@clerk/nextjs/server", () => ({
+  clerkMiddleware: vi.fn((handler) => handler),
+}));
+
+import { normalizePathname, shouldRejectForCsrf } from "../../middleware";
+
+function request(pathname: string, init?: ConstructorParameters<typeof NextRequest>[1]) {
+  return new NextRequest(`https://flaim.app${pathname}`, init);
+}
+
+describe("normalizePathname", () => {
+  it("removes trailing slashes without changing root", () => {
+    expect(normalizePathname("/api/webhooks/clerk/")).toBe("/api/webhooks/clerk");
+    expect(normalizePathname("/api/webhooks/clerk//")).toBe("/api/webhooks/clerk");
+    expect(normalizePathname("/")).toBe("/");
+  });
+});
+
+describe("shouldRejectForCsrf", () => {
+  it("allows Clerk webhooks without a browser origin", () => {
+    expect(shouldRejectForCsrf(request("/api/webhooks/clerk", { method: "POST" }))).toBe(false);
+    expect(shouldRejectForCsrf(request("/api/webhooks/clerk/", { method: "POST" }))).toBe(false);
+  });
+
+  it("allows safe methods without a browser origin", () => {
+    expect(shouldRejectForCsrf(request("/api/user/preferences", { method: "GET" }))).toBe(false);
+    expect(shouldRejectForCsrf(request("/api/webhooks/clerk", { method: "GET" }))).toBe(false);
+  });
+
+  it("rejects mutating API requests without an origin or auth header", () => {
+    expect(shouldRejectForCsrf(request("/api/user/preferences", { method: "POST" }))).toBe(true);
+  });
+
+  it("rejects non-Clerk webhook paths without a browser origin", () => {
+    expect(shouldRejectForCsrf(request("/api/webhooks/stripe", { method: "POST" }))).toBe(true);
+  });
+
+  it("allows mutating API requests from allowed origins", () => {
+    expect(shouldRejectForCsrf(request("/api/user/preferences", {
+      headers: { origin: "https://flaim.app" },
+      method: "POST",
+    }))).toBe(false);
+  });
+
+  it("rejects mutating API requests from disallowed origins", () => {
+    expect(shouldRejectForCsrf(request("/api/user/preferences", {
+      headers: { origin: "https://example.com" },
+      method: "POST",
+    }))).toBe(true);
+  });
+
+  it("allows mutating API requests with authorization headers", () => {
+    expect(shouldRejectForCsrf(request("/api/user/preferences", {
+      headers: { authorization: "Bearer token" },
+      method: "POST",
+    }))).toBe(false);
+  });
+
+  it("applies the same CSRF rule to tRPC routes", () => {
+    expect(shouldRejectForCsrf(request("/trpc/profile.update", { method: "POST" }))).toBe(true);
+    expect(shouldRejectForCsrf(request("/trpc/profile.update", {
+      headers: { origin: "https://flaim.app" },
+      method: "POST",
+    }))).toBe(false);
+  });
+});

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -3,6 +3,8 @@ import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 
 const CSRF_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+// Exact machine-to-machine endpoint paths exempted here must enforce their own request authentication.
+const CSRF_EXEMPT_PATHS = new Set(['/api/webhooks/clerk']);
 
 const ALLOWED_ORIGINS = [
   'https://flaim.app',
@@ -43,17 +45,36 @@ function getRequestOrigin(request: NextRequest): string | null {
   }
 }
 
-export default clerkMiddleware((_auth, request) => {
-  const { pathname } = request.nextUrl;
+export function normalizePathname(pathname: string): string {
+  if (pathname.length > 1) {
+    return pathname.replace(/\/+$/, '');
+  }
+  return pathname;
+}
 
-  if (pathname.startsWith('/api') && CSRF_METHODS.has(request.method)) {
-    const hasAuthHeader = Boolean(request.headers.get('authorization'));
-    if (!hasAuthHeader) {
-      const origin = getRequestOrigin(request);
-      if (!origin || !isOriginAllowed(origin)) {
-        return NextResponse.json({ error: 'Invalid origin' }, { status: 403 });
-      }
-    }
+export function shouldRejectForCsrf(request: NextRequest): boolean {
+  const pathname = normalizePathname(request.nextUrl.pathname);
+
+  if (
+    !(pathname.startsWith('/api') || pathname.startsWith('/trpc')) ||
+    !CSRF_METHODS.has(request.method) ||
+    CSRF_EXEMPT_PATHS.has(pathname)
+  ) {
+    return false;
+  }
+
+  const hasAuthHeader = Boolean(request.headers.get('authorization'));
+  if (hasAuthHeader) {
+    return false;
+  }
+
+  const origin = getRequestOrigin(request);
+  return !origin || !isOriginAllowed(origin);
+}
+
+export default clerkMiddleware((_auth, request) => {
+  if (shouldRejectForCsrf(request)) {
+    return NextResponse.json({ error: 'Invalid origin' }, { status: 403 });
   }
 
   return NextResponse.next();


### PR DESCRIPTION
## Summary
- Exempts the Clerk webhook endpoint from the browser-origin CSRF middleware check.
- Keeps the exemption scoped to /api/webhooks/clerk only, with pathname normalization for trailing slashes.
- Applies the existing CSRF guard consistently to both /api and /trpc mutating requests.
- Leaves Clerk/Svix signature verification in the webhook route as the endpoint protection.

## Root cause
Svix webhook tests were reaching https://flaim.app/api/webhooks/clerk but failing with 403 Invalid origin. The global middleware applied browser-origin CSRF enforcement to all unauthenticated POST /api/* requests, including machine-to-machine webhooks that do not send a browser Origin header.

## Validation
- corepack pnpm --dir web run lint
- corepack pnpm --dir web run test -- lib/__tests__/middleware.test.ts
- corepack pnpm --dir web run test -- lib/server/__tests__/resend-contact-sync.test.ts