### PR TITLE
De-emphasize setup guides on homepage

### DIFF
--- a/web/app/(site)/page.tsx
+++ b/web/app/(site)/page.tsx
@@ -18,7 +18,6 @@ import {
   PUBLIC_CHAT_SIMPLE_PRESETS,
   PUBLIC_CHAT_TOOL_DISPLAY_LABELS,
 } from "@/lib/public-chat";
-import { CHATGPT_APP_URL } from "@/lib/product-links";
 import {
   ArrowRight,
   ChevronDown,
@@ -96,91 +95,6 @@ export default async function LandingPage({ searchParams }: LandingPageProps) {
         id="live-demo"
         initialPresetId={initialPresetId ?? null}
       />
-
-      <section className="px-4 pb-10 pt-2 sm:px-6 lg:px-8">
-        <div className="mx-auto grid max-w-5xl gap-4 text-sm text-muted-foreground md:grid-cols-3">
-          <div className="rounded-2xl border bg-background/70 p-4">
-            <Link
-              href="/guide/platforms"
-              className="text-[11px] font-semibold uppercase tracking-[0.18em] text-foreground/70 hover:text-primary transition-colors"
-            >
-              Platforms
-            </Link>
-            <div className="mt-3 flex flex-wrap gap-2">
-              <Link
-                href="/guide/platforms#espn"
-                className="rounded-full border bg-background px-3 py-1 transition-colors hover:border-foreground/30"
-              >
-                ESPN
-              </Link>
-              <Link
-                href="/guide/platforms#yahoo"
-                className="rounded-full border bg-background px-3 py-1 transition-colors hover:border-foreground/30"
-              >
-                Yahoo
-              </Link>
-              <Link
-                href="/guide/platforms#sleeper"
-                className="rounded-full border bg-background px-3 py-1 transition-colors hover:border-foreground/30"
-              >
-                Sleeper
-              </Link>
-            </div>
-          </div>
-          <div className="rounded-2xl border bg-background/70 p-4">
-            <Link
-              href="/guide/sports"
-              className="text-[11px] font-semibold uppercase tracking-[0.18em] text-foreground/70 hover:text-primary transition-colors"
-            >
-              Sports
-            </Link>
-            <div className="mt-3 flex flex-wrap gap-2">
-              <Link
-                href="/guide/sports#football"
-                className="rounded-full border bg-background px-3 py-1 transition-colors hover:border-foreground/30"
-              >
-                Football
-              </Link>
-              <Link
-                href="/guide/sports#baseball"
-                className="rounded-full border bg-background px-3 py-1 transition-colors hover:border-foreground/30"
-              >
-                Baseball
-              </Link>
-              <Link
-                href="/guide/sports#basketball"
-                className="rounded-full border bg-background px-3 py-1 transition-colors hover:border-foreground/30"
-              >
-                Basketball
-              </Link>
-              <Link
-                href="/guide/sports#hockey"
-                className="rounded-full border bg-background px-3 py-1 transition-colors hover:border-foreground/30"
-              >
-                Hockey
-              </Link>
-            </div>
-          </div>
-          <div className="rounded-2xl border bg-background/70 p-4">
-            <Link
-              href="/guide/ai"
-              className="text-[11px] font-semibold uppercase tracking-[0.18em] text-foreground/70 hover:text-primary transition-colors"
-            >
-              Works With
-            </Link>
-            <div className="mt-3 flex flex-wrap gap-2">
-              <Link
-                href={CHATGPT_APP_URL}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="rounded-full border bg-background px-3 py-1 transition-colors hover:border-foreground/30"
-              >
-                ChatGPT
-              </Link>
-            </div>
-          </div>
-        </div>
-      </section>
 
       {/* Primary CTA */}
       <section className="px-4 pb-10 text-center">
@@ -413,7 +327,7 @@ export default async function LandingPage({ searchParams }: LandingPageProps) {
               </Button>
             </SignedIn>
             <Button asChild variant="outline" size="lg">
-              <Link href="/guide">Setup guides</Link>
+              <Link href="/guide">Help</Link>
             </Button>
           </div>
         </div>

--- a/web/public/llms-full.txt
+++ b/web/public/llms-full.txt
@@ -33,14 +33,16 @@ Single MCP endpoint: https://api.flaim.app/mcp
 ## How to Connect
 
 1. Create a Flaim account at https://flaim.app
-2. Open https://flaim.app/leagues
+2. Go to https://flaim.app/leagues
 3. Connect your fantasy platforms there:
-   - ESPN: Use the Chrome extension to sync private ESPN leagues
+   - ESPN: Install the Chrome extension to sync private ESPN leagues
    - Yahoo: Start Yahoo auth from /leagues and wait for league discovery
    - Sleeper: Enter your exact username and wait for league discovery
-4. Open Flaim Fantasy in ChatGPT, or add the MCP server URL to an optional manual MCP client: https://api.flaim.app/mcp
+4. Open Flaim Fantasy in ChatGPT
 5. Authorize Flaim when prompted
 6. Start a fresh chat and ask "What leagues do I have?" to confirm setup
+
+Optional manual MCP clients can use the same server URL after leagues are connected: https://api.flaim.app/mcp
 
 ## Example Prompts
 
@@ -62,7 +64,7 @@ Flaim is a ChatGPT-first fantasy analysis app, a skill that teaches AI how to an
 Flaim is read-only. It cannot trade, drop, or modify anything in your league. ESPN credentials are encrypted and stored securely — they are never shared with AI providers.
 
 ### Why does ESPN need a Chrome extension?
-ESPN doesn't offer a public API for fantasy data. The extension is the preferred way to sync the session details Flaim needs for read-only access. Manual cookie entry is available as a fallback.
+ESPN doesn't offer a public API for private fantasy league data. For private ESPN leagues, the Chrome extension syncs the session details Flaim needs for read-only access.
 
 ### How does Flaim connect to AI clients?
 Flaim Fantasy is available in ChatGPT. Optional manual MCP clients can also add the single server URL, and Flaim handles authentication and data retrieval after your leagues are linked in /leagues.
@@ -74,8 +76,9 @@ The primary experience is Flaim Fantasy in ChatGPT. Optional manual MCP clients 
 
 - Website: https://flaim.app
 - Leagues setup: https://flaim.app/leagues
-- Setup guide: https://flaim.app/guide/platforms
-- AI setup guide: https://flaim.app/guide/ai
+- Help: https://flaim.app/guide
+- Platform guide: https://flaim.app/guide/platforms
+- AI guide: https://flaim.app/guide/ai
 - Sports guide: https://flaim.app/guide/sports
 - ChatGPT guide: https://flaim.app/guide/ai#chatgpt
 - Claude guide: https://flaim.app/guide/ai#claude

--- a/web/public/llms.txt
+++ b/web/public/llms.txt
@@ -14,16 +14,17 @@
 ## How to connect
 
 1. Create an account at https://flaim.app
-2. Open https://flaim.app/leagues
-3. Connect fantasy platforms there (ESPN via Chrome extension or manual fallback, Yahoo via OAuth, Sleeper via username)
-4. Open Flaim Fantasy in ChatGPT, or add MCP server URL https://api.flaim.app/mcp to an optional manual MCP client
+2. Go to https://flaim.app/leagues
+3. Connect your fantasy platforms there (private ESPN leagues via Chrome extension, Yahoo via OAuth, Sleeper via username)
+4. Open Flaim Fantasy in ChatGPT
 5. Start a fresh chat and ask what leagues you have to confirm setup
+6. Optional: add MCP server URL https://api.flaim.app/mcp to a manual MCP client
 
 ## Links
 
 - Website: https://flaim.app
 - Leagues setup: https://flaim.app/leagues
-- Setup guide: https://flaim.app/guide
+- Help: https://flaim.app/guide
 - GitHub: https://github.com/jdguggs10/flaim
 - Privacy: https://flaim.app/privacy
 - Full details: https://flaim.app/llms-full.txt

--- a/web/public/llms.txt
+++ b/web/public/llms.txt
@@ -16,7 +16,7 @@
 1. Create an account at https://flaim.app
 2. Go to https://flaim.app/leagues
 3. Connect your fantasy platforms there (private ESPN leagues via Chrome extension, Yahoo via OAuth, Sleeper via username)
-4. Open Flaim Fantasy in ChatGPT
+4. Open Flaim Fantasy in ChatGPT and authorize when prompted
 5. Start a fresh chat and ask what leagues you have to confirm setup
 6. Optional: add MCP server URL https://api.flaim.app/mcp to a manual MCP client
 


### PR DESCRIPTION
## Summary

- remove the prominent homepage guide doorway below the demo so setup feels simpler
- keep a quieter Help CTA plus contextual FAQ/popover guide links for users who need help
- refresh llms.txt and llms-full.txt so AI/search surfaces still explain the full setup flow and ESPN extension-only path

## Verification

- git diff --check
- corepack pnpm --dir web exec tsc --noEmit
- corepack pnpm --dir web run lint

Note: local lint reported the repo's existing Node engine warning because this shell is on Node 26 while the repo expects Node 24.
