### PR TITLE
[codex] Fix ESPN zero final rank outcomes

### DIFF
--- a/workers/espn-client/src/shared/__tests__/standings.test.ts
+++ b/workers/espn-client/src/shared/__tests__/standings.test.ts
@@ -37,6 +37,17 @@ describe('deriveStandingsSeasonPhase', () => {
     })).toBe('season_complete');
   });
 
+  it('does not treat zero final ranks as explicit completion data', () => {
+    expect(deriveStandingsSeasonPhase({
+      requestedSeasonYear: 2026,
+      currentSeasonYear: 2026,
+      currentMatchupPeriod: 21,
+      scoringPeriodId: 150,
+      regularSeasonMatchupPeriods: 20,
+      teams: [{ id: 1, rankFinal: 0, rankCalculatedFinal: 0 }],
+    })).toBe('playoffs_in_progress');
+  });
+
   it('returns playoffs_in_progress for current-season requests after the regular season', () => {
     expect(deriveStandingsSeasonPhase({
       requestedSeasonYear: 2026,
@@ -145,6 +156,63 @@ describe('deriveStandingsOutcome', () => {
       playoffOutcome: null,
       outcomeConfidence: null,
       madePlayoffs: null,
+    });
+  });
+
+  it('keeps outcome fields null when completed-season final ranks are zero', () => {
+    expect(deriveStandingsOutcome({
+      rankFinal: 0,
+      rankCalculatedFinal: 0,
+      seasonComplete: true,
+    })).toEqual({
+      finalRank: null,
+      championshipWon: null,
+      playoffOutcome: null,
+      outcomeConfidence: null,
+      madePlayoffs: null,
+    });
+  });
+
+  it('keeps outcome fields null when only rankFinal is zero', () => {
+    expect(deriveStandingsOutcome({
+      rankFinal: 0,
+      seasonComplete: true,
+    })).toEqual({
+      finalRank: null,
+      championshipWon: null,
+      playoffOutcome: null,
+      outcomeConfidence: null,
+      madePlayoffs: null,
+    });
+  });
+
+  it('falls back to rankCalculatedFinal when rankFinal is zero', () => {
+    expect(deriveStandingsOutcome({
+      rankFinal: 0,
+      rankCalculatedFinal: 3,
+      playoffSeed: 3,
+      seasonComplete: true,
+    })).toEqual({
+      finalRank: 3,
+      championshipWon: false,
+      playoffOutcome: 'eliminated',
+      outcomeConfidence: 'explicit',
+      madePlayoffs: true,
+    });
+  });
+
+  it('prefers valid rankFinal when rankCalculatedFinal is zero', () => {
+    expect(deriveStandingsOutcome({
+      rankFinal: 2,
+      rankCalculatedFinal: 0,
+      playoffSeed: 2,
+      seasonComplete: true,
+    })).toEqual({
+      finalRank: 2,
+      championshipWon: false,
+      playoffOutcome: 'runner_up',
+      outcomeConfidence: 'explicit',
+      madePlayoffs: true,
     });
   });
 

--- a/workers/espn-client/src/shared/standings.ts
+++ b/workers/espn-client/src/shared/standings.ts
@@ -28,8 +28,16 @@ interface DeriveStandingsOutcomeInput {
   seasonComplete: boolean;
 }
 
+function getValidFinalRank(
+  rankFinal?: number,
+  rankCalculatedFinal?: number,
+): number | null {
+  // ESPN can return 0 as a sentinel for "not yet ranked".
+  return [rankFinal, rankCalculatedFinal].find((rank) => rank != null && rank > 0) ?? null;
+}
+
 function hasExplicitCompletionData(teams: EspnTeam[]): boolean {
-  return teams.some((team) => team.rankFinal != null || team.rankCalculatedFinal != null);
+  return teams.some((team) => getValidFinalRank(team.rankFinal, team.rankCalculatedFinal) !== null);
 }
 
 export function deriveStandingsSeasonPhase({
@@ -65,7 +73,7 @@ export function deriveStandingsOutcome({
   playoffSeed,
   seasonComplete,
 }: DeriveStandingsOutcomeInput): EspnStandingsOutcome {
-  const resolvedFinalRank = rankFinal ?? rankCalculatedFinal ?? null;
+  const resolvedFinalRank = getValidFinalRank(rankFinal, rankCalculatedFinal);
   const finalRank = seasonComplete && resolvedFinalRank !== null ? resolvedFinalRank : null;
   const championshipWon = finalRank !== null ? finalRank === 1 : null;
   const playoffOutcome =


### PR DESCRIPTION
## Summary

- Treat ESPN `rankFinal` / `rankCalculatedFinal` values of `0` as invalid final ranks.
- Keep standings outcome fields unconfirmed when ESPN only provides zero final-rank values.
- Add regression coverage for zero final-rank completion detection and outcome derivation.

## Why

ESPN baseball historical standings can return `finalRank: 0` for completed seasons. Flaim previously treated that as explicit completion data, which let `get_standings` emit confident but false championship outcome fields such as `championshipWon: false` and `outcomeConfidence: explicit`.

This is the narrow hotfix. It prevents false claims. A fuller follow-up can derive champion/runner-up from final winners-bracket matchup data when standings ranks are missing or invalid.

## Validation

- `corepack pnpm --dir workers/espn-client exec vitest run src/shared/__tests__/standings.test.ts src/sports/baseball/__tests__/standings.test.ts`
- `corepack pnpm --dir workers/espn-client run type-check`
- `corepack pnpm --dir workers/espn-client test`
- `git diff --check`
