### PR TITLE
[codex] Add Resend contact backfill tooling

### DIFF
--- a/docs/EMAILS.md
+++ b/docs/EMAILS.md
@@ -56,7 +56,19 @@ This package includes a server-only Resend send helper, but no user action shoul
 
 Clerk is the source of truth for user identity. Resend is the product email audience and delivery layer, not the canonical CRM. The Clerk webhook at `web/app/api/webhooks/clerk/route.ts` keeps Resend contacts lightly synchronized from `user.created` and `user.updated` events. The handler verifies Clerk's webhook signature with `CLERK_WEBHOOK_SIGNING_SECRET`, acknowledges verified Clerk events even if downstream Resend sync fails, and does nothing unless `RESEND_CONTACT_SYNC_ENABLED=true`.
 
-The contact sync stores only email, first name, last name, and minimal properties (`clerk_user_id`, latest Clerk event, and source). It intentionally does not resubscribe existing contacts during updates, so Resend unsubscribe state remains authoritative for product and broadcast email. If `RESEND_CONTACT_SEGMENT_ID` is set, new and updated contacts are assigned to that Resend Segment for future Broadcast targeting.
+The contact sync stores only email, first name, and last name. It intentionally does not resubscribe existing contacts during updates, so Resend unsubscribe state remains authoritative for product and broadcast email. If `RESEND_CONTACT_SEGMENT_ID` is set, new and updated contacts are assigned to that Resend Segment for future Broadcast targeting. Avoid writing custom Resend contact properties unless those properties have first been created in Resend.
+
+Existing users are backfilled with a separate dry-run-first script. Run it from the repo root:
+
+```sh
+corepack pnpm --dir web exec node scripts/backfill-resend-contacts.mjs
+```
+
+The script requires `CLERK_SECRET_KEY` for dry-runs and also requires `RESEND_CONTACTS_API_KEY` when applying writes. `RESEND_API_KEY` should remain the send-only email key; the contact sync key needs Resend Contacts and Segments permissions. The script skips users without a primary email and users whose primary email is explicitly unverified. To write a single controlled contact before a full backfill:
+
+```sh
+corepack pnpm --dir web exec node scripts/backfill-resend-contacts.mjs --apply --max-users 1
+```
 
 React Email's preview server may add lockfile entries for its own bundled Next.js version. Those entries are isolated to the preview tooling; the Flaim web app should continue to resolve the app-pinned Next.js version. Keep the React Email preview packages pinned to exact versions so preview tooling upgrades do not silently churn the lockfile.
 

--- a/docs/EMAILS.md
+++ b/docs/EMAILS.md
@@ -64,7 +64,7 @@ Existing users are backfilled with a separate dry-run-first script. Run it from 
 corepack pnpm --dir web exec node scripts/backfill-resend-contacts.mjs
 ```
 
-The script requires `CLERK_SECRET_KEY` for dry-runs and also requires `RESEND_CONTACTS_API_KEY` when applying writes. `RESEND_API_KEY` should remain the send-only email key; the contact sync key needs Resend Contacts and Segments permissions. The script skips users without a primary email and users whose primary email is explicitly unverified. To write a single controlled contact before a full backfill:
+The script requires `CLERK_SECRET_KEY` for dry-runs and also requires `RESEND_CONTACTS_API_KEY` when applying writes. `RESEND_API_KEY` should remain the send-only email key; the contact sync key needs Resend Contacts and Segments permissions. The script skips users without a primary email and users whose primary email is explicitly unverified. Use `--delay-ms` to pace larger writes if needed. To write a single controlled contact before a full backfill:
 
 ```sh
 corepack pnpm --dir web exec node scripts/backfill-resend-contacts.mjs --apply --max-users 1

--- a/web/app/api/webhooks/clerk/route.ts
+++ b/web/app/api/webhooks/clerk/route.ts
@@ -39,10 +39,7 @@ export async function POST(request: NextRequest) {
     });
   }
 
-  const result = await syncClerkUserToResendContact(
-    event.data,
-    event.type as "user.created" | "user.updated",
-  );
+  const result = await syncClerkUserToResendContact(event.data);
 
   if (!result.ok && !result.skipped) {
     console.error("Clerk to Resend contact sync failed:", result.error);

--- a/web/lib/server/__tests__/backfill-resend-contacts-script.test.ts
+++ b/web/lib/server/__tests__/backfill-resend-contacts-script.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getPrimaryEmail,
+  hasExplicitUnverifiedStatus,
+  maskEmail,
+  parseArgs,
+} from "../../../scripts/backfill-resend-contacts.mjs";
+
+describe("backfill-resend-contacts script helpers", () => {
+  it("defaults to dry-run mode", () => {
+    expect(parseArgs([])).toMatchObject({
+      apply: false,
+      delayMs: 0,
+      limit: 100,
+      offset: 0,
+    });
+  });
+
+  it("parses write pacing options", () => {
+    expect(parseArgs(["--apply", "--max-users", "5", "--delay-ms", "250"])).toMatchObject({
+      apply: true,
+      delayMs: 250,
+      maxUsers: 5,
+    });
+  });
+
+  it("masks email addresses in logs", () => {
+    expect(maskEmail("gerry@example.com")).toBe("ge***@example.com");
+  });
+
+  it("uses the only Clerk email when primary id is missing", () => {
+    expect(getPrimaryEmail({
+      email_addresses: [{ id: "only", email_address: "Only@Example.com" }],
+      primary_email_address_id: null,
+    })).toBe("only@example.com");
+  });
+
+  it("does not guess when multiple Clerk emails exist without a primary id", () => {
+    expect(getPrimaryEmail({
+      email_addresses: [
+        { id: "first", email_address: "first@example.com" },
+        { id: "second", email_address: "second@example.com" },
+      ],
+      primary_email_address_id: null,
+    })).toBeNull();
+  });
+
+  it("skips only explicit unverified statuses", () => {
+    expect(hasExplicitUnverifiedStatus({ verification: { status: "unverified" } })).toBe(true);
+    expect(hasExplicitUnverifiedStatus({ verification: { status: "verified" } })).toBe(false);
+    expect(hasExplicitUnverifiedStatus({})).toBe(false);
+  });
+});

