### PR TITLE
Support confidential MCP OAuth clients

### DIFF
--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -136,7 +136,7 @@ Short-lived authorization codes for OAuth 2.1.
 | Column | Type | Notes |
 |---|---|---|
 | id | uuid | Primary key |
-| code | text | Unique auth code |
+| code | text | Unique auth code; confidential-client codes encode a signed client binding |
 | user_id | text | Clerk user ID |
 | redirect_uri | text | OAuth redirect URI |
 | code_challenge | text | PKCE challenge |
@@ -160,7 +160,7 @@ Access and refresh tokens for MCP clients.
 | client_name | text | Derived from redirect URI (Claude, ChatGPT, etc.) |
 | expires_at | timestamptz | Access token expiry |
 | revoked_at | timestamptz | Revocation time |
-| refresh_token | text | Optional refresh token |
+| refresh_token | text | Optional refresh token; confidential-client refresh tokens encode a signed client binding |
 | refresh_token_expires_at | timestamptz | MCP refresh-token inactivity expiry (1 year by default; `OAUTH_REFRESH_TOKEN_TTL_SECONDS`) |
 | created_at | timestamptz | Created timestamp |
 

--- a/workers/README.md
+++ b/workers/README.md
@@ -71,6 +71,8 @@ NODE_ENV=production|development
 OAUTH_CLIENT_REGISTRATION_SIGNING_KEY=optional-stable-secret
 ```
 
+Use a dedicated stable `OAUTH_CLIENT_REGISTRATION_SIGNING_KEY` for preview and production before depending on confidential MCP clients. If it is omitted, auth-worker falls back to `SUPABASE_SERVICE_KEY`; rotating that key also invalidates existing confidential client registrations.
+
 ### MCP + Platform Workers (`fantasy-mcp`, `espn-client`, `yahoo-client`, `sleeper-client`)
 
 ```

--- a/workers/README.md
+++ b/workers/README.md
@@ -68,6 +68,7 @@ SUPABASE_URL=https://xxx.supabase.co
 SUPABASE_SERVICE_KEY=sb_secret_...
 ENVIRONMENT=prod|preview|dev
 NODE_ENV=production|development
+OAUTH_CLIENT_REGISTRATION_SIGNING_KEY=optional-stable-secret
 ```
 
 ### MCP + Platform Workers (`fantasy-mcp`, `espn-client`, `yahoo-client`, `sleeper-client`)

--- a/workers/auth-worker/README.md
+++ b/workers/auth-worker/README.md
@@ -46,6 +46,8 @@ MCP OAuth token lifetime:
 - Refresh-token inactivity window defaults to 1 year (`31536000` seconds) and can be overridden with `OAUTH_REFRESH_TOKEN_TTL_SECONDS` (clamped to 1 hour minimum, 1 year maximum).
 - This provider-side MCP OAuth flow is separate from the downstream Yahoo OAuth token chain.
 
+Dynamic client registration supports both public PKCE clients (`token_endpoint_auth_method: none`) and confidential clients that request or require `client_secret_post`. Confidential registrations receive a generated `client_secret`; token and refresh exchanges validate that secret and bind confidential authorization codes and refresh tokens to the registered client without storing plaintext client secrets. Confidential client IDs are stateless and HMAC-signed with `OAUTH_CLIENT_REGISTRATION_SIGNING_KEY` when set, otherwise `SUPABASE_SERVICE_KEY`.
+
 ### Yahoo Connect (Flaim → Yahoo)
 
 These endpoints manage the OAuth 2.0 client flow with Yahoo Fantasy.
@@ -196,6 +198,8 @@ wrangler secret put SUPABASE_URL --env preview
 wrangler secret put SUPABASE_SERVICE_KEY --env preview
 wrangler secret put YAHOO_CLIENT_ID --env preview
 wrangler secret put YAHOO_CLIENT_SECRET --env preview
+# Optional: if set, keep stable because it signs confidential MCP client IDs
+wrangler secret put OAUTH_CLIENT_REGISTRATION_SIGNING_KEY --env preview
 # Eval API key (optional — for headless eval/CI)
 wrangler secret put EVAL_API_KEY --env preview
 wrangler secret put EVAL_USER_ID --env preview
@@ -209,6 +213,8 @@ SUPABASE_URL=https://your-project-ref.supabase.co
 SUPABASE_SERVICE_KEY=your-service-role-key
 YAHOO_CLIENT_ID=your-yahoo-client-id
 YAHOO_CLIENT_SECRET=your-yahoo-client-secret
+# Optional; defaults to SUPABASE_SERVICE_KEY
+OAUTH_CLIENT_REGISTRATION_SIGNING_KEY=your-stable-signing-key
 ```
 
 ## Development

--- a/workers/auth-worker/README.md
+++ b/workers/auth-worker/README.md
@@ -46,7 +46,7 @@ MCP OAuth token lifetime:
 - Refresh-token inactivity window defaults to 1 year (`31536000` seconds) and can be overridden with `OAUTH_REFRESH_TOKEN_TTL_SECONDS` (clamped to 1 hour minimum, 1 year maximum).
 - This provider-side MCP OAuth flow is separate from the downstream Yahoo OAuth token chain.
 
-Dynamic client registration supports both public PKCE clients (`token_endpoint_auth_method: none`) and confidential clients that request or require `client_secret_post`. Confidential registrations receive a generated `client_secret`; token and refresh exchanges validate that secret and bind confidential authorization codes and refresh tokens to the registered client without storing plaintext client secrets. Confidential client IDs are stateless and HMAC-signed with `OAUTH_CLIENT_REGISTRATION_SIGNING_KEY` when set, otherwise `SUPABASE_SERVICE_KEY`.
+Dynamic client registration supports both public PKCE clients (`token_endpoint_auth_method: none`) and confidential clients that request or require `client_secret_post`. Confidential registrations receive a generated `client_secret`; token and refresh exchanges validate that secret and bind confidential authorization codes and refresh tokens to the registered client without storing plaintext client secrets. Confidential client IDs are stateless and HMAC-signed with `OAUTH_CLIENT_REGISTRATION_SIGNING_KEY` when set. A fallback to `SUPABASE_SERVICE_KEY` exists so existing environments keep working, but production and preview should use a dedicated stable signing key to avoid coupling client validity to Supabase service-key rotation.
 
 ### Yahoo Connect (Flaim → Yahoo)
 

--- a/workers/auth-worker/README.md
+++ b/workers/auth-worker/README.md
@@ -46,7 +46,9 @@ MCP OAuth token lifetime:
 - Refresh-token inactivity window defaults to 1 year (`31536000` seconds) and can be overridden with `OAUTH_REFRESH_TOKEN_TTL_SECONDS` (clamped to 1 hour minimum, 1 year maximum).
 - This provider-side MCP OAuth flow is separate from the downstream Yahoo OAuth token chain.
 
-Dynamic client registration supports both public PKCE clients (`token_endpoint_auth_method: none`) and confidential clients that request or require `client_secret_post`. Confidential registrations receive a generated `client_secret`; token and refresh exchanges validate that secret and bind confidential authorization codes and refresh tokens to the registered client without storing plaintext client secrets. Confidential client IDs are stateless and HMAC-signed with `OAUTH_CLIENT_REGISTRATION_SIGNING_KEY` when set. A fallback to `SUPABASE_SERVICE_KEY` exists so existing environments keep working, but production and preview should use a dedicated stable signing key to avoid coupling client validity to Supabase service-key rotation.
+Dynamic client registration supports both public PKCE clients (`token_endpoint_auth_method: none`) and confidential clients that request or require `client_secret_post`. Confidential registrations receive a generated `client_secret`; token and refresh exchanges validate that secret and bind confidential authorization codes and refresh tokens to the registered client without storing plaintext client secrets. Confidential client IDs are stateless and HMAC-signed with `OAUTH_CLIENT_REGISTRATION_SIGNING_KEY` when set.
+
+Set a dedicated, stable `OAUTH_CLIENT_REGISTRATION_SIGNING_KEY` in preview and production before relying on confidential MCP clients such as Perplexity. If it is absent, the worker falls back to `SUPABASE_SERVICE_KEY` for compatibility. That fallback keeps deployments running, but rotating the Supabase service key will invalidate existing confidential client registrations and surface as `invalid_client` until those clients reconnect.
 
 ### Yahoo Connect (Flaim → Yahoo)
 
@@ -213,7 +215,8 @@ SUPABASE_URL=https://your-project-ref.supabase.co
 SUPABASE_SERVICE_KEY=your-service-role-key
 YAHOO_CLIENT_ID=your-yahoo-client-id
 YAHOO_CLIENT_SECRET=your-yahoo-client-secret
