### PR TITLE
Force confidential DCR for Perplexity callbacks

### DIFF
--- a/workers/auth-worker/src/__tests__/oauth-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/oauth-handlers.test.ts
@@ -79,8 +79,9 @@ describe('oauth-handlers', () => {
     expect(body1.client_id).not.toBe(body2.client_id);
   });
 
-  it('keeps public DCR clients public without a client_secret', async () => {
+  it('keeps non-Perplexity public DCR clients public without a client_secret when auth method is none', async () => {
     const res = await handleClientRegistration(buildRegisterRequest({
+      redirect_uris: ['https://claude.ai/api/mcp/auth_callback'],
       token_endpoint_auth_method: 'none',
     }), env, corsHeaders);
 

--- a/workers/auth-worker/src/__tests__/oauth-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/oauth-handlers.test.ts
@@ -160,6 +160,8 @@ describe('oauth-handlers', () => {
   });
 
   it('returns a client_secret for Perplexity DCR when auth method is client_secret_post', async () => {
+    // This verifies Perplexity works on the normal explicit confidential path,
+    // separate from the compatibility override for omitted/none auth methods.
     const res = await handleClientRegistration(buildRegisterRequest({
       redirect_uris: ['https://www.perplexity.ai/rest/connections/oauth_callback'],
       client_name: 'Perplexity',

--- a/workers/auth-worker/src/__tests__/oauth-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/oauth-handlers.test.ts
@@ -139,7 +139,7 @@ describe('oauth-handlers', () => {
     expect(body.token_endpoint_auth_method).toBe('client_secret_post');
   });
 
-  it('respects explicit public auth method for Perplexity DCR clients', async () => {
+  it('returns a client_secret for Perplexity DCR even when auth method is none', async () => {
     const res = await handleClientRegistration(buildRegisterRequest({
       redirect_uris: ['https://www.perplexity.ai/rest/connections/oauth_callback'],
       client_name: 'Perplexity',
@@ -153,10 +153,9 @@ describe('oauth-handlers', () => {
       token_endpoint_auth_method?: string;
     };
 
-    expect(body.client_id).toMatch(/^mcp_/);
-    expect(body.client_id).not.toMatch(/^mcp_conf_/);
-    expect(body.client_secret).toBeUndefined();
-    expect(body.token_endpoint_auth_method).toBe('none');
+    expect(body.client_id).toMatch(/^mcp_conf_/);
+    expect(body.client_secret).toMatch(/^mcp_secret_/);
+    expect(body.token_endpoint_auth_method).toBe('client_secret_post');
   });
 
   it('returns a client_secret for Perplexity DCR when auth method is omitted', async () => {

--- a/workers/auth-worker/src/__tests__/oauth-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/oauth-handlers.test.ts
@@ -158,6 +158,25 @@ describe('oauth-handlers', () => {
     expect(body.token_endpoint_auth_method).toBe('client_secret_post');
   });
 
+  it('returns a client_secret for Perplexity DCR when auth method is client_secret_post', async () => {
+    const res = await handleClientRegistration(buildRegisterRequest({
+      redirect_uris: ['https://www.perplexity.ai/rest/connections/oauth_callback'],
+      client_name: 'Perplexity',
+      token_endpoint_auth_method: 'client_secret_post',
+    }), env, corsHeaders);
+
+    expect(res.status).toBe(201);
+    const body = await res.json() as {
+      client_id?: string;
+      client_secret?: string;
+      token_endpoint_auth_method?: string;
+    };
+
+    expect(body.client_id).toMatch(/^mcp_conf_/);
+    expect(body.client_secret).toMatch(/^mcp_secret_/);
+    expect(body.token_endpoint_auth_method).toBe('client_secret_post');
+  });
+
   it('returns a client_secret for Perplexity DCR when auth method is omitted', async () => {
     const res = await handleClientRegistration(buildRegisterRequest({
       redirect_uris: ['https://www.perplexity.ai/rest/connections/oauth_callback'],

--- a/workers/auth-worker/src/oauth-handlers.ts
+++ b/workers/auth-worker/src/oauth-handlers.ts
@@ -334,14 +334,14 @@ export async function handleClientRegistration(
     });
   }
 
-  const inferredPerplexityConfidentialClient = isPerplexityRegistration(body)
+  const perplexityConfidentialOverride = isPerplexityRegistration(body)
     && (body.token_endpoint_auth_method === undefined || body.token_endpoint_auth_method === 'none');
-  if (inferredPerplexityConfidentialClient) {
+  if (perplexityConfidentialOverride) {
     console.log('[oauth] Overriding token_endpoint_auth_method to client_secret_post for Perplexity DCR callback heuristic');
   }
 
   const issueConfidentialClient =
-    body.token_endpoint_auth_method === 'client_secret_post' || inferredPerplexityConfidentialClient;
+    body.token_endpoint_auth_method === 'client_secret_post' || perplexityConfidentialOverride;
   const confidentialClient = issueConfidentialClient
     ? await createConfidentialClientRegistration(getClientRegistrationSigningKey(env))
     : undefined;

--- a/workers/auth-worker/src/oauth-handlers.ts
+++ b/workers/auth-worker/src/oauth-handlers.ts
@@ -144,9 +144,10 @@ function isPerplexityCallbackUri(uri: string): boolean {
 }
 
 function isPerplexityRegistration(body: ClientRegistrationRequest): boolean {
-  // Perplexity omits token_endpoint_auth_method but currently rejects DCR
-  // responses that do not include a client_secret, so infer confidential mode
-  // from its callback shape when the method is omitted.
+  // Perplexity currently rejects DCR responses that do not include a
+  // client_secret, even when it omits token_endpoint_auth_method or sends
+  // token_endpoint_auth_method=none. Infer confidential mode from its callback
+  // shape so public PKCE clients on other hosts remain unchanged.
   // TODO: remove this compatibility heuristic if Perplexity starts sending
   // token_endpoint_auth_method=client_secret_post during registration.
   return (body.redirect_uris || []).some(isPerplexityCallbackUri);
@@ -333,8 +334,8 @@ export async function handleClientRegistration(
     });
   }
 
-  const inferredPerplexityConfidentialClient =
-    body.token_endpoint_auth_method === undefined && isPerplexityRegistration(body);
+  const inferredPerplexityConfidentialClient = isPerplexityRegistration(body)
+    && body.token_endpoint_auth_method !== 'client_secret_post';
   if (inferredPerplexityConfidentialClient) {
     console.log('[oauth] Inferring client_secret_post for Perplexity DCR callback heuristic');
   }

--- a/workers/auth-worker/src/oauth-handlers.ts
+++ b/workers/auth-worker/src/oauth-handlers.ts
@@ -335,9 +335,9 @@ export async function handleClientRegistration(
   }
 
   const inferredPerplexityConfidentialClient = isPerplexityRegistration(body)
-    && body.token_endpoint_auth_method !== 'client_secret_post';
+    && (body.token_endpoint_auth_method === undefined || body.token_endpoint_auth_method === 'none');
   if (inferredPerplexityConfidentialClient) {
-    console.log('[oauth] Inferring client_secret_post for Perplexity DCR callback heuristic');
+    console.log('[oauth] Overriding token_endpoint_auth_method to client_secret_post for Perplexity DCR callback heuristic');
   }
 
   const issueConfidentialClient =


### PR DESCRIPTION
## Summary
- force Perplexity callback-shaped DCR registrations to receive confidential client metadata even when Perplexity sends token_endpoint_auth_method=none
- keep non-Perplexity public PKCE clients public
- update the OAuth handler test to cover the live Perplexity behavior observed after PR #96 merged

## Context
Production browser testing after PR #96 showed Perplexity still displaying [API_CLIENTS_ERROR]. Cloudflare logs showed Perplexity reached /auth/register and received HTTP 201, but auth-worker issued a public mcp_ client rather than a confidential mcp_conf_ client. This patch treats Perplexity's known callback URI shape as confidential even when the request says none, because Perplexity rejects registrations without client_secret.

## Verification
- corepack pnpm --dir workers/auth-worker exec vitest run src/__tests__/oauth-handlers.test.ts
- corepack pnpm --dir workers/auth-worker run type-check
- corepack pnpm --dir workers/auth-worker run test
- git diff --check