--- a/web/lib/server/__tests__/resend-contact-sync.test.ts
+++ b/web/lib/server/__tests__/resend-contact-sync.test.ts
@@ -83,7 +83,7 @@ describe("syncClerkUserToResendContact", () => {
   it("skips when contact sync is disabled", async () => {
     const { client, get } = makeClient(false);
 
-    const result = await syncClerkUserToResendContact(clerkUser, "user.created", {
+    const result = await syncClerkUserToResendContact(clerkUser, {
       client,
       enabled: false,
     });
@@ -97,7 +97,7 @@ describe("syncClerkUserToResendContact", () => {
   });
 
   it("reports missing contact API configuration when enabled without a client", async () => {
-    const result = await syncClerkUserToResendContact(clerkUser, "user.created", {
+    const result = await syncClerkUserToResendContact(clerkUser, {
       enabled: true,
     });
 
@@ -110,7 +110,7 @@ describe("syncClerkUserToResendContact", () => {
   it("creates a Resend contact without changing future unsubscribe state", async () => {
     const { client, create } = makeClient(false);
 
-    const result = await syncClerkUserToResendContact(clerkUser, "user.created", {
+    const result = await syncClerkUserToResendContact(clerkUser, {
       client,
       enabled: true,
       segmentId: "segment_123",
@@ -133,7 +133,7 @@ describe("syncClerkUserToResendContact", () => {
   it("updates an existing Resend contact without passing unsubscribed", async () => {
     const { client, segmentAdd, update } = makeClient(true);
 
-    const result = await syncClerkUserToResendContact(clerkUser, "user.updated", {
+    const result = await syncClerkUserToResendContact(clerkUser, {
       client,
       enabled: true,
       segmentId: "segment_123",
@@ -158,14 +158,17 @@ describe("syncClerkUserToResendContact", () => {
   it("omits blank names when updating an existing Resend contact", async () => {
     const { client, update } = makeClient(true);
 
-    await syncClerkUserToResendContact({
-      ...clerkUser,
-      first_name: null,
-      last_name: " ",
-    }, "user.updated", {
-      client,
-      enabled: true,
-    });
+    await syncClerkUserToResendContact(
+      {
+        ...clerkUser,
+        first_name: null,
+        last_name: " ",
+      },
+      {
+        client,
+        enabled: true,
+      },
+    );
 
     expect(update).toHaveBeenCalledWith({
       email: "gerry@example.com",
@@ -177,19 +180,22 @@ describe("syncClerkUserToResendContact", () => {
   it("skips explicitly unverified Clerk primary emails", async () => {
     const { client, get } = makeClient(false);
 
-    const result = await syncClerkUserToResendContact({
-      ...clerkUser,
-      email_addresses: [
-        {
-          id: "primary",
-          email_address: "unverified@example.com",
-          verification: { status: "unverified" },
-        },
-      ],
-    }, "user.created", {
-      client,
-      enabled: true,
-    });
+    const result = await syncClerkUserToResendContact(
+      {
+        ...clerkUser,
+        email_addresses: [
+          {
+            id: "primary",
+            email_address: "unverified@example.com",
+            verification: { status: "unverified" },
+          },
+        ],
+      },
+      {
+        client,
+        enabled: true,
+      },
+    );
 
     expect(result).toEqual({
       ok: false,
@@ -197,5 +203,38 @@ describe("syncClerkUserToResendContact", () => {
       error: "Clerk user primary email is not verified",
     });
     expect(get).not.toHaveBeenCalled();
+  });
+
+  it("syncs users when Clerk omits email verification status", async () => {
+    const { client, create } = makeClient(false);
+
+    const result = await syncClerkUserToResendContact(
+      {
+        ...clerkUser,
+        email_addresses: [
+          {
+            id: "primary",
+            email_address: "oauth@example.com",
+          },
+        ],
+        primary_email_address_id: "primary",
+      },
+      {
+        client,
+        enabled: true,
+      },
+    );
+
+    expect(result).toEqual({
+      action: "created",
+      email: "oauth@example.com",
+      ok: true,
+    });
+    expect(create).toHaveBeenCalledWith({
+      email: "oauth@example.com",
+      firstName: "Gerry",
+      lastName: "Gugger",
+      unsubscribed: false,
+    });
   });
 });

--- a/web/lib/server/__tests__/resend-contact-sync.test.ts
+++ b/web/lib/server/__tests__/resend-contact-sync.test.ts
@@ -11,7 +11,11 @@ import {
 const clerkUser: ClerkUserEmailSyncPayload = {
   email_addresses: [
     { id: "secondary", email_address: "secondary@example.com" },
-    { id: "primary", email_address: "Gerry@Example.com" },
+    {
+      id: "primary",
+      email_address: "Gerry@Example.com",
+      verification: { status: "verified" },
+    },
   ],
   first_name: "Gerry",
   id: "user_123",
@@ -92,6 +96,17 @@ describe("syncClerkUserToResendContact", () => {
     expect(get).not.toHaveBeenCalled();
   });
 
+  it("reports missing contact API configuration when enabled without a client", async () => {
+    const result = await syncClerkUserToResendContact(clerkUser, "user.created", {
+      enabled: true,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: "RESEND_CONTACTS_API_KEY or RESEND_API_KEY is not configured",
+    });
+  });
+
   it("creates a Resend contact without changing future unsubscribe state", async () => {
     const { client, create } = makeClient(false);
 
@@ -110,11 +125,6 @@ describe("syncClerkUserToResendContact", () => {
       email: "gerry@example.com",
       firstName: "Gerry",
       lastName: "Gugger",
-      properties: {
-        clerk_event: "user.created",
-        clerk_user_id: "user_123",
-        source: "clerk",
-      },
       segments: [{ id: "segment_123" }],
       unsubscribed: false,
     });
@@ -138,11 +148,6 @@ describe("syncClerkUserToResendContact", () => {
       email: "gerry@example.com",
       firstName: "Gerry",
       lastName: "Gugger",
-      properties: {
-        clerk_event: "user.updated",
-        clerk_user_id: "user_123",
-        source: "clerk",
-      },
     });
     expect(segmentAdd).toHaveBeenCalledWith({
       email: "gerry@example.com",
@@ -166,11 +171,31 @@ describe("syncClerkUserToResendContact", () => {
       email: "gerry@example.com",
       firstName: undefined,
       lastName: undefined,
-      properties: {
-        clerk_event: "user.updated",
-        clerk_user_id: "user_123",
-        source: "clerk",
-      },
     });
+  });
+
+  it("skips explicitly unverified Clerk primary emails", async () => {
+    const { client, get } = makeClient(false);
+
+    const result = await syncClerkUserToResendContact({
+      ...clerkUser,
+      email_addresses: [
+        {
+          id: "primary",
+          email_address: "unverified@example.com",
+          verification: { status: "unverified" },
+        },
+      ],
+    }, "user.created", {
+      client,
+      enabled: true,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      skipped: true,
+      error: "Clerk user primary email is not verified",
+    });
+    expect(get).not.toHaveBeenCalled();
   });
 });

--- a/web/lib/server/__tests__/resend-contact-sync.test.ts
+++ b/web/lib/server/__tests__/resend-contact-sync.test.ts
@@ -71,11 +71,19 @@ describe("getClerkUserPrimaryEmail", () => {
     expect(getClerkUserPrimaryEmail(clerkUser)).toBe("gerry@example.com");
   });
 
-  it("falls back to the first email address when Clerk has no primary id", () => {
+  it("uses the only email address when Clerk has no primary id", () => {
+    expect(getClerkUserPrimaryEmail({
+      ...clerkUser,
+      email_addresses: [{ id: "only", email_address: "Only@Example.com" }],
+      primary_email_address_id: null,
+    })).toBe("only@example.com");
+  });
+
+  it("does not guess an email address when Clerk has multiple addresses and no primary id", () => {
     expect(getClerkUserPrimaryEmail({
       ...clerkUser,
       primary_email_address_id: null,
-    })).toBe("secondary@example.com");
+    })).toBeNull();
   });
 });
 
@@ -103,7 +111,7 @@ describe("syncClerkUserToResendContact", () => {
 
     expect(result).toEqual({
       ok: false,
-      error: "RESEND_CONTACTS_API_KEY or RESEND_API_KEY is not configured",
+      error: "RESEND_CONTACTS_API_KEY is not configured",
     });
   });
 

--- a/web/lib/server/resend-client.ts
+++ b/web/lib/server/resend-client.ts
@@ -7,6 +7,8 @@ type ResendApiError = {
 
 let resend: Resend | null = null;
 let resendApiKey: string | null = null;
+let resendContacts: Resend | null = null;
+let resendContactsApiKey: string | null = null;
 
 export function getResendClient() {
   const apiKey = process.env.RESEND_API_KEY;
@@ -18,6 +20,18 @@ export function getResendClient() {
   }
 
   return resend;
+}
+
+export function getResendContactsClient() {
+  const apiKey = process.env.RESEND_CONTACTS_API_KEY ?? process.env.RESEND_API_KEY;
+  if (!apiKey) return null;
+
+  if (!resendContacts || resendContactsApiKey !== apiKey) {
+    resendContacts = new Resend(apiKey);
+    resendContactsApiKey = apiKey;
+  }
+
+  return resendContacts;
 }
 
 export function getResendErrorMessage(error: ResendApiError | unknown) {

--- a/web/lib/server/resend-client.ts
+++ b/web/lib/server/resend-client.ts
@@ -23,7 +23,7 @@ export function getResendClient() {
 }
 
 export function getResendContactsClient() {
-  const apiKey = process.env.RESEND_CONTACTS_API_KEY ?? process.env.RESEND_API_KEY;
+  const apiKey = process.env.RESEND_CONTACTS_API_KEY;
   if (!apiKey) return null;
 
   if (!resendContacts || resendContactsApiKey !== apiKey) {

--- a/web/lib/server/resend-contact-sync.ts
+++ b/web/lib/server/resend-contact-sync.ts
@@ -26,7 +26,6 @@ export type ClerkUserEmailSyncPayload = {
   primary_email_address_id?: string | null;
 };
 
-type ContactSyncEventType = "user.created" | "user.updated";
 type ContactSyncAction = "created" | "updated";
 
 export interface ContactSyncResult {
@@ -74,7 +73,7 @@ function isNotFound(error: ContactApiError) {
 }
 
 function isAlreadyInSegment(error: ContactApiError) {
-  return error.statusCode === 409 || /already.*segment/i.test(error.message ?? "");
+  return /already.*segment/i.test(error.message ?? "") || error.statusCode === 409;
 }
 
 function isContactSyncEnabled(options: SyncClerkUserOptions) {
@@ -91,6 +90,7 @@ export function getClerkUserPrimaryEmail(user: ClerkUserEmailSyncPayload) {
 }
 
 function hasExplicitUnverifiedStatus(emailAddress: ClerkEmailAddress | null | undefined) {
+  // Missing verification status is common for OAuth-backed users; only skip explicit failures.
   const status = cleanString(emailAddress?.verification?.status);
   return Boolean(status && status !== "verified");
 }
@@ -120,7 +120,6 @@ async function ensureContactSegment(
 
 export async function syncClerkUserToResendContact(
   user: ClerkUserEmailSyncPayload,
-  _eventType: ContactSyncEventType,
   options: SyncClerkUserOptions = {},
 ): Promise<ContactSyncResult> {
   if (!isContactSyncEnabled(options)) {

--- a/web/lib/server/resend-contact-sync.ts
+++ b/web/lib/server/resend-contact-sync.ts
@@ -81,12 +81,7 @@ function isContactSyncEnabled(options: SyncClerkUserOptions) {
 }
 
 export function getClerkUserPrimaryEmail(user: ClerkUserEmailSyncPayload) {
-  const emailAddresses = user.email_addresses ?? [];
-  const primaryEmail =
-    emailAddresses.find((email) => email.id === user.primary_email_address_id) ??
-    emailAddresses[0];
-
-  return cleanString(primaryEmail?.email_address)?.toLowerCase() ?? null;
+  return cleanString(getClerkUserPrimaryEmailAddress(user)?.email_address)?.toLowerCase() ?? null;
 }
 
 function hasExplicitUnverifiedStatus(emailAddress: ClerkEmailAddress | null | undefined) {
@@ -95,11 +90,15 @@ function hasExplicitUnverifiedStatus(emailAddress: ClerkEmailAddress | null | un
   return Boolean(status && status !== "verified");
 }
 
+// Keep primary email selection aligned with web/scripts/backfill-resend-contacts.mjs.
 function getClerkUserPrimaryEmailAddress(user: ClerkUserEmailSyncPayload) {
   const emailAddresses = user.email_addresses ?? [];
+  if (emailAddresses.length === 1) {
+    return emailAddresses[0];
+  }
+
   return (
     emailAddresses.find((email) => email.id === user.primary_email_address_id) ??
-    emailAddresses[0] ??
     null
   );
 }
@@ -138,7 +137,7 @@ export async function syncClerkUserToResendContact(
 
   const client = options.client ?? getResendContactsClient();
   if (!client) {
-    return { ok: false, error: "RESEND_CONTACTS_API_KEY or RESEND_API_KEY is not configured" };
+    return { ok: false, error: "RESEND_CONTACTS_API_KEY is not configured" };
   }
 
   const firstName = cleanString(user.first_name);

--- a/web/lib/server/resend-contact-sync.ts
+++ b/web/lib/server/resend-contact-sync.ts
@@ -5,11 +5,17 @@ import type {
   GetContactOptions,
   UpdateContactOptions,
 } from "resend";
-import { getResendClient, getResendErrorMessage } from "@/lib/server/resend-client";
+import {
+  getResendContactsClient,
+  getResendErrorMessage,
+} from "@/lib/server/resend-client";
 
 type ClerkEmailAddress = {
   email_address?: string | null;
   id?: string | null;
+  verification?: {
+    status?: string | null;
+  } | null;
 };
 
 export type ClerkUserEmailSyncPayload = {
@@ -84,6 +90,20 @@ export function getClerkUserPrimaryEmail(user: ClerkUserEmailSyncPayload) {
   return cleanString(primaryEmail?.email_address)?.toLowerCase() ?? null;
 }
 
+function hasExplicitUnverifiedStatus(emailAddress: ClerkEmailAddress | null | undefined) {
+  const status = cleanString(emailAddress?.verification?.status);
+  return Boolean(status && status !== "verified");
+}
+
+function getClerkUserPrimaryEmailAddress(user: ClerkUserEmailSyncPayload) {
+  const emailAddresses = user.email_addresses ?? [];
+  return (
+    emailAddresses.find((email) => email.id === user.primary_email_address_id) ??
+    emailAddresses[0] ??
+    null
+  );
+}
+
 async function ensureContactSegment(
   client: ContactSyncClient,
   email: string,
@@ -100,7 +120,7 @@ async function ensureContactSegment(
 
 export async function syncClerkUserToResendContact(
   user: ClerkUserEmailSyncPayload,
-  eventType: ContactSyncEventType,
+  _eventType: ContactSyncEventType,
   options: SyncClerkUserOptions = {},
 ): Promise<ContactSyncResult> {
   if (!isContactSyncEnabled(options)) {
@@ -112,19 +132,19 @@ export async function syncClerkUserToResendContact(
     return { ok: false, skipped: true, error: "Clerk user has no email address" };
   }
 
-  const client = options.client ?? getResendClient();
+  const primaryEmailAddress = getClerkUserPrimaryEmailAddress(user);
+  if (hasExplicitUnverifiedStatus(primaryEmailAddress)) {
+    return { ok: false, skipped: true, error: "Clerk user primary email is not verified" };
+  }
+
+  const client = options.client ?? getResendContactsClient();
   if (!client) {
-    return { ok: false, error: "RESEND_API_KEY is not configured" };
+    return { ok: false, error: "RESEND_CONTACTS_API_KEY or RESEND_API_KEY is not configured" };
   }
 
   const firstName = cleanString(user.first_name);
   const lastName = cleanString(user.last_name);
   const segmentId = cleanString(options.segmentId ?? process.env.RESEND_CONTACT_SEGMENT_ID);
-  const properties = {
-    clerk_event: eventType,
-    clerk_user_id: user.id,
-    source: "clerk",
-  };
 
   try {
     const existing = await client.contacts.get({ email });
@@ -138,7 +158,6 @@ export async function syncClerkUserToResendContact(
         email,
         firstName: firstName ?? undefined,
         lastName: lastName ?? undefined,
-        properties,
         unsubscribed: false,
       };
 
@@ -158,7 +177,6 @@ export async function syncClerkUserToResendContact(
       email,
       firstName: firstName ?? undefined,
       lastName: lastName ?? undefined,
-      properties,
     });
 
     if (updated.error) {

--- a/web/scripts/backfill-resend-contacts.mjs
+++ b/web/scripts/backfill-resend-contacts.mjs
@@ -9,6 +9,7 @@ const MAX_LIMIT = 500;
 function parseArgs(argv) {
   const args = {
     apply: false,
+    delayMs: 0,
     limit: DEFAULT_LIMIT,
     maxUsers: Number.POSITIVE_INFINITY,
     offset: 0,
@@ -26,6 +27,12 @@ function parseArgs(argv) {
 
     if (arg === "--limit" && next) {
       args.limit = Math.min(Number(next), MAX_LIMIT);
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--delay-ms" && next) {
+      args.delayMs = Number(next);
       index += 1;
       continue;
     }
@@ -68,6 +75,10 @@ function parseArgs(argv) {
     throw new Error("--offset must be zero or greater");
   }
 
+  if (!Number.isFinite(args.delayMs) || args.delayMs < 0) {
+    throw new Error("--delay-ms must be zero or greater");
+  }
+
   return args;
 }
 
@@ -83,12 +94,13 @@ Apply to one eligible user:
 
 Options:
   --apply              Write contacts to Resend. Omit for dry-run.
+  --delay-ms <n>       Wait between Resend writes. Defaults to 0.
   --limit <n>          Clerk page size. Defaults to ${DEFAULT_LIMIT}, max ${MAX_LIMIT}.
   --max-users <n>      Stop after scanning this many Clerk users.
   --offset <n>         Start at a Clerk list offset.
   --segment-id <id>    Resend Segment ID. Defaults to RESEND_CONTACT_SEGMENT_ID.
 
-Resend rate limits apply. Use --max-users and --offset to pace larger backfills.
+Resend rate limits apply. Use --delay-ms, --max-users, and --offset to pace larger backfills.
 `);
 }
 
@@ -97,13 +109,11 @@ function cleanString(value) {
   return cleaned || null;
 }
 
+// Keep primary email selection aligned with web/lib/server/resend-contact-sync.ts.
 function getPrimaryEmailAddress(user) {
   const emails = Array.isArray(user.email_addresses) ? user.email_addresses : [];
-  return (
-    emails.find((email) => email.id === user.primary_email_address_id) ??
-    emails[0] ??
-    null
-  );
+  if (emails.length === 1) return emails[0];
+  return emails.find((email) => email.id === user.primary_email_address_id) ?? null;
 }
 
 function getPrimaryEmail(user) {
@@ -185,6 +195,11 @@ async function ensureContactSegment(resend, email, segmentId) {
   return getResendErrorMessage(error);
 }
 
+async function delay(ms) {
+  if (ms <= 0) return;
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 async function syncContact({ resend, segmentId, user }) {
   const email = getPrimaryEmail(user);
   const { firstName, lastName } = getNameFields(user);
@@ -200,12 +215,9 @@ async function syncContact({ resend, segmentId, user }) {
       email,
       firstName,
       lastName,
+      ...(segmentId ? { segments: [{ id: segmentId }] } : {}),
       unsubscribed: false,
     };
-
-    if (segmentId) {
-      payload.segments = [{ id: segmentId }];
-    }
 
     const created = await resend.contacts.create(payload);
     if (created.error) {
@@ -238,14 +250,14 @@ async function syncContact({ resend, segmentId, user }) {
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const clerkSecretKey = process.env.CLERK_SECRET_KEY;
-  const resendContactsApiKey = process.env.RESEND_CONTACTS_API_KEY ?? process.env.RESEND_API_KEY;
+  const resendContactsApiKey = process.env.RESEND_CONTACTS_API_KEY;
 
   if (!clerkSecretKey) {
     throw new Error("CLERK_SECRET_KEY is required");
   }
 
   if (args.apply && !resendContactsApiKey) {
-    throw new Error("RESEND_CONTACTS_API_KEY or RESEND_API_KEY is required when --apply is set");
+    throw new Error("RESEND_CONTACTS_API_KEY is required when --apply is set");
   }
 
   const resend = args.apply ? new Resend(resendContactsApiKey) : null;
@@ -284,12 +296,18 @@ async function main() {
       } else {
         const result = await syncContact({ resend, segmentId: args.segmentId, user });
         if (result.ok) {
-          stats[result.action] += 1;
+          if (result.action === "created") {
+            stats.created += 1;
+          } else {
+            stats.updated += 1;
+          }
           console.log(`${result.action} ${maskEmail(result.email)} ${user.id}`);
         } else {
           stats.failed += 1;
           console.error(`failed ${maskEmail(result.email ?? email)} ${user.id}: ${result.error}`);
         }
+
+        await delay(args.delayMs);
       }
 
       if (stats.scanned >= args.maxUsers) break;

--- a/web/scripts/backfill-resend-contacts.mjs
+++ b/web/scripts/backfill-resend-contacts.mjs
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
 
+import { pathToFileURL } from "node:url";
 import { Resend } from "resend";
 
 const CLERK_USERS_URL = "https://api.clerk.com/v1/users";
 const DEFAULT_LIMIT = 100;
 const MAX_LIMIT = 500;
 
-function parseArgs(argv) {
+export function parseArgs(argv) {
   const args = {
     apply: false,
     delayMs: 0,
@@ -104,23 +105,23 @@ Resend rate limits apply. Use --delay-ms, --max-users, and --offset to pace larg
 `);
 }
 
-function cleanString(value) {
+export function cleanString(value) {
   const cleaned = typeof value === "string" ? value.trim() : "";
   return cleaned || null;
 }
 
 // Keep primary email selection aligned with web/lib/server/resend-contact-sync.ts.
-function getPrimaryEmailAddress(user) {
+export function getPrimaryEmailAddress(user) {
   const emails = Array.isArray(user.email_addresses) ? user.email_addresses : [];
   if (emails.length === 1) return emails[0];
   return emails.find((email) => email.id === user.primary_email_address_id) ?? null;
 }
 
-function getPrimaryEmail(user) {
+export function getPrimaryEmail(user) {
   return cleanString(getPrimaryEmailAddress(user)?.email_address)?.toLowerCase() ?? null;
 }
 
-function hasExplicitUnverifiedStatus(emailAddress) {
+export function hasExplicitUnverifiedStatus(emailAddress) {
   const status = cleanString(emailAddress?.verification?.status);
   return Boolean(status && status !== "verified");
 }
@@ -148,7 +149,7 @@ function isAlreadyInSegment(error) {
   return /already.*segment/i.test(error?.message ?? "") || error?.statusCode === 409;
 }
 
-function maskEmail(email) {
+export function maskEmail(email) {
   const [local, domain] = email.split("@");
   if (!domain) return email;
   const prefix = local.slice(0, 2);
@@ -326,7 +327,9 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  console.error(error instanceof Error ? error.message : error);
-  process.exit(1);
-});
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}

--- a/web/scripts/backfill-resend-contacts.mjs
+++ b/web/scripts/backfill-resend-contacts.mjs
@@ -1,0 +1,312 @@
+#!/usr/bin/env node
+
+import { Resend } from "resend";
+
+const CLERK_USERS_URL = "https://api.clerk.com/v1/users";
+const DEFAULT_LIMIT = 100;
+const MAX_LIMIT = 500;
+
+function parseArgs(argv) {
+  const args = {
+    apply: false,
+    limit: DEFAULT_LIMIT,
+    maxUsers: Number.POSITIVE_INFINITY,
+    offset: 0,
+    segmentId: process.env.RESEND_CONTACT_SEGMENT_ID?.trim() || null,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+
+    if (arg === "--apply") {
+      args.apply = true;
+      continue;
+    }
+
+    if (arg === "--limit" && next) {
+      args.limit = Math.min(Number(next), MAX_LIMIT);
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--max-users" && next) {
+      args.maxUsers = Number(next);
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--offset" && next) {
+      args.offset = Number(next);
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--segment-id" && next) {
+      args.segmentId = next.trim() || null;
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--help") {
+      printUsage();
+      process.exit(0);
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (!Number.isFinite(args.limit) || args.limit < 1) {
+    throw new Error("--limit must be a positive number");
+  }
+
+  if (Number.isNaN(args.maxUsers) || args.maxUsers < 1) {
+    throw new Error("--max-users must be a positive number");
+  }
+
+  if (!Number.isFinite(args.offset) || args.offset < 0) {
+    throw new Error("--offset must be zero or greater");
+  }
+
+  return args;
+}
+
+function printUsage() {
+  console.log(`
+Backfill Clerk users into Resend contacts.
+
+Dry-run:
+  node scripts/backfill-resend-contacts.mjs
+
+Apply to one eligible user:
+  node scripts/backfill-resend-contacts.mjs --apply --max-users 1
+
+Options:
+  --apply              Write contacts to Resend. Omit for dry-run.
+  --limit <n>          Clerk page size. Defaults to ${DEFAULT_LIMIT}, max ${MAX_LIMIT}.
+  --max-users <n>      Stop after scanning this many Clerk users.
+  --offset <n>         Start at a Clerk list offset.
+  --segment-id <id>    Resend Segment ID. Defaults to RESEND_CONTACT_SEGMENT_ID.
+`);
+}
+
+function cleanString(value) {
+  const cleaned = typeof value === "string" ? value.trim() : "";
+  return cleaned || null;
+}
+
+function getPrimaryEmailAddress(user) {
+  const emails = Array.isArray(user.email_addresses) ? user.email_addresses : [];
+  return (
+    emails.find((email) => email.id === user.primary_email_address_id) ??
+    emails[0] ??
+    null
+  );
+}
+
+function getPrimaryEmail(user) {
+  return cleanString(getPrimaryEmailAddress(user)?.email_address)?.toLowerCase() ?? null;
+}
+
+function hasExplicitUnverifiedStatus(emailAddress) {
+  const status = cleanString(emailAddress?.verification?.status);
+  return Boolean(status && status !== "verified");
+}
+
+function getNameFields(user) {
+  return {
+    firstName: cleanString(user.first_name) ?? undefined,
+    lastName: cleanString(user.last_name) ?? undefined,
+  };
+}
+
+function getResendErrorMessage(error) {
+  if (error instanceof Error) return error.message;
+  if (error && typeof error === "object" && typeof error.message === "string") {
+    return error.message;
+  }
+  return "Unknown Resend error";
+}
+
+function isNotFound(error) {
+  return error?.statusCode === 404 || error?.name === "not_found";
+}
+
+function isAlreadyInSegment(error) {
+  return error?.statusCode === 409 || /already.*segment/i.test(error?.message ?? "");
+}
+
+function maskEmail(email) {
+  const [local, domain] = email.split("@");
+  if (!domain) return email;
+  const prefix = local.slice(0, 2);
+  return `${prefix}${"*".repeat(Math.max(local.length - 2, 1))}@${domain}`;
+}
+
+async function listClerkUsers({ clerkSecretKey, limit, offset }) {
+  const url = new URL(CLERK_USERS_URL);
+  url.searchParams.set("limit", String(limit));
+  url.searchParams.set("offset", String(offset));
+  url.searchParams.set("order_by", "-created_at");
+
+  const response = await fetch(url, {
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${clerkSecretKey}`,
+    },
+  });
+
+  const body = await response.json().catch(() => null);
+
+  if (!response.ok) {
+    const message = body?.errors?.[0]?.message ?? body?.message ?? response.statusText;
+    throw new Error(`Clerk user list failed: ${response.status} ${message}`);
+  }
+
+  if (Array.isArray(body)) {
+    return { totalCount: null, users: body };
+  }
+
+  if (Array.isArray(body?.data)) {
+    return {
+      totalCount: typeof body.total_count === "number" ? body.total_count : null,
+      users: body.data,
+    };
+  }
+
+  throw new Error("Clerk user list returned an unexpected response shape");
+}
+
+async function ensureContactSegment(resend, email, segmentId) {
+  const { error } = await resend.contacts.segments.add({ email, segmentId });
+  if (!error || isAlreadyInSegment(error)) return null;
+  return getResendErrorMessage(error);
+}
+
+async function syncContact({ resend, segmentId, user }) {
+  const email = getPrimaryEmail(user);
+  const { firstName, lastName } = getNameFields(user);
+
+  const existing = await resend.contacts.get({ email });
+
+  if (existing.error && !isNotFound(existing.error)) {
+    return { ok: false, email, error: getResendErrorMessage(existing.error) };
+  }
+
+  if (existing.error) {
+    const payload = {
+      email,
+      firstName,
+      lastName,
+      unsubscribed: false,
+    };
+
+    if (segmentId) {
+      payload.segments = [{ id: segmentId }];
+    }
+
+    const created = await resend.contacts.create(payload);
+    if (created.error) {
+      return { ok: false, email, error: getResendErrorMessage(created.error) };
+    }
+
+    return { ok: true, action: "created", email };
+  }
+
+  const updated = await resend.contacts.update({
+    email,
+    firstName,
+    lastName,
+  });
+
+  if (updated.error) {
+    return { ok: false, email, error: getResendErrorMessage(updated.error) };
+  }
+
+  if (segmentId) {
+    const segmentError = await ensureContactSegment(resend, email, segmentId);
+    if (segmentError) {
+      return { ok: false, email, error: segmentError };
+    }
+  }
+
+  return { ok: true, action: "updated", email };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const clerkSecretKey = process.env.CLERK_SECRET_KEY;
+  const resendContactsApiKey = process.env.RESEND_CONTACTS_API_KEY ?? process.env.RESEND_API_KEY;
+
+  if (!clerkSecretKey) {
+    throw new Error("CLERK_SECRET_KEY is required");
+  }
+
+  if (args.apply && !resendContactsApiKey) {
+    throw new Error("RESEND_CONTACTS_API_KEY or RESEND_API_KEY is required when --apply is set");
+  }
+
+  const resend = args.apply ? new Resend(resendContactsApiKey) : null;
+  const stats = {
+    created: 0,
+    dryRunEligible: 0,
+    failed: 0,
+    scanned: 0,
+    skippedNoEmail: 0,
+    skippedUnverified: 0,
+    updated: 0,
+  };
+
+  let offset = args.offset;
+
+  while (stats.scanned < args.maxUsers) {
+    const remaining = args.maxUsers - stats.scanned;
+    const limit = Math.min(args.limit, remaining);
+    const page = await listClerkUsers({ clerkSecretKey, limit, offset });
+
+    if (page.users.length === 0) break;
+
+    for (const user of page.users) {
+      stats.scanned += 1;
+
+      const primaryEmailAddress = getPrimaryEmailAddress(user);
+      const email = getPrimaryEmail(user);
+
+      if (!email) {
+        stats.skippedNoEmail += 1;
+      } else if (hasExplicitUnverifiedStatus(primaryEmailAddress)) {
+        stats.skippedUnverified += 1;
+      } else if (!args.apply) {
+        stats.dryRunEligible += 1;
+        console.log(`dry-run eligible ${maskEmail(email)} ${user.id}`);
+      } else {
+        const result = await syncContact({ resend, segmentId: args.segmentId, user });
+        if (result.ok) {
+          stats[result.action] += 1;
+          console.log(`${result.action} ${maskEmail(result.email)} ${user.id}`);
+        } else {
+          stats.failed += 1;
+          console.error(`failed ${maskEmail(result.email ?? email)} ${user.id}: ${result.error}`);
+        }
+      }
+
+      if (stats.scanned >= args.maxUsers) break;
+    }
+
+    offset += page.users.length;
+
+    if (page.users.length < limit) break;
+    if (page.totalCount !== null && offset >= page.totalCount) break;
+  }
+
+  console.log(JSON.stringify({ apply: args.apply, segmentId: args.segmentId, stats }, null, 2));
+
+  if (stats.failed > 0) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/web/scripts/backfill-resend-contacts.mjs
+++ b/web/scripts/backfill-resend-contacts.mjs
@@ -87,6 +87,8 @@ Options:
   --max-users <n>      Stop after scanning this many Clerk users.
   --offset <n>         Start at a Clerk list offset.
   --segment-id <id>    Resend Segment ID. Defaults to RESEND_CONTACT_SEGMENT_ID.
+
+Resend rate limits apply. Use --max-users and --offset to pace larger backfills.
 `);
 }
 
@@ -133,7 +135,7 @@ function isNotFound(error) {
 }
 
 function isAlreadyInSegment(error) {
-  return error?.statusCode === 409 || /already.*segment/i.test(error?.message ?? "");
+  return /already.*segment/i.test(error?.message ?? "") || error?.statusCode === 409;
 }
 
 function maskEmail(email) {


### PR DESCRIPTION
## Summary

- Adds a dry-run-first Clerk-to-Resend contact backfill script.
- Updates Clerk webhook contact sync to use a contacts-capable Resend key when present.
- Skips explicitly unverified Clerk primary emails.
- Documents the Resend contact sync/backfill workflow and required production env vars.

## Context

The existing Resend integration key is send-only, which is good for normal email delivery but cannot manage contacts or segments. This PR separates contact sync from send mail by supporting `RESEND_CONTACTS_API_KEY` while keeping `RESEND_API_KEY` available for email sending.

During live validation, Resend rejected custom contact properties unless those properties already exist in the account. The implementation now keeps the MVP intentionally simple: email, first name, last name, and membership in the `Flaim Users` segment.

## Operational Notes

- Production Vercel now has `RESEND_CONTACTS_API_KEY`.
- Production Vercel now has `RESEND_CONTACT_SEGMENT_ID` for the `Flaim Users` segment.
- `RESEND_CONTACT_SYNC_ENABLED` should remain disabled until this PR is deployed.
- The backfill script masks email addresses in logs.
- This does not send user emails.

## Validation

- `corepack pnpm --dir web run test -- lib/server/__tests__/resend-contact-sync.test.ts`
- `corepack pnpm --dir web exec tsc --noEmit`
- `corepack pnpm --dir web run lint`
- `corepack pnpm --dir web exec node scripts/backfill-resend-contacts.mjs --help`
- Production dry run scanned eligible Clerk users without writing.
- Production apply test created one masked Clerk user in Resend and confirmed segment readback.

Local Node warning remains: repo expects Node `24.x`; local machine is running Node `v26.0.0`.
