### PR TITLE
[codex] Fetch Yahoo completed add/drop transactions

### DIFF
--- a/workers/yahoo-client/src/shared/__tests__/yahoo-transactions.test.ts
+++ b/workers/yahoo-client/src/shared/__tests__/yahoo-transactions.test.ts
@@ -3,8 +3,8 @@ import { buildYahooTransactionsPath, buildYahooPendingTransactionsPath, normaliz
 
 describe('yahoo-transactions', () => {
   it('builds matrix-param path with count clamp', () => {
-    expect(buildYahooTransactionsPath('449.l.123', 0)).toBe('/league/449.l.123/transactions;types=add,drop,trade;count=1');
-    expect(buildYahooTransactionsPath('449.l.123', 999)).toBe('/league/449.l.123/transactions;types=add,drop,trade;count=100');
+    expect(buildYahooTransactionsPath('449.l.123', 0)).toBe('/league/449.l.123/transactions;types=add,drop,add%2Fdrop,trade;count=1');
+    expect(buildYahooTransactionsPath('449.l.123', 999)).toBe('/league/449.l.123/transactions;types=add,drop,add%2Fdrop,trade;count=100');
   });
 
   it('normalizes add/drop transactions from numeric-keyed Yahoo JSON', () => {
@@ -124,6 +124,126 @@ describe('yahoo-transactions', () => {
     expect(normalized[0].players_dropped).toEqual([
       { id: '8888', name: 'Array Drop Player', position: 'RP', team: 'SEA' },
     ]);
+  });
+
+  it('normalizes completed add/drop transactions and extracts team attribution from player transaction data', () => {
+    const raw = {
+      fantasy_content: {
+        league: [
+          { league_key: '449.l.123' },
+          {
+            transactions: {
+              0: {
+                transaction: [
+                  { transaction_key: '449.l.123.tr.4' },
+                  { type: 'add/drop' },
+                  { status: 'successful' },
+                  { timestamp: '1700000000' },
+                  {
+                    players: {
+                      0: {
+                        player: [
+                          [
+                            { player_id: '9999' },
+                            { name: { full: 'Waiver Add Player' } },
+                            { display_position: 'SP' },
+                            { editorial_team_abbr: 'SD' },
+                          ],
+                          {
+                            transaction_data: [
+                              { type: 'add' },
+                              { source_type: 'waivers' },
+                              { destination_team_key: '449.l.123.t.6' },
+                              { faab_bid: '11' },
+                            ],
+                          },
+                        ],
+                      },
+                      1: {
+                        player: [
+                          [
+                            { player_id: '8888' },
+                            { name: { full: 'Waiver Drop Player' } },
+                            { display_position: 'RP' },
+                            { editorial_team_abbr: 'SEA' },
+                          ],
+                          {
+                            transaction_data: [
+                              { type: 'drop' },
+                              { source_team_key: '449.l.123.t.6' },
+                              { destination_type: 'waivers' },
+                            ],
+                          },
+                        ],
+                      },
+                      count: 2,
+                    },
+                  },
+                ],
+              },
+              count: 1,
+            },
+          },
+        ],
+      },
+    };
+
+    const normalized = normalizeYahooTransactions(raw);
+    expect(normalized).toHaveLength(1);
+    expect(normalized[0]).toMatchObject({
+      transaction_id: '449.l.123.tr.4',
+      type: 'add',
+      faab_bid: 11,
+      team_ids: ['449.l.123.t.6'],
+    });
+    expect(normalized[0].players_added).toEqual([
+      { id: '9999', name: 'Waiver Add Player', position: 'SP', team: 'SD' },
+    ]);
+    expect(normalized[0].players_dropped).toEqual([
+      { id: '8888', name: 'Waiver Drop Player', position: 'RP', team: 'SEA' },
+    ]);
+  });
+
+  it('extracts team attribution for standalone adds', () => {
+    const raw = {
+      fantasy_content: {
+        league: [
+          { league_key: '449.l.123' },
+          {
+            transactions: {
+              0: {
+                transaction: [
+                  { transaction_key: '449.l.123.tr.7' },
+                  { type: 'add' },
+                  { status: 'successful' },
+                  { timestamp: '1700000000' },
+                  {
+                    players: {
+                      0: {
+                        player: [
+                          [{ player_id: '7777' }, { name: { full: 'Standalone Add' } }],
+                          { transaction_data: { type: 'add', destination_team_key: '449.l.123.t.3' } },
+                        ],
+                      },
+                      count: 1,
+                    },
+                  },
+                ],
+              },
+              count: 1,
+            },
+          },
+        ],
+      },
+    };
+
+    const normalized = normalizeYahooTransactions(raw);
+    expect(normalized).toHaveLength(1);
+    expect(normalized[0]).toMatchObject({
+      transaction_id: '449.l.123.tr.7',
+      type: 'add',
+      team_ids: ['449.l.123.t.3'],
+    });
   });
 
   it('extracts faab_bid when transaction_data includes waiver bid info', () => {

--- a/workers/yahoo-client/src/shared/yahoo-transactions.ts
+++ b/workers/yahoo-client/src/shared/yahoo-transactions.ts
@@ -24,9 +24,12 @@ type TransactionPlayer = {
   team?: string;
 };
 
+const COMPLETED_TRANSACTION_TYPES = ['add', 'drop', 'add/drop', 'trade'];
+
 export function buildYahooTransactionsPath(leagueKey: string, count = 25): string {
   const clamped = Math.max(1, Math.min(100, count));
-  return `/league/${leagueKey}/transactions;types=add,drop,trade;count=${clamped}`;
+  const types = COMPLETED_TRANSACTION_TYPES.map((type) => encodeURIComponent(type)).join(',');
+  return `/league/${leagueKey}/transactions;types=${types};count=${clamped}`;
 }
 
 export function buildYahooPendingTransactionsPath(
@@ -43,6 +46,7 @@ function canonicalType(value: unknown): TransactionType | null {
   if (typeof value !== 'string') return null;
   if (value === 'add') return 'add';
   if (value === 'drop') return 'drop';
+  if (value === 'add/drop') return 'add';
   if (value === 'trade') return 'trade';
   if (value === 'waiver') return 'waiver';
   if (value === 'pending_trade') return 'pending_trade';
@@ -126,11 +130,16 @@ export function normalizeYahooTransactions(raw: unknown): NormalizedTransaction[
       }
     }
 
-    const type = canonicalType(meta.type);
-    if (!type) continue;
+    const rawType = canonicalType(meta.type);
+    if (!rawType) continue;
 
     const playersAdded: TransactionPlayer[] = [];
     const playersDropped: TransactionPlayer[] = [];
+    const teamIds = new Set(
+      [meta.trader_team_key, meta.tradee_team_key]
+        .filter((v) => typeof v === 'string')
+        .map((v) => String(v)),
+    );
     let faabBid: number | null = null;
 
     const playersObj = meta.players as Record<string, unknown> | undefined;
@@ -155,16 +164,17 @@ export function normalizeYahooTransactions(raw: unknown): NormalizedTransaction[
       if (faabBid === null && candidateBid !== null) {
         faabBid = candidateBid;
       }
+      const sourceTeamKey = optionalId(tdata.source_team_key);
+      const destinationTeamKey = optionalId(tdata.destination_team_key);
+      if (sourceTeamKey) teamIds.add(sourceTeamKey);
+      if (destinationTeamKey) teamIds.add(destinationTeamKey);
+
       const player = buildTransactionPlayer(pmeta);
       if (player) {
         if (t === 'add') playersAdded.push(player);
         if (t === 'drop') playersDropped.push(player);
       }
     }
-
-    const teamIds = [meta.trader_team_key, meta.tradee_team_key]
-      .filter((v) => typeof v === 'string')
-      .map((v) => String(v));
 
     const timestamp = Number(meta.timestamp ?? 0) * 1000;
     if (faabBid === null) {
@@ -175,6 +185,9 @@ export function normalizeYahooTransactions(raw: unknown): NormalizedTransaction[
       typeof rawPriority === 'number' && Number.isFinite(rawPriority) ? rawPriority
       : typeof rawPriority === 'string' && Number.isFinite(Number(rawPriority)) ? Number(rawPriority)
       : null;
+    const type: TransactionType = rawType === 'add' && playersAdded.length === 0 && playersDropped.length > 0
+      ? 'drop'
+      : rawType;
 
     out.push({
       transaction_id: String(meta.transaction_key ?? meta.transaction_id ?? `${type}-${timestamp}`),
@@ -183,7 +196,7 @@ export function normalizeYahooTransactions(raw: unknown): NormalizedTransaction[
       timestamp,
       date: new Date(timestamp).toISOString().slice(0, 10),
       week: null,
-      team_ids: teamIds.length > 0 ? teamIds : undefined,
+      team_ids: teamIds.size > 0 ? Array.from(teamIds) : undefined,
       players_added: playersAdded,
       players_dropped: playersDropped,
       faab_bid: faabBid,


### PR DESCRIPTION
## Summary

Fetch Yahoo completed `add/drop` transaction rows and preserve team attribution from player-level transaction data.

## Root Cause

The Yahoo league transactions query only requested `add,drop,trade`. Yahoo's UI shows completed replacement moves as combined `add/drop` transactions, especially for processed waiver-style overnight moves, so those rows were omitted from `get_transactions`.

Separately, Yahoo places team attribution for add/drop players in each player's `transaction_data` as `source_team_key` or `destination_team_key`. The normalizer ignored those fields, leaving rows like Luis Severino's add without a `team_ids` value even though Yahoo provides the destination team key.

## Impact

Yahoo `get_transactions` should now return the missing completed replacement moves and include the fantasy team key when Yahoo provides it. This should make processed overnight add/drop batches visible and help agents resolve the team through `get_league_info`.

## Validation

- `corepack pnpm --dir workers/yahoo-client exec vitest run src/shared/__tests__/yahoo-transactions.test.ts`
- `corepack pnpm --dir workers/yahoo-client run type-check`
- `corepack pnpm --dir workers/yahoo-client run test`