-# Optional; defaults to SUPABASE_SERVICE_KEY
+# Optional; defaults to SUPABASE_SERVICE_KEY, but use a dedicated stable value
+# in shared environments so Supabase key rotation does not invalidate clients.
 OAUTH_CLIENT_REGISTRATION_SIGNING_KEY=your-stable-signing-key
 ```
 

--- a/workers/auth-worker/src/__tests__/oauth-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/oauth-handlers.test.ts
@@ -394,6 +394,42 @@ describe('oauth-handlers', () => {
     expect(body.expires_in).toBeGreaterThan(0);
   });
 
+  it('ignores client_secret on public authorization_code exchange', async () => {
+    const expiresAt = new Date(Date.now() + 60 * 60 * 1000);
+    const exchangeCodeForToken = vi.fn().mockResolvedValue({
+      accessToken: 'access-token',
+      scope: 'mcp:read',
+      expiresAt,
+      refreshToken: 'refresh-token',
+    });
+    vi.spyOn(OAuthStorage, 'fromEnvironment').mockReturnValue({
+      exchangeCodeForToken,
+    } as unknown as OAuthStorage);
+
+    const req = new Request('https://api.flaim.app/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'authorization_code',
+        code: 'public-code',
+        redirect_uri: 'https://claude.ai/api/mcp/auth_callback',
+        code_verifier: 'verifier',
+        client_id: 'mcp_public-client',
+        client_secret: 'ignored-public-secret',
+      }),
+    });
+
+    const res = await handleToken(req, env, corsHeaders);
+
+    expect(res.status).toBe(200);
+    expect(exchangeCodeForToken).toHaveBeenCalledWith(
+      'public-code',
+      'https://claude.ai/api/mcp/auth_callback',
+      'verifier',
+      undefined
+    );
+  });
+
   it('accepts authorization_code exchange for valid confidential client_secret', async () => {
     const client = await registerConfidentialClient();
     const authCode = createClientBoundToken('mcp_ac', client.client_id, 'test-code');

--- a/workers/auth-worker/src/__tests__/oauth-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/oauth-handlers.test.ts
@@ -111,6 +111,24 @@ describe('oauth-handlers', () => {
     expect(body.client_secret).toBeUndefined();
   });
 
+  it('does not infer Perplexity confidential mode from client_name alone', async () => {
+    const res = await handleClientRegistration(buildRegisterRequest({
+      client_name: 'Perplexity',
+    }), env, corsHeaders);
+
+    expect(res.status).toBe(201);
+    const body = await res.json() as {
+      client_id?: string;
+      client_secret?: string;
+      token_endpoint_auth_method?: string;
+    };
+
+    expect(body.client_id).toMatch(/^mcp_/);
+    expect(body.client_id).not.toMatch(/^mcp_conf_/);
+    expect(body.token_endpoint_auth_method).toBe('none');
+    expect(body.client_secret).toBeUndefined();
+  });
+
   it('returns a real client_secret for explicit client_secret_post DCR clients', async () => {
     const body = await registerConfidentialClient();
 
@@ -465,6 +483,35 @@ describe('oauth-handlers', () => {
     expect(exchangeCodeForToken).not.toHaveBeenCalled();
   });
 
+  it('rejects confidential client credentials for an unbound public authorization code', async () => {
+    const client = await registerConfidentialClient();
+    const exchangeCodeForToken = vi.fn();
+    vi.spyOn(OAuthStorage, 'fromEnvironment').mockReturnValue({
+      exchangeCodeForToken,
+    } as unknown as OAuthStorage);
+
+    const req = new Request('https://api.flaim.app/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'authorization_code',
+        code: 'public-code',
+        redirect_uri: 'https://claude.ai/api/mcp/auth_callback',
+        code_verifier: 'verifier',
+        client_id: client.client_id,
+        client_secret: client.client_secret,
+      }),
+    });
+
+    const res = await handleToken(req, env, corsHeaders);
+    const body = await res.json() as { error?: string; error_description?: string };
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe('invalid_client');
+    expect(body.error_description).toContain('client-bound authorization codes');
+    expect(exchangeCodeForToken).not.toHaveBeenCalled();
+  });
+
   it('rejects unsigned confidential client_id values', async () => {
     const fakeClientId = buildUnsignedConfidentialClientId();
     const authCode = createClientBoundToken('mcp_ac', fakeClientId, 'test-code');
@@ -578,6 +625,33 @@ describe('oauth-handlers', () => {
 
     expect(res.status).toBe(401);
     expect(body.error).toBe('invalid_client');
+    expect(refreshAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('rejects confidential client credentials for an unbound public refresh token', async () => {
+    const client = await registerConfidentialClient();
+    const refreshAccessToken = vi.fn();
+    vi.spyOn(OAuthStorage, 'fromEnvironment').mockReturnValue({
+      refreshAccessToken,
+    } as unknown as OAuthStorage);
+
+    const req = new Request('https://api.flaim.app/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'refresh_token',
+        refresh_token: 'public-refresh-token',
+        client_id: client.client_id,
+        client_secret: client.client_secret,
+      }),
+    });
+
+    const res = await handleToken(req, env, corsHeaders);
+    const body = await res.json() as { error?: string; error_description?: string };
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe('invalid_client');
+    expect(body.error_description).toContain('client-bound authorization codes');
     expect(refreshAccessToken).not.toHaveBeenCalled();
   });
 

--- a/workers/auth-worker/src/__tests__/oauth-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/oauth-handlers.test.ts
@@ -432,6 +432,76 @@ describe('oauth-handlers', () => {
     );
   });
 
+  it('accepts fallback-signed confidential clients while SUPABASE_SERVICE_KEY is unchanged', async () => {
+    const client = await registerConfidentialClient();
+    const authCode = createClientBoundToken('mcp_ac', client.client_id, 'test-code');
+    const expiresAt = new Date(Date.now() + 60 * 60 * 1000);
+    const exchangeCodeForToken = vi.fn().mockResolvedValue({
+      accessToken: 'access-token',
+      scope: 'mcp:read',
+      expiresAt,
+      refreshToken: 'refresh-token',
+    });
+    vi.spyOn(OAuthStorage, 'fromEnvironment').mockReturnValue({
+      exchangeCodeForToken,
+    } as unknown as OAuthStorage);
+
+    const req = new Request('https://api.flaim.app/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'authorization_code',
+        code: authCode,
+        redirect_uri: 'https://claude.ai/api/mcp/auth_callback',
+        code_verifier: 'verifier',
+        client_id: client.client_id,
+        client_secret: client.client_secret,
+      }),
+    });
+
+    const res = await handleToken(req, env, corsHeaders);
+
+    expect(res.status).toBe(200);
+    expect(exchangeCodeForToken).toHaveBeenCalledWith(
+      authCode,
+      'https://claude.ai/api/mcp/auth_callback',
+      'verifier',
+      client.client_id
+    );
+  });
+
+  it('rejects fallback-signed confidential clients after SUPABASE_SERVICE_KEY rotation', async () => {
+    const client = await registerConfidentialClient();
+    const authCode = createClientBoundToken('mcp_ac', client.client_id, 'test-code');
+    const exchangeCodeForToken = vi.fn();
+    vi.spyOn(OAuthStorage, 'fromEnvironment').mockReturnValue({
+      exchangeCodeForToken,
+    } as unknown as OAuthStorage);
+
+    const req = new Request('https://api.flaim.app/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'authorization_code',
+        code: authCode,
+        redirect_uri: 'https://claude.ai/api/mcp/auth_callback',
+        code_verifier: 'verifier',
+        client_id: client.client_id,
+        client_secret: client.client_secret,
+      }),
+    });
+
+    const res = await handleToken(req, {
+      ...env,
+      SUPABASE_SERVICE_KEY: 'rotated-test-key',
+    }, corsHeaders);
+    const body = await res.json() as { error?: string };
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe('invalid_client');
+    expect(exchangeCodeForToken).not.toHaveBeenCalled();
+  });
+
   it('rejects authorization_code exchange for missing confidential client_secret', async () => {
     const client = await registerConfidentialClient();
     const authCode = createClientBoundToken('mcp_ac', client.client_id, 'test-code');
@@ -544,7 +614,7 @@ describe('oauth-handlers', () => {
 
     expect(res.status).toBe(401);
     expect(body.error).toBe('invalid_client');
-    expect(body.error_description).toContain('client-bound authorization codes');
+    expect(body.error_description).toBe('confidential clients must use client-bound authorization codes');
     expect(exchangeCodeForToken).not.toHaveBeenCalled();
   });
 
@@ -687,7 +757,7 @@ describe('oauth-handlers', () => {
 
     expect(res.status).toBe(401);
     expect(body.error).toBe('invalid_client');
-    expect(body.error_description).toContain('client-bound authorization codes');
+    expect(body.error_description).toBe('confidential clients must use client-bound refresh tokens');
     expect(refreshAccessToken).not.toHaveBeenCalled();
   });
 

--- a/workers/auth-worker/src/__tests__/oauth-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/oauth-handlers.test.ts
@@ -209,7 +209,8 @@ describe('oauth-handlers', () => {
     expect(exchangeCodeForToken).toHaveBeenCalledWith(
       'test-code',
       'https://claude.ai/api/mcp/auth_callback',
-      'verifier'
+      'verifier',
+      undefined
     );
   });
 
@@ -604,7 +605,7 @@ describe('oauth-handlers', () => {
     const res = await handleToken(req, env, corsHeaders);
 
     expect(res.status).toBe(200);
-    expect(refreshAccessToken).toHaveBeenCalledWith('public-refresh-token');
+    expect(refreshAccessToken).toHaveBeenCalledWith('public-refresh-token', undefined);
   });
 
   it('returns invalid_grant when refresh token is expired', async () => {
@@ -628,7 +629,7 @@ describe('oauth-handlers', () => {
     const body = await res.json() as { error?: string; error_description?: string };
     expect(body.error).toBe('invalid_grant');
     expect(body.error_description).toBe('Invalid or expired refresh token');
-    expect(refreshAccessToken).toHaveBeenCalledWith('expired-refresh-token');
+    expect(refreshAccessToken).toHaveBeenCalledWith('expired-refresh-token', undefined);
   });
 
   it('reports active connection when access token expired but refresh token is still valid', async () => {

--- a/workers/auth-worker/src/__tests__/oauth-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/oauth-handlers.test.ts
@@ -10,6 +10,7 @@ import { isValidRedirectUri } from '@flaim/worker-shared';
 import { handleToken } from '../oauth-handlers';
 import { OAuthStorage } from '../oauth-storage';
 import type { OAuthEnv } from '../oauth-handlers';
+import { createClientBoundToken, isConfidentialClientId } from '../oauth-client-auth';
 
 const env: OAuthEnv = {
   SUPABASE_URL: 'https://example.supabase.co',
@@ -21,15 +22,33 @@ const env: OAuthEnv = {
 const corsHeaders = {};
 const cursorRedirectUri = 'cursor://anysphere.cursor-mcp/oauth/abc123/callback';
 
-function buildRegisterRequest(): Request {
+function buildRegisterRequest(body: Record<string, unknown> = {}): Request {
   return new Request('https://api.flaim.app/auth/register', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       redirect_uris: ['https://claude.ai/api/mcp/auth_callback'],
       client_name: 'Test Client',
+      ...body,
     }),
   });
+}
+
+async function registerConfidentialClient(body: Record<string, unknown> = {}) {
+  const res = await handleClientRegistration(buildRegisterRequest({
+    token_endpoint_auth_method: 'client_secret_post',
+    ...body,
+  }), env, corsHeaders);
+  expect(res.status).toBe(201);
+  return await res.json() as {
+    client_id: string;
+    client_secret: string;
+    token_endpoint_auth_method: string;
+  };
+}
+
+function buildUnsignedConfidentialClientId(): string {
+  return `mcp_conf_${'a'.repeat(22)}.${'b'.repeat(43)}.${'c'.repeat(43)}`;
 }
 
 function expectRedirectLocation(response: Response): URL {
@@ -57,6 +76,86 @@ describe('oauth-handlers', () => {
     expect(body1.client_id).toMatch(/^mcp_/);
     expect(body2.client_id).toMatch(/^mcp_/);
     expect(body1.client_id).not.toBe(body2.client_id);
+  });
+
+  it('keeps public DCR clients public without a client_secret', async () => {
+    const res = await handleClientRegistration(buildRegisterRequest({
+      token_endpoint_auth_method: 'none',
+    }), env, corsHeaders);
+
+    expect(res.status).toBe(201);
+    const body = await res.json() as {
+      client_id?: string;
+      client_secret?: string;
+      token_endpoint_auth_method?: string;
+    };
+
+    expect(body.client_id).toMatch(/^mcp_/);
+    expect(body.token_endpoint_auth_method).toBe('none');
+    expect(body.client_secret).toBeUndefined();
+  });
+
+  it('keeps omitted non-Perplexity DCR clients public', async () => {
+    const res = await handleClientRegistration(buildRegisterRequest(), env, corsHeaders);
+
+    expect(res.status).toBe(201);
+    const body = await res.json() as {
+      client_id?: string;
+      client_secret?: string;
+      token_endpoint_auth_method?: string;
+    };
+
+    expect(body.client_id).toMatch(/^mcp_/);
+    expect(body.client_id).not.toMatch(/^mcp_conf_/);
+    expect(body.token_endpoint_auth_method).toBe('none');
+    expect(body.client_secret).toBeUndefined();
+  });
+
+  it('returns a real client_secret for explicit client_secret_post DCR clients', async () => {
+    const body = await registerConfidentialClient();
+
+    expect(body.client_id).toMatch(/^mcp_conf_/);
+    expect(isConfidentialClientId(body.client_id)).toBe(true);
+    expect(body.client_secret).toMatch(/^mcp_secret_/);
+    expect(body.token_endpoint_auth_method).toBe('client_secret_post');
+  });
+
+  it('respects explicit public auth method for Perplexity DCR clients', async () => {
+    const res = await handleClientRegistration(buildRegisterRequest({
+      redirect_uris: ['https://www.perplexity.ai/rest/connections/oauth_callback'],
+      client_name: 'Perplexity',
+      token_endpoint_auth_method: 'none',
+    }), env, corsHeaders);
+
+    expect(res.status).toBe(201);
+    const body = await res.json() as {
+      client_id?: string;
+      client_secret?: string;
+      token_endpoint_auth_method?: string;
+    };
+
+    expect(body.client_id).toMatch(/^mcp_/);
+    expect(body.client_id).not.toMatch(/^mcp_conf_/);
+    expect(body.client_secret).toBeUndefined();
+    expect(body.token_endpoint_auth_method).toBe('none');
+  });
+
+  it('returns a client_secret for Perplexity DCR when auth method is omitted', async () => {
+    const res = await handleClientRegistration(buildRegisterRequest({
+      redirect_uris: ['https://www.perplexity.ai/rest/connections/oauth_callback'],
+      client_name: 'Perplexity',
+    }), env, corsHeaders);
+
+    expect(res.status).toBe(201);
+    const body = await res.json() as {
+      client_id?: string;
+      client_secret?: string;
+      token_endpoint_auth_method?: string;
+    };
+
+    expect(body.client_id).toMatch(/^mcp_conf_/);
+    expect(body.client_secret).toMatch(/^mcp_secret_/);
+    expect(body.token_endpoint_auth_method).toBe('client_secret_post');
   });
 
   it('requires PKCE code_challenge for /authorize', async () => {
@@ -238,6 +337,274 @@ describe('oauth-handlers', () => {
     expect(body.refresh_token).toBe('refresh-token');
     expect(typeof body.expires_in).toBe('number');
     expect(body.expires_in).toBeGreaterThan(0);
+  });
+
+  it('accepts authorization_code exchange for valid confidential client_secret', async () => {
+    const client = await registerConfidentialClient();
+    const authCode = createClientBoundToken('mcp_ac', client.client_id, 'test-code');
+    const expiresAt = new Date(Date.now() + 60 * 60 * 1000);
+    const exchangeCodeForToken = vi.fn().mockResolvedValue({
+      accessToken: 'access-token',
+      scope: 'mcp:read',
+      expiresAt,
+      refreshToken: 'refresh-token',
+    });
+    vi.spyOn(OAuthStorage, 'fromEnvironment').mockReturnValue({
+      exchangeCodeForToken,
+    } as unknown as OAuthStorage);
+
+    const req = new Request('https://api.flaim.app/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'authorization_code',
+        code: authCode,
+        redirect_uri: 'https://claude.ai/api/mcp/auth_callback',
+        code_verifier: 'verifier',
+        client_id: client.client_id,
+        client_secret: client.client_secret,
+      }),
+    });
+
+    const res = await handleToken(req, env, corsHeaders);
+
+    expect(res.status).toBe(200);
+    expect(exchangeCodeForToken).toHaveBeenCalledWith(
+      authCode,
+      'https://claude.ai/api/mcp/auth_callback',
+      'verifier',
+      client.client_id
+    );
+  });
+
+  it('rejects authorization_code exchange for missing confidential client_secret', async () => {
+    const client = await registerConfidentialClient();
+    const authCode = createClientBoundToken('mcp_ac', client.client_id, 'test-code');
+    const exchangeCodeForToken = vi.fn();
+    vi.spyOn(OAuthStorage, 'fromEnvironment').mockReturnValue({
+      exchangeCodeForToken,
+    } as unknown as OAuthStorage);
+
+    const req = new Request('https://api.flaim.app/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'authorization_code',
+        code: authCode,
+        redirect_uri: 'https://claude.ai/api/mcp/auth_callback',
+        code_verifier: 'verifier',
+        client_id: client.client_id,
+      }),
+    });
+
+    const res = await handleToken(req, env, corsHeaders);
+    const body = await res.json() as { error?: string };
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe('invalid_client');
+    expect(exchangeCodeForToken).not.toHaveBeenCalled();
+  });
+
+  it('rejects authorization_code exchange for invalid confidential client_secret', async () => {
+    const client = await registerConfidentialClient();
+    const authCode = createClientBoundToken('mcp_ac', client.client_id, 'test-code');
+    const exchangeCodeForToken = vi.fn();
+    vi.spyOn(OAuthStorage, 'fromEnvironment').mockReturnValue({
+      exchangeCodeForToken,
+    } as unknown as OAuthStorage);
+
+    const req = new Request('https://api.flaim.app/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'authorization_code',
+        code: authCode,
+        redirect_uri: 'https://claude.ai/api/mcp/auth_callback',
+        code_verifier: 'verifier',
+        client_id: client.client_id,
+        client_secret: 'wrong-secret',
+      }),
+    });
+
+    const res = await handleToken(req, env, corsHeaders);
+    const body = await res.json() as { error?: string };
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe('invalid_client');
+    expect(exchangeCodeForToken).not.toHaveBeenCalled();
+  });
+
+  it('rejects authorization_code exchange when bound client_id does not match', async () => {
+    const client = await registerConfidentialClient();
+    const otherClient = await registerConfidentialClient();
+    const authCode = createClientBoundToken('mcp_ac', client.client_id, 'test-code');
+    const exchangeCodeForToken = vi.fn();
+    vi.spyOn(OAuthStorage, 'fromEnvironment').mockReturnValue({
+      exchangeCodeForToken,
+    } as unknown as OAuthStorage);
+
+    const req = new Request('https://api.flaim.app/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'authorization_code',
+        code: authCode,
+        redirect_uri: 'https://claude.ai/api/mcp/auth_callback',
+        code_verifier: 'verifier',
+        client_id: otherClient.client_id,
+        client_secret: otherClient.client_secret,
+      }),
+    });
+
+    const res = await handleToken(req, env, corsHeaders);
+    const body = await res.json() as { error?: string };
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe('invalid_client');
+    expect(exchangeCodeForToken).not.toHaveBeenCalled();
+  });
+
+  it('rejects unsigned confidential client_id values', async () => {
+    const fakeClientId = buildUnsignedConfidentialClientId();
+    const authCode = createClientBoundToken('mcp_ac', fakeClientId, 'test-code');
+    const exchangeCodeForToken = vi.fn();
+    vi.spyOn(OAuthStorage, 'fromEnvironment').mockReturnValue({
+      exchangeCodeForToken,
+    } as unknown as OAuthStorage);
+
+    const req = new Request('https://api.flaim.app/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'authorization_code',
+        code: authCode,
+        redirect_uri: 'https://claude.ai/api/mcp/auth_callback',
+        code_verifier: 'verifier',
+        client_id: fakeClientId,
+        client_secret: 'mcp_secret_fake',
+      }),
+    });
+
+    const res = await handleToken(req, env, corsHeaders);
+    const body = await res.json() as { error?: string };
+
+    expect(isConfidentialClientId(fakeClientId)).toBe(true);
+    expect(res.status).toBe(401);
+    expect(body.error).toBe('invalid_client');
+    expect(exchangeCodeForToken).not.toHaveBeenCalled();
+  });
+
+  it('accepts refresh_token grant for valid confidential client_secret', async () => {
+    const client = await registerConfidentialClient();
+    const refreshToken = createClientBoundToken('mcp_rt', client.client_id, 'refresh-token');
+    const expiresAt = new Date(Date.now() + 60 * 60 * 1000);
+    const refreshAccessToken = vi.fn().mockResolvedValue({
+      accessToken: 'new-access-token',
+      scope: 'mcp:read',
+      expiresAt,
+      refreshToken: 'new-refresh-token',
+    });
+    vi.spyOn(OAuthStorage, 'fromEnvironment').mockReturnValue({
+      refreshAccessToken,
+    } as unknown as OAuthStorage);
+
+    const req = new Request('https://api.flaim.app/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+        client_id: client.client_id,
+        client_secret: client.client_secret,
+      }),
+    });
+
+    const res = await handleToken(req, env, corsHeaders);
+
+    expect(res.status).toBe(200);
+    expect(refreshAccessToken).toHaveBeenCalledWith(refreshToken, client.client_id);
+  });
+
+  it('rejects refresh_token grant for invalid confidential client_secret', async () => {
+    const client = await registerConfidentialClient();
+    const refreshToken = createClientBoundToken('mcp_rt', client.client_id, 'refresh-token');
+    const refreshAccessToken = vi.fn();
+    vi.spyOn(OAuthStorage, 'fromEnvironment').mockReturnValue({
+      refreshAccessToken,
+    } as unknown as OAuthStorage);
+
+    const req = new Request('https://api.flaim.app/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+        client_id: client.client_id,
+        client_secret: 'wrong-secret',
+      }),
+    });
+
+    const res = await handleToken(req, env, corsHeaders);
+    const body = await res.json() as { error?: string };
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe('invalid_client');
+    expect(refreshAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('rejects refresh_token grant when bound client_id does not match', async () => {
+    const client = await registerConfidentialClient();
+    const otherClient = await registerConfidentialClient();
+    const refreshToken = createClientBoundToken('mcp_rt', client.client_id, 'refresh-token');
+    const refreshAccessToken = vi.fn();
+    vi.spyOn(OAuthStorage, 'fromEnvironment').mockReturnValue({
+      refreshAccessToken,
+    } as unknown as OAuthStorage);
+
+    const req = new Request('https://api.flaim.app/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+        client_id: otherClient.client_id,
+        client_secret: otherClient.client_secret,
+      }),
+    });
+
+    const res = await handleToken(req, env, corsHeaders);
+    const body = await res.json() as { error?: string };
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe('invalid_client');
+    expect(refreshAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('keeps public refresh_token grant usable without client_secret', async () => {
+    const expiresAt = new Date(Date.now() + 60 * 60 * 1000);
+    const refreshAccessToken = vi.fn().mockResolvedValue({
+      accessToken: 'new-access-token',
+      scope: 'mcp:read',
+      expiresAt,
+      refreshToken: 'new-refresh-token',
+    });
+    vi.spyOn(OAuthStorage, 'fromEnvironment').mockReturnValue({
+      refreshAccessToken,
+    } as unknown as OAuthStorage);
+
+    const req = new Request('https://api.flaim.app/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'refresh_token',
+        refresh_token: 'public-refresh-token',
+      }),
+    });
+
+    const res = await handleToken(req, env, corsHeaders);
+
+    expect(res.status).toBe(200);
+    expect(refreshAccessToken).toHaveBeenCalledWith('public-refresh-token');
   });
 
   it('returns invalid_grant when refresh token is expired', async () => {

--- a/workers/auth-worker/src/__tests__/oauth-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/oauth-handlers.test.ts
@@ -3,6 +3,7 @@ import {
   handleAuthorize,
   handleCheckStatus,
   handleClientRegistration,
+  handleCreateCode,
   handleMetadataDiscovery,
   validateOAuthToken,
 } from '../oauth-handlers';
@@ -309,6 +310,41 @@ describe('oauth-handlers', () => {
     expect(redirect.pathname).toBe('/oauth/abc123/callback');
     expect(redirect.searchParams.get('error')).toBe('invalid_request');
     expect(redirect.searchParams.get('error_description')).toBe('Only S256 PKCE is supported');
+  });
+
+  it('passes confidential client_id through /oauth/code into authorization-code storage', async () => {
+    const client = await registerConfidentialClient();
+    const createAuthorizationCode = vi.fn().mockResolvedValue('auth-code');
+    vi.spyOn(OAuthStorage, 'fromEnvironment').mockReturnValue({
+      createAuthorizationCode,
+    } as unknown as OAuthStorage);
+
+    const req = new Request('https://api.flaim.app/oauth/code', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        redirect_uri: 'https://www.perplexity.ai/rest/connections/oauth_callback',
+        scope: 'mcp:read',
+        client_id: client.client_id,
+        code_challenge: 'challenge',
+        code_challenge_method: 'S256',
+      }),
+    });
+
+    const res = await handleCreateCode(req, env, 'user_123', corsHeaders);
+    const body = await res.json() as { success?: boolean; code?: string };
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.code).toBe('auth-code');
+    expect(createAuthorizationCode).toHaveBeenCalledWith(expect.objectContaining({
+      userId: 'user_123',
+      redirectUri: 'https://www.perplexity.ai/rest/connections/oauth_callback',
+      clientId: client.client_id,
+      scope: 'mcp:read',
+      codeChallenge: 'challenge',
+      codeChallengeMethod: 'S256',
+    }));
   });
 
   it('authorization server metadata advertises S256 only', async () => {

--- a/workers/auth-worker/src/__tests__/oauth-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/oauth-storage.test.ts
@@ -270,6 +270,39 @@ describe('OAuthStorage MCP token lifetimes', () => {
     expect(insertPayloads[0].refresh_token).toBe(token?.refreshToken);
   });
 
+  it('rejects confidential authorization code exchange when client binding mismatches', async () => {
+    const client = await createConfidentialClientRegistration(clientSigningKey);
+    const otherClient = await createConfidentialClientRegistration(clientSigningKey);
+    const code = createClientBoundToken('mcp_ac', client.clientId, 'auth-code');
+    const redirectUri = 'https://www.perplexity.ai/rest/connections/oauth_callback';
+    const single = vi.fn().mockResolvedValue({
+      data: {
+        code,
+        user_id: 'user_123',
+        redirect_uri: redirectUri,
+        code_challenge: null,
+        code_challenge_method: null,
+        scope: 'mcp:read',
+        resource: null,
+        expires_at: new Date(Date.now() + 60_000).toISOString(),
+      },
+      error: null,
+    });
+    const select = vi.fn().mockReturnValue({ single });
+    const gt = vi.fn().mockReturnValue({ select });
+    const is = vi.fn().mockReturnValue({ gt });
+    const eq = vi.fn().mockReturnValue({ is });
+    const update = vi.fn().mockReturnValue({ eq });
+    const insert = vi.fn();
+    mockFrom.mockReturnValue({ update, insert });
+    const storage = new OAuthStorage('https://example.supabase.co', 'test-key');
+
+    const token = await storage.exchangeCodeForToken(code, redirectUri, undefined, otherClient.clientId);
+
+    expect(token).toBeNull();
+    expect(insert).not.toHaveBeenCalled();
+  });
+
   it('rejects expired refresh tokens', async () => {
     buildTableMock({
       lookupRow: {

--- a/workers/auth-worker/src/__tests__/oauth-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/oauth-storage.test.ts
@@ -5,8 +5,14 @@ import {
   MIN_OAUTH_REFRESH_TOKEN_TTL_SECONDS,
   OAuthStorage,
 } from '../oauth-storage';
+import {
+  createClientBoundToken,
+  createConfidentialClientRegistration,
+  getClientIdFromBoundToken,
+} from '../oauth-client-auth';
 
 const mockFrom = vi.fn();
+const clientSigningKey = 'test-key';
 
 vi.mock('@supabase/supabase-js', () => ({
   createClient: () => ({
@@ -130,6 +136,37 @@ describe('OAuthStorage MCP token lifetimes', () => {
     expect(refreshTokenExpiresAt).toBeLessThanOrEqual(after + 1209600 * 1000 + 1000);
   });
 
+  it('marks confidential authorization codes with the client binding', async () => {
+    const { insertPayloads } = buildTableMock();
+    const client = await createConfidentialClientRegistration(clientSigningKey);
+    const storage = new OAuthStorage('https://example.supabase.co', 'test-key');
+
+    const code = await storage.createAuthorizationCode({
+      userId: 'user_123',
+      redirectUri: 'https://www.perplexity.ai/rest/connections/oauth_callback',
+      clientId: client.clientId,
+    });
+
+    expect(getClientIdFromBoundToken('mcp_ac', code)).toBe(client.clientId);
+    expect(insertPayloads[0].code).toBe(code);
+  });
+
+  it('marks confidential refresh tokens with the client binding', async () => {
+    const { insertPayloads } = buildTableMock();
+    const client = await createConfidentialClientRegistration(clientSigningKey);
+    const storage = new OAuthStorage('https://example.supabase.co', 'test-key');
+
+    const token = await storage.createAccessToken({
+      userId: 'user_123',
+      includeRefreshToken: true,
+      clientId: client.clientId,
+    });
+
+    expect(token.refreshToken).toBeTruthy();
+    expect(getClientIdFromBoundToken('mcp_rt', token.refreshToken)).toBe(client.clientId);
+    expect(insertPayloads[0].refresh_token).toBe(token.refreshToken);
+  });
+
   it('caps oversized OAUTH_REFRESH_TOKEN_TTL_SECONDS env override at 1 year', async () => {
     const { insertPayloads } = buildTableMock();
     const storage = OAuthStorage.fromEnvironment({
@@ -207,6 +244,30 @@ describe('OAuthStorage MCP token lifetimes', () => {
     const refreshTokenExpiresAt = new Date(insertPayloads[0].refresh_token_expires_at as string).getTime();
     expect(refreshTokenExpiresAt).toBeGreaterThanOrEqual(before + 2592000 * 1000 - 1000);
     expect(refreshTokenExpiresAt).toBeLessThanOrEqual(after + 2592000 * 1000 + 1000);
+  });
+
+  it('refresh rotation preserves confidential client binding', async () => {
+    const client = await createConfidentialClientRegistration(clientSigningKey);
+    const refreshToken = createClientBoundToken('mcp_rt', client.clientId, 'old-refresh-token');
+    const { insertPayloads } = buildTableMock({
+      lookupRow: {
+        access_token: 'old-access-token',
+        refresh_token: refreshToken,
+        refresh_token_expires_at: new Date(Date.now() + 60_000).toISOString(),
+        revoked_at: null,
+        user_id: 'user_123',
+        scope: 'mcp:read',
+        client_name: 'Perplexity',
+      },
+      insertId: 'new-token-id',
+    });
+    const storage = new OAuthStorage('https://example.supabase.co', 'test-key');
+
+    const token = await storage.refreshAccessToken(refreshToken, client.clientId);
+
+    expect(token?.refreshToken).toBeTruthy();
+    expect(getClientIdFromBoundToken('mcp_rt', token?.refreshToken)).toBe(client.clientId);
+    expect(insertPayloads[0].refresh_token).toBe(token?.refreshToken);
   });
 
   it('rejects expired refresh tokens', async () => {

--- a/workers/auth-worker/src/__tests__/oauth-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/oauth-storage.test.ts
@@ -300,6 +300,7 @@ describe('OAuthStorage MCP token lifetimes', () => {
     const token = await storage.exchangeCodeForToken(code, redirectUri, undefined, otherClient.clientId);
 
     expect(token).toBeNull();
+    expect(update).not.toHaveBeenCalled();
     expect(insert).not.toHaveBeenCalled();
   });
 

--- a/workers/auth-worker/src/index-hono.ts
+++ b/workers/auth-worker/src/index-hono.ts
@@ -84,6 +84,7 @@ export interface Env {
   ENVIRONMENT?: string; // 'dev' | 'preview' | 'prod'
   FRONTEND_URL?: string;
   OAUTH_REFRESH_TOKEN_TTL_SECONDS?: string; // MCP OAuth refresh-token inactivity TTL
+  OAUTH_CLIENT_REGISTRATION_SIGNING_KEY?: string; // Optional stable signing key for confidential MCP DCR clients
   CLERK_ISSUER?: string; // Expected Clerk JWT issuer (e.g. "https://clerk.flaim.app")
   // Yahoo OAuth
   YAHOO_CLIENT_ID?: string;

--- a/workers/auth-worker/src/oauth-client-auth.ts
+++ b/workers/auth-worker/src/oauth-client-auth.ts
@@ -51,11 +51,18 @@ export async function validateConfidentialClientSecret(
     && timingSafeEqual(expectedSignature, parts.signature);
 }
 
+/**
+ * Prefixes an opaque auth code or refresh token with a confidential client
+ * binding. opaqueValue must be dot-free because "." is the token delimiter.
+ */
 export function createClientBoundToken(
   kind: ClientBoundTokenKind,
   clientId: string,
   opaqueValue: string
 ): string {
+  if (opaqueValue.includes('.')) {
+    throw new Error('Client-bound token opaqueValue must not contain "."');
+  }
   return `${kind}.${base64UrlEncodeText(clientId)}.${opaqueValue}`;
 }
 
@@ -145,6 +152,7 @@ function timingSafeEqual(actual: string, expected: string): boolean {
   const encoder = new TextEncoder();
   const actualBytes = encoder.encode(actual);
   const expectedBytes = encoder.encode(expected);
+  // All current callers compare fixed-length base64url SHA-256/HMAC outputs.
   if (actualBytes.length !== expectedBytes.length) {
     return false;
   }

--- a/workers/auth-worker/src/oauth-client-auth.ts
+++ b/workers/auth-worker/src/oauth-client-auth.ts
@@ -26,6 +26,10 @@ export async function createConfidentialClientRegistration(signingKey: string): 
   return { clientId, clientSecret };
 }
 
+/**
+ * Checks confidential client_id shape only. Use validateConfidentialClientSecret
+ * when the caller needs to verify the HMAC signature and matching secret.
+ */
 export function isConfidentialClientId(clientId?: string): clientId is string {
   return getConfidentialClientIdParts(clientId) !== null;
 }

--- a/workers/auth-worker/src/oauth-client-auth.ts
+++ b/workers/auth-worker/src/oauth-client-auth.ts
@@ -16,6 +16,8 @@ export function generateSecureToken(length: number = 32): string {
 
 export async function createConfidentialClientRegistration(signingKey: string): Promise<ConfidentialClientRegistration> {
   const clientSecret = `${CLIENT_SECRET_PREFIX}${generateSecureToken(32)}`;
+  // The secret hash is embedded in client_id for stateless validation. This is
+  // safe because clientSecret is 256 bits of random entropy, not user material.
   const clientSecretHash = await sha256Base64Url(clientSecret);
   const clientHandle = generateSecureToken(16);
   const signedPayload = `${clientHandle}.${clientSecretHash}`;

--- a/workers/auth-worker/src/oauth-client-auth.ts
+++ b/workers/auth-worker/src/oauth-client-auth.ts
@@ -11,12 +11,7 @@ export interface ConfidentialClientRegistration {
 export function generateSecureToken(length: number = 32): string {
   const bytes = new Uint8Array(length);
   crypto.getRandomValues(bytes);
-  let binary = '';
-  for (const byte of bytes) {
-    binary += String.fromCharCode(byte);
-  }
-  const base64 = btoa(binary);
-  return toBase64Url(base64);
+  return bytesToBase64Url(bytes);
 }
 
 export async function createConfidentialClientRegistration(signingKey: string): Promise<ConfidentialClientRegistration> {
@@ -134,8 +129,7 @@ async function sha256Base64Url(value: string): Promise<string> {
   const data = encoder.encode(value);
   const hashBuffer = await crypto.subtle.digest('SHA-256', data);
   const hashArray = new Uint8Array(hashBuffer);
-  const base64 = btoa(String.fromCharCode(...hashArray));
-  return toBase64Url(base64);
+  return bytesToBase64Url(hashArray);
 }
 
 async function hmacSha256Base64Url(value: string, key: string): Promise<string> {
@@ -149,8 +143,7 @@ async function hmacSha256Base64Url(value: string, key: string): Promise<string> 
   );
   const signature = await crypto.subtle.sign('HMAC', cryptoKey, encoder.encode(value));
   const signatureBytes = new Uint8Array(signature);
-  const base64 = btoa(String.fromCharCode(...signatureBytes));
-  return toBase64Url(base64);
+  return bytesToBase64Url(signatureBytes);
 }
 
 function timingSafeEqual(actual: string, expected: string): boolean {
@@ -191,6 +184,14 @@ function base64UrlDecodeText(value: string): string | undefined {
   } catch {
     return undefined;
   }
+}
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return toBase64Url(btoa(binary));
 }
 
 function toBase64Url(value: string): string {

--- a/workers/auth-worker/src/oauth-client-auth.ts
+++ b/workers/auth-worker/src/oauth-client-auth.ts
@@ -11,7 +11,11 @@ export interface ConfidentialClientRegistration {
 export function generateSecureToken(length: number = 32): string {
   const bytes = new Uint8Array(length);
   crypto.getRandomValues(bytes);
-  const base64 = btoa(String.fromCharCode(...bytes));
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  const base64 = btoa(binary);
   return toBase64Url(base64);
 }
 
@@ -74,6 +78,7 @@ export function getClientIdFromBoundToken(
     return undefined;
   }
 
+  // The client_id segment is base64url text and cannot contain ".".
   const parts = token.split('.');
   if (parts.length !== 3 || parts[0] !== kind || !parts[1] || !parts[2]) {
     return undefined;

--- a/workers/auth-worker/src/oauth-client-auth.ts
+++ b/workers/auth-worker/src/oauth-client-auth.ts
@@ -1,0 +1,187 @@
+const CONFIDENTIAL_CLIENT_ID_PREFIX = 'mcp_conf_';
+const CLIENT_SECRET_PREFIX = 'mcp_secret_';
+
+export type ClientBoundTokenKind = 'mcp_ac' | 'mcp_rt';
+
+export interface ConfidentialClientRegistration {
+  clientId: string;
+  clientSecret: string;
+}
+
+export function generateSecureToken(length: number = 32): string {
+  const bytes = new Uint8Array(length);
+  crypto.getRandomValues(bytes);
+  const base64 = btoa(String.fromCharCode(...bytes));
+  return toBase64Url(base64);
+}
+
+export async function createConfidentialClientRegistration(signingKey: string): Promise<ConfidentialClientRegistration> {
+  const clientSecret = `${CLIENT_SECRET_PREFIX}${generateSecureToken(32)}`;
+  const clientSecretHash = await sha256Base64Url(clientSecret);
+  const clientHandle = generateSecureToken(16);
+  const signedPayload = `${clientHandle}.${clientSecretHash}`;
+  const signature = await hmacSha256Base64Url(signedPayload, signingKey);
+  const clientId = `${CONFIDENTIAL_CLIENT_ID_PREFIX}${signedPayload}.${signature}`;
+
+  return { clientId, clientSecret };
+}
+
+export function isConfidentialClientId(clientId?: string): clientId is string {
+  return getConfidentialClientIdParts(clientId) !== null;
+}
+
+export async function validateConfidentialClientSecret(
+  clientId: string | undefined,
+  clientSecret: string | undefined,
+  signingKey: string
+): Promise<boolean> {
+  const parts = getConfidentialClientIdParts(clientId);
+  if (!parts || !clientSecret) {
+    return false;
+  }
+
+  const actualHash = await sha256Base64Url(clientSecret);
+  const expectedSignature = await hmacSha256Base64Url(parts.signedPayload, signingKey);
+
+  return timingSafeEqual(actualHash, parts.clientSecretHash)
+    && timingSafeEqual(expectedSignature, parts.signature);
+}
+
+export function createClientBoundToken(
+  kind: ClientBoundTokenKind,
+  clientId: string,
+  opaqueValue: string
+): string {
+  return `${kind}.${base64UrlEncodeText(clientId)}.${opaqueValue}`;
+}
+
+export function getClientIdFromBoundToken(
+  kind: ClientBoundTokenKind,
+  token?: string
+): string | undefined {
+  if (!token) {
+    return undefined;
+  }
+
+  const parts = token.split('.');
+  if (parts.length !== 3 || parts[0] !== kind || !parts[1] || !parts[2]) {
+    return undefined;
+  }
+
+  const clientId = base64UrlDecodeText(parts[1]);
+  if (!clientId || !isConfidentialClientId(clientId)) {
+    return undefined;
+  }
+
+  return clientId;
+}
+
+interface ConfidentialClientIdParts {
+  signedPayload: string;
+  clientSecretHash: string;
+  signature: string;
+}
+
+function getConfidentialClientIdParts(clientId?: string): ConfidentialClientIdParts | null {
+  if (!clientId?.startsWith(CONFIDENTIAL_CLIENT_ID_PREFIX)) {
+    return null;
+  }
+
+  const suffix = clientId.slice(CONFIDENTIAL_CLIENT_ID_PREFIX.length);
+  const parts = suffix.split('.');
+  if (parts.length !== 3) {
+    return null;
+  }
+
+  const [clientHandle, clientSecretHash, signature] = parts;
+  if (!/^[A-Za-z0-9_-]{22}$/.test(clientHandle)) {
+    return null;
+  }
+
+  if (!/^[A-Za-z0-9_-]{43}$/.test(clientSecretHash)) {
+    return null;
+  }
+
+  if (!/^[A-Za-z0-9_-]{43}$/.test(signature)) {
+    return null;
+  }
+
+  return {
+    signedPayload: `${clientHandle}.${clientSecretHash}`,
+    clientSecretHash,
+    signature,
+  };
+}
+
+async function sha256Base64Url(value: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(value);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  const hashArray = new Uint8Array(hashBuffer);
+  const base64 = btoa(String.fromCharCode(...hashArray));
+  return toBase64Url(base64);
+}
+
+async function hmacSha256Base64Url(value: string, key: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const cryptoKey = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(key),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const signature = await crypto.subtle.sign('HMAC', cryptoKey, encoder.encode(value));
+  const signatureBytes = new Uint8Array(signature);
+  const base64 = btoa(String.fromCharCode(...signatureBytes));
+  return toBase64Url(base64);
+}
+
+function timingSafeEqual(actual: string, expected: string): boolean {
+  const encoder = new TextEncoder();
+  const actualBytes = encoder.encode(actual);
+  const expectedBytes = encoder.encode(expected);
+  if (actualBytes.length !== expectedBytes.length) {
+    return false;
+  }
+
+  let result = 0;
+  for (let i = 0; i < actualBytes.length; i++) {
+    result |= actualBytes[i] ^ expectedBytes[i];
+  }
+
+  return result === 0;
+}
+
+function base64UrlEncodeText(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return toBase64Url(btoa(binary));
+}
+
+function base64UrlDecodeText(value: string): string | undefined {
+  try {
+    const padded = fromBase64Url(value);
+    const binary = atob(padded);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return new TextDecoder().decode(bytes);
+  } catch {
+    return undefined;
+  }
+}
+
+function toBase64Url(value: string): string {
+  return value.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+
+function fromBase64Url(value: string): string {
+  const base64 = value.replace(/-/g, '+').replace(/_/g, '/');
+  const padding = (4 - (base64.length % 4)) % 4;
+  return `${base64}${'='.repeat(padding)}`;
+}

--- a/workers/auth-worker/src/oauth-handlers.ts
+++ b/workers/auth-worker/src/oauth-handlers.ts
@@ -67,6 +67,7 @@ interface TokenRequest {
 // =============================================================================
 
 // Deduplicates noisy fallback warnings only within a warm Worker isolate.
+// Isolate recycling or redeploys reset this flag, so ops may see it again.
 let warnedAboutSigningKeyFallback = false;
 
 // Base URL for OAuth endpoints (used in metadata)
@@ -103,6 +104,7 @@ function maskState(state: string): string {
 }
 
 function maskClientId(clientId?: string): string {
+  // Short IDs are legacy/public client IDs; confidential IDs are much longer.
   if (!clientId) return '***';
   if (clientId.length <= 18) return `${clientId.substring(0, 6)}...`;
   return `${clientId.substring(0, 14)}...${clientId.substring(clientId.length - 6)}`;
@@ -150,14 +152,6 @@ function isPerplexityRegistration(body: ClientRegistrationRequest): boolean {
   return (body.redirect_uris || []).some(isPerplexityCallbackUri);
 }
 
-function shouldIssueConfidentialClient(body: ClientRegistrationRequest): boolean {
-  if (body.token_endpoint_auth_method === 'client_secret_post') {
-    return true;
-  }
-
-  return body.token_endpoint_auth_method === undefined && isPerplexityRegistration(body);
-}
-
 function invalidClientResponse(
   description: string,
   corsHeaders: Record<string, string>
@@ -179,6 +173,7 @@ function invalidClientResponse(
 async function validateTokenEndpointClient(
   body: TokenRequest,
   requiredClientId: string | undefined,
+  unboundConfidentialClientDescription: string,
   env: OAuthEnv,
   corsHeaders: Record<string, string>
 ): Promise<{ clientId?: string; errorResponse?: Response }> {
@@ -209,7 +204,7 @@ async function validateTokenEndpointClient(
 
   if (isConfidentialClientId(body.client_id)) {
     return {
-      errorResponse: invalidClientResponse('confidential clients must use client-bound authorization codes and refresh tokens', corsHeaders),
+      errorResponse: invalidClientResponse(unboundConfidentialClientDescription, corsHeaders),
     };
   }
 
@@ -338,7 +333,14 @@ export async function handleClientRegistration(
     });
   }
 
-  const issueConfidentialClient = shouldIssueConfidentialClient(body);
+  const inferredPerplexityConfidentialClient =
+    body.token_endpoint_auth_method === undefined && isPerplexityRegistration(body);
+  if (inferredPerplexityConfidentialClient) {
+    console.log('[oauth] Inferring client_secret_post for Perplexity DCR callback heuristic');
+  }
+
+  const issueConfidentialClient =
+    body.token_endpoint_auth_method === 'client_secret_post' || inferredPerplexityConfidentialClient;
   const confidentialClient = issueConfidentialClient
     ? await createConfidentialClientRegistration(getClientRegistrationSigningKey(env))
     : undefined;
@@ -360,7 +362,7 @@ export async function handleClientRegistration(
 
   if (confidentialClient) {
     response.client_secret = confidentialClient.clientSecret;
-    response.client_secret_expires_at = 0;
+    response.client_secret_expires_at = 0; // RFC 7591: 0 means no expiry
   }
 
   console.log(`📝 DCR: Registered client ${maskClientId(clientId)} for ${body.client_name || 'MCP Client'}`);
@@ -647,7 +649,13 @@ export async function handleToken(
       }
 
       const requiredClientId = getClientIdFromBoundToken('mcp_ac', body.code);
-      const clientAuth = await validateTokenEndpointClient(body, requiredClientId, env, corsHeaders);
+      const clientAuth = await validateTokenEndpointClient(
+        body,
+        requiredClientId,
+        'confidential clients must use client-bound authorization codes',
+        env,
+        corsHeaders
+      );
       if (clientAuth.errorResponse) {
         return clientAuth.errorResponse;
       }
@@ -701,7 +709,13 @@ export async function handleToken(
       }
 
       const requiredClientId = getClientIdFromBoundToken('mcp_rt', body.refresh_token);
-      const clientAuth = await validateTokenEndpointClient(body, requiredClientId, env, corsHeaders);
+      const clientAuth = await validateTokenEndpointClient(
+        body,
+        requiredClientId,
+        'confidential clients must use client-bound refresh tokens',
+        env,
+        corsHeaders
+      );
       if (clientAuth.errorResponse) {
         return clientAuth.errorResponse;
       }

--- a/workers/auth-worker/src/oauth-handlers.ts
+++ b/workers/auth-worker/src/oauth-handlers.ts
@@ -66,6 +66,7 @@ interface TokenRequest {
 // CONFIGURATION
 // =============================================================================
 
+// Deduplicates noisy fallback warnings only within a warm Worker isolate.
 let warnedAboutSigningKeyFallback = false;
 
 // Base URL for OAuth endpoints (used in metadata)
@@ -144,6 +145,8 @@ function isPerplexityRegistration(body: ClientRegistrationRequest): boolean {
   // Perplexity omits token_endpoint_auth_method but currently rejects DCR
   // responses that do not include a client_secret, so infer confidential mode
   // from its callback shape when the method is omitted.
+  // TODO: remove this compatibility heuristic if Perplexity starts sending
+  // token_endpoint_auth_method=client_secret_post during registration.
   return (body.redirect_uris || []).some(isPerplexityCallbackUri);
 }
 

--- a/workers/auth-worker/src/oauth-handlers.ts
+++ b/workers/auth-worker/src/oauth-handlers.ts
@@ -68,6 +68,7 @@ interface TokenRequest {
 
 // OAuth client ID (static for now, no DCR)
 const OAUTH_CLIENT_ID = 'flaim-mcp';
+let warnedAboutSigningKeyFallback = false;
 
 // Base URL for OAuth endpoints (used in metadata)
 const getBaseUrl = (env: OAuthEnv): string => {
@@ -102,14 +103,25 @@ function maskState(state: string): string {
   return `${state.substring(0, 6)}...${state.substring(state.length - 4)}`;
 }
 
-function maskClientId(clientId: string): string {
+function maskClientId(clientId?: string): string {
   if (!clientId) return '***';
   if (clientId.length <= 18) return `${clientId.substring(0, 6)}...`;
   return `${clientId.substring(0, 14)}...${clientId.substring(clientId.length - 6)}`;
 }
 
 function getClientRegistrationSigningKey(env: OAuthEnv): string {
-  return env.OAUTH_CLIENT_REGISTRATION_SIGNING_KEY || env.SUPABASE_SERVICE_KEY;
+  if (env.OAUTH_CLIENT_REGISTRATION_SIGNING_KEY) {
+    return env.OAUTH_CLIENT_REGISTRATION_SIGNING_KEY;
+  }
+
+  if (!warnedAboutSigningKeyFallback) {
+    warnedAboutSigningKeyFallback = true;
+    console.warn(
+      '[oauth] OAUTH_CLIENT_REGISTRATION_SIGNING_KEY is not set; falling back to SUPABASE_SERVICE_KEY for confidential MCP client signing'
+    );
+  }
+
+  return env.SUPABASE_SERVICE_KEY;
 }
 
 function isPerplexityCallbackUri(uri: string): boolean {
@@ -131,6 +143,9 @@ function isPerplexityCallbackUri(uri: string): boolean {
 }
 
 function isPerplexityRegistration(body: ClientRegistrationRequest): boolean {
+  // Perplexity omits token_endpoint_auth_method but currently rejects DCR
+  // responses that do not include a client_secret, so infer confidential mode
+  // from its callback shape or exact client_name when the method is omitted.
   return (body.redirect_uris || []).some(isPerplexityCallbackUri)
     || body.client_name?.trim().toLowerCase() === 'perplexity';
 }
@@ -642,18 +657,12 @@ export async function handleToken(
         return clientAuth.errorResponse;
       }
 
-      const token = clientAuth.clientId
-        ? await storage.exchangeCodeForToken(
-          body.code,
-          body.redirect_uri,
-          body.code_verifier,
-          clientAuth.clientId
-        )
-        : await storage.exchangeCodeForToken(
-          body.code,
-          body.redirect_uri,
-          body.code_verifier
-        );
+      const token = await storage.exchangeCodeForToken(
+        body.code,
+        body.redirect_uri,
+        body.code_verifier,
+        clientAuth.clientId
+      );
 
       if (!token) {
         return new Response(JSON.stringify({
@@ -702,9 +711,7 @@ export async function handleToken(
         return clientAuth.errorResponse;
       }
 
-      const token = clientAuth.clientId
-        ? await storage.refreshAccessToken(body.refresh_token, clientAuth.clientId)
-        : await storage.refreshAccessToken(body.refresh_token);
+      const token = await storage.refreshAccessToken(body.refresh_token, clientAuth.clientId);
 
       if (!token) {
         return new Response(JSON.stringify({

--- a/workers/auth-worker/src/oauth-handlers.ts
+++ b/workers/auth-worker/src/oauth-handlers.ts
@@ -66,8 +66,6 @@ interface TokenRequest {
 // CONFIGURATION
 // =============================================================================
 
-// OAuth client ID (static for now, no DCR)
-const OAUTH_CLIENT_ID = 'flaim-mcp';
 let warnedAboutSigningKeyFallback = false;
 
 // Base URL for OAuth endpoints (used in metadata)
@@ -145,9 +143,8 @@ function isPerplexityCallbackUri(uri: string): boolean {
 function isPerplexityRegistration(body: ClientRegistrationRequest): boolean {
   // Perplexity omits token_endpoint_auth_method but currently rejects DCR
   // responses that do not include a client_secret, so infer confidential mode
-  // from its callback shape or exact client_name when the method is omitted.
-  return (body.redirect_uris || []).some(isPerplexityCallbackUri)
-    || body.client_name?.trim().toLowerCase() === 'perplexity';
+  // from its callback shape when the method is omitted.
+  return (body.redirect_uris || []).some(isPerplexityCallbackUri);
 }
 
 function shouldIssueConfidentialClient(body: ClientRegistrationRequest): boolean {
@@ -208,14 +205,9 @@ async function validateTokenEndpointClient(
   }
 
   if (isConfidentialClientId(body.client_id)) {
-    const validSecret = await validateConfidentialClientSecret(body.client_id, body.client_secret, signingKey);
-    if (!validSecret) {
-      return {
-        errorResponse: invalidClientResponse('Invalid client credentials', corsHeaders),
-      };
-    }
-
-    return { clientId: body.client_id };
+    return {
+      errorResponse: invalidClientResponse('confidential clients must use client-bound authorization codes and refresh tokens', corsHeaders),
+    };
   }
 
   return {};

--- a/workers/auth-worker/src/oauth-handlers.ts
+++ b/workers/auth-worker/src/oauth-handlers.ts
@@ -20,6 +20,12 @@
 import { OAuthStorage } from './oauth-storage';
 import { getFrontendUrl } from './preview-url';
 import { isValidRedirectUri } from '@flaim/worker-shared';
+import {
+  createConfidentialClientRegistration,
+  getClientIdFromBoundToken,
+  isConfidentialClientId,
+  validateConfidentialClientSecret,
+} from './oauth-client-auth';
 
 // =============================================================================
 // TYPES
@@ -32,6 +38,7 @@ export interface OAuthEnv {
   ENVIRONMENT?: string;
   FRONTEND_URL?: string;
   OAUTH_REFRESH_TOKEN_TTL_SECONDS?: string;
+  OAUTH_CLIENT_REGISTRATION_SIGNING_KEY?: string;
 }
 
 interface AuthorizeParams {
@@ -93,6 +100,110 @@ function maskState(state: string): string {
   if (!state) return '***';
   if (state.length <= 10) return `${state.substring(0, 3)}...`;
   return `${state.substring(0, 6)}...${state.substring(state.length - 4)}`;
+}
+
+function maskClientId(clientId: string): string {
+  if (!clientId) return '***';
+  if (clientId.length <= 18) return `${clientId.substring(0, 6)}...`;
+  return `${clientId.substring(0, 14)}...${clientId.substring(clientId.length - 6)}`;
+}
+
+function getClientRegistrationSigningKey(env: OAuthEnv): string {
+  return env.OAUTH_CLIENT_REGISTRATION_SIGNING_KEY || env.SUPABASE_SERVICE_KEY;
+}
+
+function isPerplexityCallbackUri(uri: string): boolean {
+  try {
+    const parsed = new URL(uri);
+    const hostname = parsed.hostname.toLowerCase();
+    const isPerplexityHost = hostname === 'perplexity.ai'
+      || hostname.endsWith('.perplexity.ai')
+      || hostname === 'perplexity.com'
+      || hostname.endsWith('.perplexity.com');
+
+    return isPerplexityHost
+      && parsed.pathname === '/rest/connections/oauth_callback'
+      && !parsed.search
+      && !parsed.hash;
+  } catch {
+    return false;
+  }
+}
+
+function isPerplexityRegistration(body: ClientRegistrationRequest): boolean {
+  return (body.redirect_uris || []).some(isPerplexityCallbackUri)
+    || body.client_name?.trim().toLowerCase() === 'perplexity';
+}
+
+function shouldIssueConfidentialClient(body: ClientRegistrationRequest): boolean {
+  if (body.token_endpoint_auth_method === 'client_secret_post') {
+    return true;
+  }
+
+  return body.token_endpoint_auth_method === undefined && isPerplexityRegistration(body);
+}
+
+function invalidClientResponse(
+  description: string,
+  corsHeaders: Record<string, string>
+): Response {
+  return new Response(JSON.stringify({
+    error: 'invalid_client',
+    error_description: description,
+  }), {
+    status: 401,
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'no-store',
+      'Pragma': 'no-cache',
+      ...corsHeaders,
+    },
+  });
+}
+
+async function validateTokenEndpointClient(
+  body: TokenRequest,
+  requiredClientId: string | undefined,
+  env: OAuthEnv,
+  corsHeaders: Record<string, string>
+): Promise<{ clientId?: string; errorResponse?: Response }> {
+  const signingKey = getClientRegistrationSigningKey(env);
+
+  if (requiredClientId) {
+    if (!body.client_id) {
+      return {
+        errorResponse: invalidClientResponse('client_id is required for this confidential client', corsHeaders),
+      };
+    }
+
+    if (body.client_id !== requiredClientId) {
+      return {
+        errorResponse: invalidClientResponse('client_id does not match this confidential client', corsHeaders),
+      };
+    }
+
+    const validSecret = await validateConfidentialClientSecret(body.client_id, body.client_secret, signingKey);
+    if (!validSecret) {
+      return {
+        errorResponse: invalidClientResponse('Invalid client credentials', corsHeaders),
+      };
+    }
+
+    return { clientId: requiredClientId };
+  }
+
+  if (isConfidentialClientId(body.client_id)) {
+    const validSecret = await validateConfidentialClientSecret(body.client_id, body.client_secret, signingKey);
+    if (!validSecret) {
+      return {
+        errorResponse: invalidClientResponse('Invalid client credentials', corsHeaders),
+      };
+    }
+
+    return { clientId: body.client_id };
+  }
+
+  return {};
 }
 
 // =============================================================================
@@ -204,27 +315,52 @@ export async function handleClientRegistration(
     }
   }
 
-  // Generate an unpredictable client_id (RFC 7591)
-  const clientId = `mcp_${crypto.randomUUID()}`;
+  if (
+    body.token_endpoint_auth_method
+    && !['none', 'client_secret_post'].includes(body.token_endpoint_auth_method)
+  ) {
+    return new Response(JSON.stringify({
+      error: 'invalid_client_metadata',
+      error_description: 'Only none and client_secret_post token endpoint auth methods are supported',
+    }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json', ...corsHeaders }
+    });
+  }
 
-  // For public MCP clients, we don't issue a client_secret
-  // Per RFC 7591, this is allowed for public clients
-  const response = {
+  const issueConfidentialClient = shouldIssueConfidentialClient(body);
+  const confidentialClient = issueConfidentialClient
+    ? await createConfidentialClientRegistration(getClientRegistrationSigningKey(env))
+    : undefined;
+
+  // Generate an unpredictable client_id (RFC 7591)
+  const clientId = confidentialClient?.clientId || `mcp_${crypto.randomUUID()}`;
+
+  // Public MCP clients do not receive a client_secret. Confidential clients
+  // receive one real secret and must use client_secret_post at the token endpoint.
+  const response: Record<string, unknown> = {
     client_id: clientId,
     client_id_issued_at: Math.floor(Date.now() / 1000),
     redirect_uris: redirectUris,
     client_name: body.client_name || 'MCP Client',
     grant_types: body.grant_types || ['authorization_code', 'refresh_token'],
     response_types: body.response_types || ['code'],
-    token_endpoint_auth_method: 'none', // Public client
+    token_endpoint_auth_method: confidentialClient ? 'client_secret_post' : 'none',
   };
 
-  console.log(`📝 DCR: Registered client ${clientId} for ${body.client_name || 'MCP Client'}`);
+  if (confidentialClient) {
+    response.client_secret = confidentialClient.clientSecret;
+    response.client_secret_expires_at = 0;
+  }
+
+  console.log(`📝 DCR: Registered client ${maskClientId(clientId)} for ${body.client_name || 'MCP Client'}`);
 
   return new Response(JSON.stringify(response), {
     status: 201,
     headers: {
       'Content-Type': 'application/json',
+      'Cache-Control': 'no-store',
+      'Pragma': 'no-cache',
       ...corsHeaders
     }
   });
@@ -335,7 +471,9 @@ export async function handleAuthorize(request: Request, env: OAuthEnv): Promise<
   if (params.client_id) consentUrl.searchParams.set('client_id', params.client_id);
   if (params.resource) consentUrl.searchParams.set('resource', params.resource); // RFC 8707
 
-  console.log(`[oauth] Redirecting to consent page: ${consentUrl.toString()}`);
+  console.log(
+    `[oauth] Redirecting to consent page: ${consentUrl.origin}${consentUrl.pathname}, client_id=${params.client_id ? maskClientId(params.client_id) : 'none'}`
+  );
 
   return Response.redirect(consentUrl.toString(), 302);
 }
@@ -394,7 +532,7 @@ export async function handleCreateCode(
       );
       if (!validState) {
         console.log(
-          `[oauth] Invalid state during /oauth/code: state=${maskState(body.state)}, redirect_uri=${body.redirect_uri}, client_id=${body.client_id || 'none'}`
+          `[oauth] Invalid state during /oauth/code: state=${maskState(body.state)}, redirect_uri=${body.redirect_uri}, client_id=${body.client_id ? maskClientId(body.client_id) : 'none'}`
         );
         return new Response(JSON.stringify({
           error: 'invalid_request',
@@ -415,6 +553,7 @@ export async function handleCreateCode(
     const code = await storage.createAuthorizationCode({
       userId,
       redirectUri: body.redirect_uri,
+      clientId: isConfidentialClientId(body.client_id) ? body.client_id : undefined,
       scope: body.scope || 'mcp:read',
       codeChallenge: body.code_challenge,
       codeChallengeMethod: 'S256',
@@ -497,11 +636,24 @@ export async function handleToken(
         }), { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } });
       }
 
-      const token = await storage.exchangeCodeForToken(
-        body.code,
-        body.redirect_uri,
-        body.code_verifier
-      );
+      const requiredClientId = getClientIdFromBoundToken('mcp_ac', body.code);
+      const clientAuth = await validateTokenEndpointClient(body, requiredClientId, env, corsHeaders);
+      if (clientAuth.errorResponse) {
+        return clientAuth.errorResponse;
+      }
+
+      const token = clientAuth.clientId
+        ? await storage.exchangeCodeForToken(
+          body.code,
+          body.redirect_uri,
+          body.code_verifier,
+          clientAuth.clientId
+        )
+        : await storage.exchangeCodeForToken(
+          body.code,
+          body.redirect_uri,
+          body.code_verifier
+        );
 
       if (!token) {
         return new Response(JSON.stringify({
@@ -544,7 +696,15 @@ export async function handleToken(
         }), { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } });
       }
 
-      const token = await storage.refreshAccessToken(body.refresh_token);
+      const requiredClientId = getClientIdFromBoundToken('mcp_rt', body.refresh_token);
+      const clientAuth = await validateTokenEndpointClient(body, requiredClientId, env, corsHeaders);
+      if (clientAuth.errorResponse) {
+        return clientAuth.errorResponse;
+      }
+
+      const token = clientAuth.clientId
+        ? await storage.refreshAccessToken(body.refresh_token, clientAuth.clientId)
+        : await storage.refreshAccessToken(body.refresh_token);
 
       if (!token) {
         return new Response(JSON.stringify({

--- a/workers/auth-worker/src/oauth-storage.ts
+++ b/workers/auth-worker/src/oauth-storage.ts
@@ -427,7 +427,7 @@ export class OAuthStorage {
     if (authCode.clientId && authCode.clientId !== clientId) {
       // Code has already been consumed by the atomic claim above; this is
       // intentional so a mismatched confidential-client attempt cannot replay.
-      console.log('[oauth-storage] Confidential client_id mismatch during auth code exchange; code consumed');
+      console.log('[oauth-storage] Confidential client_id mismatch during auth code exchange; code consumed, returning invalid_grant');
       return null;
     }
 

--- a/workers/auth-worker/src/oauth-storage.ts
+++ b/workers/auth-worker/src/oauth-storage.ts
@@ -391,6 +391,15 @@ export class OAuthStorage {
     codeVerifier?: string,
     clientId?: string
   ): Promise<OAuthToken | null> {
+    // Handler validation should reject this before storage, but keep this
+    // pre-claim guard for direct/internal callers so a wrong client_id does
+    // not burn an otherwise valid confidential authorization code.
+    const boundClientId = getClientIdFromBoundToken('mcp_ac', code);
+    if (boundClientId && boundClientId !== clientId) {
+      console.log('[oauth-storage] Confidential client_id mismatch before auth code claim');
+      return null;
+    }
+
     // Atomically claim the code — only succeeds if not already used and not expired
     const { data, error } = await this.supabase
       .from('oauth_codes')
@@ -426,7 +435,8 @@ export class OAuthStorage {
 
     if (authCode.clientId && authCode.clientId !== clientId) {
       // Code has already been consumed by the atomic claim above; this is
-      // intentional so a mismatched confidential-client attempt cannot replay.
+      // intentional for replay safety if an internal caller bypassed the
+      // pre-claim/handler binding checks.
       console.log('[oauth-storage] Confidential client_id mismatch during auth code exchange; code consumed, returning invalid_grant');
       return null;
     }

--- a/workers/auth-worker/src/oauth-storage.ts
+++ b/workers/auth-worker/src/oauth-storage.ts
@@ -13,6 +13,12 @@
  */
 
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import {
+  createClientBoundToken,
+  generateSecureToken,
+  getClientIdFromBoundToken,
+  isConfidentialClientId,
+} from './oauth-client-auth';
 
 // =============================================================================
 // TYPES
@@ -22,6 +28,7 @@ export interface OAuthCode {
   code: string;
   userId: string;
   redirectUri: string;
+  clientId?: string;
   codeChallenge?: string;
   codeChallengeMethod?: 'S256';
   scope: string;
@@ -53,6 +60,7 @@ export interface OAuthState {
 export interface CreateCodeParams {
   userId: string;
   redirectUri: string;
+  clientId?: string;
   codeChallenge?: string;
   codeChallengeMethod?: 'S256';
   scope?: string;
@@ -65,6 +73,7 @@ export interface CreateTokenParams {
   scope?: string;
   resource?: string; // RFC 8707 resource indicator
   redirectUri?: string; // For deriving clientName
+  clientId?: string; // Confidential OAuth client binding
   clientName?: string; // AI platform name (Claude, ChatGPT, etc.)
   expiresInSeconds?: number; // Default: 3600 (1 hour)
   includeRefreshToken?: boolean;
@@ -100,18 +109,6 @@ export interface OAuthStorageEnv {
 // =============================================================================
 // UTILITIES
 // =============================================================================
-
-/**
- * Generate a cryptographically secure random string
- * URL-safe base64 encoding
- */
-function generateSecureToken(length: number = 32): string {
-  const bytes = new Uint8Array(length);
-  crypto.getRandomValues(bytes);
-  // Convert to base64url (URL-safe)
-  const base64 = btoa(String.fromCharCode(...bytes));
-  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
-}
 
 /**
  * Verify PKCE code verifier against stored challenge
@@ -226,7 +223,9 @@ export class OAuthStorage {
    * Create and store a new authorization code
    */
   async createAuthorizationCode(params: CreateCodeParams): Promise<string> {
-    const code = generateSecureToken(32);
+    const code = params.clientId && isConfidentialClientId(params.clientId)
+      ? createClientBoundToken('mcp_ac', params.clientId, generateSecureToken(32))
+      : generateSecureToken(32);
     const expiresInSeconds = params.expiresInSeconds ?? 600; // 10 minutes default
     const expiresAt = new Date(Date.now() + expiresInSeconds * 1000);
 
@@ -352,6 +351,7 @@ export class OAuthStorage {
       code: data.code,
       userId: data.user_id,
       redirectUri: data.redirect_uri,
+      clientId: getClientIdFromBoundToken('mcp_ac', data.code),
       codeChallenge: data.code_challenge || undefined,
       codeChallengeMethod: data.code_challenge_method || undefined,
       scope: data.scope,
@@ -388,7 +388,8 @@ export class OAuthStorage {
   async exchangeCodeForToken(
     code: string,
     redirectUri: string,
-    codeVerifier?: string
+    codeVerifier?: string,
+    clientId?: string
   ): Promise<OAuthToken | null> {
     // Atomically claim the code — only succeeds if not already used and not expired
     const { data, error } = await this.supabase
@@ -409,6 +410,7 @@ export class OAuthStorage {
       code: data.code,
       userId: data.user_id,
       redirectUri: data.redirect_uri,
+      clientId: getClientIdFromBoundToken('mcp_ac', data.code),
       codeChallenge: data.code_challenge || undefined,
       codeChallengeMethod: data.code_challenge_method || undefined,
       scope: data.scope,
@@ -420,6 +422,11 @@ export class OAuthStorage {
     if (!redirectUrisMatch(authCode.redirectUri, redirectUri)) {
       console.log(`[oauth-storage] Redirect URI mismatch: expected ${authCode.redirectUri}, got ${redirectUri}`);
       return null; // Code is already burned — correct per RFC 6749 §4.1.2
+    }
+
+    if (authCode.clientId && authCode.clientId !== clientId) {
+      console.log('[oauth-storage] Confidential client_id mismatch during auth code exchange');
+      return null;
     }
 
     // Validate PKCE if challenge was provided
@@ -443,6 +450,7 @@ export class OAuthStorage {
       scope: authCode.scope,
       resource: authCode.resource, // RFC 8707 - pass through resource
       redirectUri: authCode.redirectUri, // For deriving clientName
+      clientId: authCode.clientId || (clientId && isConfidentialClientId(clientId) ? clientId : undefined),
       includeRefreshToken: true,
     });
 
@@ -468,7 +476,10 @@ export class OAuthStorage {
     let refreshTokenExpiresAt: Date | undefined;
 
     if (params.includeRefreshToken) {
-      refreshToken = generateSecureToken(32);
+      const opaqueRefreshToken = generateSecureToken(32);
+      refreshToken = params.clientId && isConfidentialClientId(params.clientId)
+        ? createClientBoundToken('mcp_rt', params.clientId, opaqueRefreshToken)
+        : opaqueRefreshToken;
       const refreshExpiresIn = params.refreshTokenExpiresInSeconds ?? this.refreshTokenTtlSeconds;
       refreshTokenExpiresAt = new Date(Date.now() + refreshExpiresIn * 1000);
     }
@@ -545,7 +556,13 @@ export class OAuthStorage {
   /**
    * Refresh an access token using a refresh token
    */
-  async refreshAccessToken(refreshToken: string): Promise<OAuthToken | null> {
+  async refreshAccessToken(refreshToken: string, clientId?: string): Promise<OAuthToken | null> {
+    const tokenClientId = getClientIdFromBoundToken('mcp_rt', refreshToken);
+    if (tokenClientId && tokenClientId !== clientId) {
+      console.log('[oauth-storage] Confidential client_id mismatch during refresh');
+      return null;
+    }
+
     const { data, error } = await this.supabase
       .from('oauth_tokens')
       .select('*')
@@ -577,6 +594,7 @@ export class OAuthStorage {
       userId: data.user_id,
       scope: data.scope,
       resource: data.resource || undefined, // Preserve resource for audience validation
+      clientId: tokenClientId,
       clientName: data.client_name || undefined, // Preserve clientName
       includeRefreshToken: true,
     });

--- a/workers/auth-worker/src/oauth-storage.ts
+++ b/workers/auth-worker/src/oauth-storage.ts
@@ -425,7 +425,9 @@ export class OAuthStorage {
     }
 
     if (authCode.clientId && authCode.clientId !== clientId) {
-      console.log('[oauth-storage] Confidential client_id mismatch during auth code exchange');
+      // Code has already been consumed by the atomic claim above; this is
+      // intentional so a mismatched confidential-client attempt cannot replay.
+      console.log('[oauth-storage] Confidential client_id mismatch during auth code exchange; code consumed');
       return null;
     }
 

--- a/workers/auth-worker/src/oauth-storage.ts
+++ b/workers/auth-worker/src/oauth-storage.ts
@@ -450,7 +450,7 @@ export class OAuthStorage {
       scope: authCode.scope,
       resource: authCode.resource, // RFC 8707 - pass through resource
       redirectUri: authCode.redirectUri, // For deriving clientName
-      clientId: authCode.clientId || (clientId && isConfidentialClientId(clientId) ? clientId : undefined),
+      clientId: authCode.clientId,
       includeRefreshToken: true,
     });
 

--- a/workers/auth-worker/wrangler.jsonc
+++ b/workers/auth-worker/wrangler.jsonc
@@ -18,7 +18,9 @@
   // - YAHOO_CLIENT_SECRET  (Yahoo Developer App)
   // Optional vars:
   // - OAUTH_REFRESH_TOKEN_TTL_SECONDS (defaults to 31536000 in code; set only to override)
-  // - OAUTH_CLIENT_REGISTRATION_SIGNING_KEY (defaults to SUPABASE_SERVICE_KEY; keep stable if set)
+  // - OAUTH_CLIENT_REGISTRATION_SIGNING_KEY (defaults to SUPABASE_SERVICE_KEY;
+  //   set a dedicated stable secret in preview/prod so Supabase key rotation
+  //   does not invalidate confidential MCP client registrations)
 
   // Environment configurations
   "env": {

--- a/workers/auth-worker/wrangler.jsonc
+++ b/workers/auth-worker/wrangler.jsonc
@@ -18,6 +18,7 @@
   // - YAHOO_CLIENT_SECRET  (Yahoo Developer App)
   // Optional vars:
   // - OAUTH_REFRESH_TOKEN_TTL_SECONDS (defaults to 31536000 in code; set only to override)
+  // - OAUTH_CLIENT_REGISTRATION_SIGNING_KEY (defaults to SUPABASE_SERVICE_KEY; keep stable if set)
 
   // Environment configurations
   "env": {


### PR DESCRIPTION
## Summary

- Add optional confidential Dynamic Client Registration support for MCP OAuth clients that request or require `client_secret_post`.
- Keep public PKCE clients on `token_endpoint_auth_method: none` so ChatGPT and Claude-style public flows continue to work without a client secret.
- Bind confidential authorization codes and refresh tokens to their registered client, validate the submitted `client_secret` on auth-code and refresh grants, and preserve refresh-token rotation.
- Mask confidential client IDs in logs and document the stateless signing key behavior.

## Root Cause

Perplexity successfully reaches `POST /auth/register`, but rejects the DCR response because it expects a `client_secret`. Flaim advertised `client_secret_post` in OAuth metadata but only returned public-client registrations.

## Validation

- `corepack pnpm --dir workers/auth-worker exec vitest run src/__tests__/oauth-handlers.test.ts src/__tests__/oauth-storage.test.ts` - 58 passed
- `corepack pnpm --dir workers/auth-worker run test` - 310 passed
- `corepack pnpm --dir workers/auth-worker run type-check` - passed
- `git diff --check` - passed

Note: local pnpm reports the expected Node engine warning because this shell is Node 26 while the repo specifies Node 24.