### PR TITLE
[codex] Remove Yahoo transaction type filter

### DIFF
--- a/workers/yahoo-client/src/shared/__tests__/yahoo-transactions.test.ts
+++ b/workers/yahoo-client/src/shared/__tests__/yahoo-transactions.test.ts
@@ -3,8 +3,8 @@ import { buildYahooTransactionsPath, buildYahooPendingTransactionsPath, normaliz
 
 describe('yahoo-transactions', () => {
   it('builds matrix-param path with count clamp', () => {
-    expect(buildYahooTransactionsPath('449.l.123', 0)).toBe('/league/449.l.123/transactions;types=add,drop,add%2Fdrop,trade;count=1');
-    expect(buildYahooTransactionsPath('449.l.123', 999)).toBe('/league/449.l.123/transactions;types=add,drop,add%2Fdrop,trade;count=100');
+    expect(buildYahooTransactionsPath('449.l.123', 0)).toBe('/league/449.l.123/transactions;count=1');
+    expect(buildYahooTransactionsPath('449.l.123', 999)).toBe('/league/449.l.123/transactions;count=100');
   });
 
   it('normalizes add/drop transactions from numeric-keyed Yahoo JSON', () => {

--- a/workers/yahoo-client/src/shared/yahoo-transactions.ts
+++ b/workers/yahoo-client/src/shared/yahoo-transactions.ts
@@ -24,12 +24,9 @@ type TransactionPlayer = {
   team?: string;
 };
 
-const COMPLETED_TRANSACTION_TYPES = ['add', 'drop', 'add/drop', 'trade'];
-
 export function buildYahooTransactionsPath(leagueKey: string, count = 25): string {
   const clamped = Math.max(1, Math.min(100, count));
-  const types = COMPLETED_TRANSACTION_TYPES.map((type) => encodeURIComponent(type)).join(',');
-  return `/league/${leagueKey}/transactions;types=${types};count=${clamped}`;
+  return `/league/${leagueKey}/transactions;count=${clamped}`;
 }
 
 export function buildYahooPendingTransactionsPath(


### PR DESCRIPTION
## Summary

Hotfixes Yahoo `get_transactions` by removing the completed-transactions `types=` matrix filter and falling back to Yahoo's unfiltered `/transactions;count=N` collection endpoint.

## Root Cause

PR #93 added `types=add,drop,add%2Fdrop,trade` to fetch Yahoo completed replacement moves. Production immediately began returning `YAHOO_NOT_FOUND` for `get_transactions` on league `469.l.6007`, while `get_league_info` still worked on the same league. The likely cause is Yahoo rejecting the encoded `add/drop` value in the collection `types` filter.

## Impact

Restores Yahoo transactions endpoint availability while preserving the parser support added in PR #93 for `add/drop` rows and player-level team attribution when Yahoo includes those rows in the unfiltered response.

## Validation

- `corepack pnpm --dir workers/yahoo-client exec vitest run src/shared/__tests__/yahoo-transactions.test.ts`
- `corepack pnpm --dir workers/yahoo-client run type-check`
- `corepack pnpm --dir workers/yahoo-client run test`