### PR TITLE
[codex] Fix Yahoo transaction player details

### DIFF
--- a/workers/yahoo-client/src/shared/__tests__/yahoo-transactions.test.ts
+++ b/workers/yahoo-client/src/shared/__tests__/yahoo-transactions.test.ts
@@ -54,6 +54,78 @@ describe('yahoo-transactions', () => {
     expect(normalized[0].players_added).toEqual([{ id: '12', name: 'Sample Player' }]);
   });
 
+  it('normalizes player details when Yahoo returns transaction_data as an array', () => {
+    const raw = {
+      fantasy_content: {
+        league: [
+          { league_key: '449.l.123' },
+          {
+            transactions: {
+              0: {
+                transaction: [
+                  { transaction_key: '449.l.123.tr.3' },
+                  { type: 'add' },
+                  { status: 'successful' },
+                  { timestamp: '1700000000' },
+                  {
+                    players: {
+                      0: {
+                        player: [
+                          [
+                            { player_key: '449.p.9999' },
+                            { player_id: '9999' },
+                            { name: { full: 'Array Add Player' } },
+                            { display_position: 'SP' },
+                            { editorial_team_abbr: 'SD' },
+                          ],
+                          {
+                            transaction_data: [
+                              { type: 'add' },
+                              { source_type: 'freeagents' },
+                              { destination_type: 'team' },
+                            ],
+                          },
+                        ],
+                      },
+                      1: {
+                        player: [
+                          [
+                            { player_id: '8888' },
+                            { name: { full: 'Array Drop Player' } },
+                            { display_position: 'RP' },
+                            { editorial_team_abbr: 'SEA' },
+                          ],
+                          {
+                            transaction_data: [
+                              { type: 'drop' },
+                              { source_type: 'team' },
+                              { destination_type: 'waivers' },
+                            ],
+                          },
+                        ],
+                      },
+                      count: 2,
+                    },
+                  },
+                ],
+              },
+              count: 1,
+            },
+          },
+        ],
+      },
+    };
+
+    const normalized = normalizeYahooTransactions(raw);
+    expect(normalized).toHaveLength(1);
+    expect(normalized[0].players_added).toEqual([
+      { id: '9999', name: 'Array Add Player', position: 'SP', team: 'SD' },
+    ]);
+    expect(normalized[0].players_dropped).toEqual([
+      { id: '8888', name: 'Array Drop Player', position: 'RP', team: 'SEA' },
+    ]);
+  });
+
   it('extracts faab_bid when transaction_data includes waiver bid info', () => {
     const raw = {
       fantasy_content: {

--- a/workers/yahoo-client/src/shared/yahoo-transactions.ts
+++ b/workers/yahoo-client/src/shared/yahoo-transactions.ts
@@ -10,12 +10,19 @@ export interface NormalizedTransaction {
   date: string;
   week: number | null;
   team_ids?: string[];
-  players_added?: Array<{ id: string; name?: string }>;
-  players_dropped?: Array<{ id: string; name?: string }>;
+  players_added?: TransactionPlayer[];
+  players_dropped?: TransactionPlayer[];
   faab_bid?: number | null;
   waiver_priority?: number | null;
   draft_picks?: unknown[] | null;
 }
+
+type TransactionPlayer = {
+  id: string;
+  name?: string;
+  position?: string;
+  team?: string;
+};
 
 export function buildYahooTransactionsPath(leagueKey: string, count = 25): string {
   const clamped = Math.max(1, Math.min(100, count));
@@ -56,6 +63,50 @@ function mapStatus(value: unknown): 'complete' | 'failed' | 'pending' | 'unknown
   return 'unknown';
 }
 
+function mergeYahooRecordList(value: unknown): Record<string, unknown> {
+  let merged: Record<string, unknown> = {};
+
+  const visit = (item: unknown) => {
+    if (Array.isArray(item)) {
+      for (const child of item) visit(child);
+      return;
+    }
+    if (typeof item === 'object' && item !== null) {
+      merged = { ...merged, ...(item as Record<string, unknown>) };
+    }
+  };
+
+  visit(value);
+  return merged;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function optionalId(value: unknown): string | undefined {
+  if (typeof value === 'string' && value.length > 0) return value;
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+  return undefined;
+}
+
+function buildTransactionPlayer(pmeta: Record<string, unknown>): TransactionPlayer | null {
+  const id = optionalId(pmeta.player_id) ?? optionalId(pmeta.player_key);
+  if (!id) return null;
+
+  const name = (pmeta.name as Record<string, unknown> | undefined)?.full;
+  const player: TransactionPlayer = { id };
+  const fullName = optionalString(name);
+  const position = optionalString(pmeta.display_position);
+  const team = optionalString(pmeta.editorial_team_abbr);
+
+  if (fullName) player.name = fullName;
+  if (position) player.position = position;
+  if (team) player.team = team;
+
+  return player;
+}
+
 export function normalizeYahooTransactions(raw: unknown): NormalizedTransaction[] {
   const leagueArray = getPath(raw, ['fantasy_content', 'league']);
   const league = unwrapLeague(leagueArray);
@@ -78,8 +129,8 @@ export function normalizeYahooTransactions(raw: unknown): NormalizedTransaction[
     const type = canonicalType(meta.type);
     if (!type) continue;
 
-    const playersAdded: Array<{ id: string; name?: string }> = [];
-    const playersDropped: Array<{ id: string; name?: string }> = [];
+    const playersAdded: TransactionPlayer[] = [];
+    const playersDropped: TransactionPlayer[] = [];
     let faabBid: number | null = null;
 
     const playersObj = meta.players as Record<string, unknown> | undefined;
@@ -88,31 +139,26 @@ export function normalizeYahooTransactions(raw: unknown): NormalizedTransaction[
       const pdata = getPath(pw, ['player']) as unknown[] | undefined;
       if (!Array.isArray(pdata)) continue;
 
-      let pmeta: Record<string, unknown> = {};
       let tdata: Record<string, unknown> = {};
+      let pmeta: Record<string, unknown> = {};
       for (const e of pdata) {
         if (Array.isArray(e)) {
-          for (const m of e) {
-            if (typeof m === 'object' && m !== null) {
-              pmeta = { ...pmeta, ...(m as Record<string, unknown>) };
-            }
-          }
+          pmeta = { ...pmeta, ...mergeYahooRecordList(e) };
         } else if (typeof e === 'object' && e !== null) {
-          const td = (e as Record<string, unknown>).transaction_data as Record<string, unknown> | undefined;
-          if (td) tdata = td;
+          const td = (e as Record<string, unknown>).transaction_data;
+          if (td) tdata = mergeYahooRecordList(td);
         }
       }
 
-      const pid = String(pmeta.player_id ?? pmeta.player_key ?? '');
-      const name = ((pmeta.name as Record<string, unknown> | undefined)?.full as string | undefined);
       const t = String(tdata.type ?? '').toLowerCase();
       const candidateBid = parseFaabBid(tdata.faab_bid ?? tdata.waiver_bid);
       if (faabBid === null && candidateBid !== null) {
         faabBid = candidateBid;
       }
-      if (pid) {
-        if (t === 'add') playersAdded.push({ id: pid, name });
-        if (t === 'drop') playersDropped.push({ id: pid, name });
+      const player = buildTransactionPlayer(pmeta);
+      if (player) {
+        if (t === 'add') playersAdded.push(player);
+        if (t === 'drop') playersDropped.push(player);
       }
     }
 


### PR DESCRIPTION
## Summary

Fixes Yahoo transaction normalization so player details are preserved when Yahoo returns `transaction_data` as an array of one-key objects instead of a plain object.

## Root Cause

The Yahoo transaction normalizer already read player metadata, but it only handled object-shaped `transaction_data`. When Yahoo returned array-shaped transaction data, the normalizer could not tell whether each player was an add or drop, so `players_added` and `players_dropped` were empty or incomplete.

## Impact

Yahoo `get_transactions` responses should now include player IDs, names, positions, and teams for add/drop entries when Yahoo provides those fields, bringing the payload closer to ESPN/Sleeper parity.

## Validation

- `corepack pnpm --dir workers/yahoo-client exec vitest run src/shared/__tests__/yahoo-transactions.test.ts`
- `corepack pnpm --dir workers/yahoo-client run type-check`
- `corepack pnpm --dir workers/yahoo-client run test`