### PR TITLE
[codex] Add Yahoo refresh cooldown backoff

### DIFF
--- a/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
@@ -77,6 +77,7 @@ describe('yahoo-connect-handlers', () => {
     getYahooCredentialHealth: ReturnType<typeof vi.fn>;
     updateYahooCredentials: ReturnType<typeof vi.fn>;
     updateYahooCredentialsIfRefreshTokenMatches: ReturnType<typeof vi.fn>;
+    markRefreshCooldown: ReturnType<typeof vi.fn>;
     acquireRefreshLease: ReturnType<typeof vi.fn>;
     releaseRefreshLease: ReturnType<typeof vi.fn>;
     deleteYahooCredentials: ReturnType<typeof vi.fn>;
@@ -97,6 +98,7 @@ describe('yahoo-connect-handlers', () => {
       getYahooCredentialHealth: vi.fn(),
       updateYahooCredentials: vi.fn().mockResolvedValue(true),
       updateYahooCredentialsIfRefreshTokenMatches: vi.fn().mockResolvedValue(false),
+      markRefreshCooldown: vi.fn().mockResolvedValue(true),
       acquireRefreshLease: vi.fn().mockResolvedValue(true),
       releaseRefreshLease: vi.fn().mockResolvedValue(undefined),
       deleteYahooCredentials: vi.fn().mockResolvedValue(undefined),
@@ -906,7 +908,7 @@ describe('yahoo-connect-handlers', () => {
       );
     });
 
-    it('retains the short lease instead of marking cooldown when Yahoo rate-limits refresh', async () => {
+    it('marks a refresh cooldown when Yahoo rate-limits refresh', async () => {
       const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
       mockStorage.getYahooCredentials.mockResolvedValue({
         clerkUserId: 'user_123',
@@ -943,10 +945,16 @@ describe('yahoo-connect-handlers', () => {
       expect(body.error_description).toBe('Too many token requests');
       expect(body.upstream_status).toBe(429);
       expect(body.retryable).toBe(true);
-      expect(body.retry_after).toBe(900);
+      expect(body.retry_after).toBe(60);
       expect(body.retry_after_source).toBe('fallback_default');
-      expect(response.headers.get('Retry-After')).toBe('900');
+      expect(response.headers.get('Retry-After')).toBe('60');
       expect(capturedOwnerId).toBeDefined();
+      expect(mockStorage.markRefreshCooldown).toHaveBeenCalledWith(
+        'user_123',
+        capturedOwnerId,
+        `cooldown:${capturedOwnerId}`,
+        60_000
+      );
       expect(mockStorage.releaseRefreshLease).not.toHaveBeenCalled();
       expect(yahooRefreshDiagnostics(logSpy)).toEqual(
         expect.arrayContaining([
@@ -963,10 +971,11 @@ describe('yahoo-connect-handlers', () => {
             diagnostic_class: 'yahoo_rate_limit',
           }),
           expect.objectContaining({
-            event: 'refresh_failure_lease_retained',
+            event: 'refresh_cooldown_marked',
             correlation_id: 'req_no_cooldown',
             outcome: 'rate_limited',
             diagnostic_class: 'yahoo_rate_limit',
+            reason: 'cooldown_marked',
           }),
         ])
       );
@@ -1104,10 +1113,16 @@ describe('yahoo-connect-handlers', () => {
       expect(body.error_description).toBe('Too many token requests [95022]');
       expect(body.upstream_status).toBe(429);
       expect(body.retryable).toBe(true);
-      expect(body.retry_after).toBe(900);
+      expect(body.retry_after).toBe(60);
       expect(body.retry_after_source).toBe('fallback_default');
-      expect(response.headers.get('Retry-After')).toBe('900');
+      expect(response.headers.get('Retry-After')).toBe('60');
       expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockStorage.markRefreshCooldown).toHaveBeenCalledWith(
+        'user_123',
+        expect.any(String),
+        expect.stringMatching(/^cooldown:/),
+        60_000
+      );
       expect(mockStorage.releaseRefreshLease).not.toHaveBeenCalled();
       expect(mockStorage.updateYahooCredentials).not.toHaveBeenCalled();
 
@@ -1139,9 +1154,16 @@ describe('yahoo-connect-handlers', () => {
             event: 'refresh_transient_failure',
             outcome: 'rate_limited',
             diagnostic_class: 'yahoo_rate_limit',
-            retry_after: 900,
+            retry_after: 60,
             retry_after_source: 'fallback_default',
             upstream_status: 429,
+          }),
+          expect.objectContaining({
+            event: 'refresh_cooldown_marked',
+            outcome: 'rate_limited',
+            diagnostic_class: 'yahoo_rate_limit',
+            retry_after: 60,
+            retry_after_source: 'fallback_default',
           }),
         ])
       );
@@ -1153,7 +1175,7 @@ describe('yahoo-connect-handlers', () => {
       expect(serialized).toContain('[redacted]');
     });
 
-    it('logs upstream Yahoo Retry-After during refresh without entering cooldown', async () => {
+    it('uses upstream Yahoo Retry-After when marking refresh cooldown', async () => {
       const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
       mockStorage.getYahooCredentials.mockResolvedValue({
         clerkUserId: 'user_123',
@@ -1184,6 +1206,12 @@ describe('yahoo-connect-handlers', () => {
       expect(body.retry_after).toBe(120);
       expect(body.retry_after_source).toBe('upstream_header');
       expect(response.headers.get('Retry-After')).toBe('120');
+      expect(mockStorage.markRefreshCooldown).toHaveBeenCalledWith(
+        'user_123',
+        expect.any(String),
+        expect.stringMatching(/^cooldown:/),
+        120_000
+      );
       expect(mockStorage.releaseRefreshLease).not.toHaveBeenCalled();
 
       expect(yahooRefreshDiagnostics(logSpy)).toEqual(
@@ -1284,10 +1312,16 @@ describe('yahoo-connect-handlers', () => {
       expect(body.error).toBe('refresh_temporarily_unavailable');
       expect(body.error_description).toBe('Yahoo token endpoint returned 999');
       expect(body.retryable).toBe(true);
-      expect(body.retry_after).toBe(900);
+      expect(body.retry_after).toBe(60);
       expect(body.retry_after_source).toBe('fallback_default');
       expect(body.upstream_status).toBe(999);
       expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockStorage.markRefreshCooldown).toHaveBeenCalledWith(
+        'user_123',
+        expect.any(String),
+        expect.stringMatching(/^cooldown:/),
+        60_000
+      );
       expect(mockStorage.releaseRefreshLease).not.toHaveBeenCalled();
       expect(mockStorage.updateYahooCredentials).not.toHaveBeenCalled();
     });
@@ -1686,7 +1720,7 @@ describe('yahoo-connect-handlers', () => {
       expect(mockStorage.releaseRefreshLease).toHaveBeenCalledWith('user_123', expect.any(String));
     });
 
-    it('clears a legacy active refresh cooldown and attempts refresh', async () => {
+    it('returns retryable failure without calling Yahoo during active refresh cooldown', async () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date('2026-05-11T18:15:00Z'));
       try {
@@ -1699,31 +1733,26 @@ describe('yahoo-connect-handlers', () => {
           refreshLeaseOwner: 'cooldown:owner-1',
           refreshLeaseExpiresAt: new Date(Date.now() + 45_000),
         });
-        mockFetch.mockResolvedValue(
-          new Response(
-            JSON.stringify({
-              access_token: 'new-access-token',
-              refresh_token: 'new-refresh-token',
-              expires_in: 3600,
-            }),
-            { status: 200 }
-          )
-        );
 
         const response = await handleYahooCredentials(env, 'user_123', corsHeaders);
 
-        expect(response.status).toBe(200);
+        expect(response.status).toBe(503);
         const body = (await response.json()) as Record<string, unknown>;
-        expect(body.access_token).toBe('new-access-token');
-        expect(mockStorage.releaseRefreshLease).toHaveBeenCalledWith('user_123', 'cooldown:owner-1');
-        expect(mockStorage.acquireRefreshLease).toHaveBeenCalledWith('user_123', expect.any(String), 30_000, 'refresh-token');
-        expect(mockFetch).toHaveBeenCalledTimes(1);
+        expect(body.error).toBe('refresh_temporarily_unavailable');
+        expect(body.error_description).toBe('Yahoo token refresh is cooling down after a temporary Yahoo response. Please try again shortly.');
+        expect(body.retryable).toBe(true);
+        expect(body.retry_after).toBe(45);
+        expect(body.retry_after_source).toBe('fallback_default');
+        expect(response.headers.get('Retry-After')).toBe('45');
+        expect(mockStorage.releaseRefreshLease).not.toHaveBeenCalled();
+        expect(mockStorage.acquireRefreshLease).not.toHaveBeenCalled();
+        expect(mockFetch).not.toHaveBeenCalled();
       } finally {
         vi.useRealTimers();
       }
     });
 
-    it('continues refresh after a legacy cooldown release failure', async () => {
+    it('logs active refresh cooldown without calling Yahoo', async () => {
       const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
       vi.useFakeTimers();
       vi.setSystemTime(new Date('2026-05-11T18:15:00Z'));
@@ -1737,45 +1766,25 @@ describe('yahoo-connect-handlers', () => {
           refreshLeaseOwner: 'cooldown:owner-1',
           refreshLeaseExpiresAt: new Date(Date.now() + 45_000),
         });
-        mockFetch.mockResolvedValue(
-          new Response(
-            JSON.stringify({
-              access_token: 'new-access-token',
-              refresh_token: 'new-refresh-token',
-              expires_in: 3600,
-            }),
-            { status: 200 }
-          )
-        );
-        mockStorage.releaseRefreshLease.mockRejectedValueOnce(new Error('release failed'));
 
-        const response = await handleYahooCredentials(env, 'user_123', corsHeaders, 'req_bypass_cooldown');
+        const response = await handleYahooCredentials(env, 'user_123', corsHeaders, 'req_active_cooldown');
 
-        expect(response.status).toBe(200);
+        expect(response.status).toBe(503);
         const body = (await response.json()) as Record<string, unknown>;
-        expect(body.access_token).toBe('new-access-token');
-        expect(mockStorage.releaseRefreshLease).toHaveBeenCalledWith('user_123', 'cooldown:owner-1');
-        expect(mockStorage.acquireRefreshLease).toHaveBeenCalledWith('user_123', expect.any(String), 30_000, 'refresh-token');
-        expect(mockFetch).toHaveBeenCalledTimes(1);
+        expect(body.error).toBe('refresh_temporarily_unavailable');
+        expect(mockStorage.releaseRefreshLease).not.toHaveBeenCalled();
+        expect(mockStorage.acquireRefreshLease).not.toHaveBeenCalled();
+        expect(mockFetch).not.toHaveBeenCalled();
         expect(yahooRefreshDiagnostics(logSpy)).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
-              event: 'cooldown_bypassed',
-              correlation_id: 'req_bypass_cooldown',
-              outcome: 'cooldown_bypassed',
+              event: 'refresh_cooldown_active',
+              correlation_id: 'req_active_cooldown',
+              outcome: 'retryable_failure',
               diagnostic_class: 'cooldown_active',
               refresh_state: 'cooldown',
               lease_remaining_seconds: 45,
-            }),
-            expect.objectContaining({
-              event: 'cooldown_bypass_release_failed',
-              correlation_id: 'req_bypass_cooldown',
-              diagnostic_class: 'cooldown_active',
-              reason: 'release_failed',
-            }),
-            expect.objectContaining({
-              event: 'refresh_request_started',
-              correlation_id: 'req_bypass_cooldown',
+              retry_after: 45,
             }),
           ])
         );
@@ -2594,7 +2603,7 @@ describe('yahoo-connect-handlers', () => {
       expect(body.error_description).toBe('Refresh token already used');
     });
 
-    it('returns retryable metadata from discovery path for transient Yahoo refresh response without cooldown', async () => {
+    it('returns retryable metadata from discovery path for transient Yahoo refresh cooldown', async () => {
       const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
       mockStorage.getYahooCredentials.mockResolvedValue({
         clerkUserId: 'user_123',
@@ -2621,10 +2630,16 @@ describe('yahoo-connect-handlers', () => {
       expect(body.error).toBe('refresh_temporarily_unavailable');
       expect(body.error_description).toBe('Too many token requests');
       expect(body.retryable).toBe(true);
-      expect(body.retry_after).toBe(900);
+      expect(body.retry_after).toBe(60);
       expect(body.retry_after_source).toBe('fallback_default');
       expect(body.upstream_status).toBe(429);
       expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockStorage.markRefreshCooldown).toHaveBeenCalledWith(
+        'user_123',
+        expect.any(String),
+        expect.stringMatching(/^cooldown:/),
+        60_000
+      );
       expect(mockStorage.releaseRefreshLease).not.toHaveBeenCalled();
       expect(mockStorage.updateYahooCredentials).not.toHaveBeenCalled();
       expect(mockStorage.upsertYahooLeague).not.toHaveBeenCalled();
@@ -2637,6 +2652,11 @@ describe('yahoo-connect-handlers', () => {
           expect.objectContaining({
             event: 'refresh_transient_failure',
             correlation_id: 'req_discover',
+          }),
+          expect.objectContaining({
+            event: 'refresh_cooldown_marked',
+            correlation_id: 'req_discover',
+            retry_after: 60,
           }),
         ])
       );

--- a/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
@@ -13,6 +13,7 @@ import { YahooStorage } from '../yahoo-storage';
 
 // Mock YahooStorage
 vi.mock('../yahoo-storage', () => ({
+  REFRESH_COOLDOWN_OWNER_PREFIX: 'cooldown:',
   YahooStorage: {
     fromEnvironment: vi.fn(),
   },
@@ -1018,6 +1019,48 @@ describe('yahoo-connect-handlers', () => {
             correlation_id: 'req_cooldown_mark_failed',
             diagnostic_class: 'yahoo_rate_limit',
             reason: 'storage_error',
+            retry_after: 60,
+            retry_after_source: 'fallback_default',
+          }),
+        ])
+      );
+    });
+
+    it('keeps retryable metadata when another owner wins before cooldown marking', async () => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+      mockStorage.getYahooCredentials.mockResolvedValue({
+        clerkUserId: 'user_123',
+        accessToken: 'old-access-token',
+        refreshToken: 'refresh-token',
+        expiresAt: new Date(Date.now() + 2 * 60 * 1000),
+        needsRefresh: true,
+      });
+      mockStorage.acquireRefreshLease.mockResolvedValue(true);
+      mockStorage.markRefreshCooldown.mockResolvedValue(false);
+      mockFetch.mockResolvedValue(new Response(
+        JSON.stringify({
+          error: 'rate_limited',
+          error_description: 'Too many token requests',
+        }),
+        { status: 429 }
+      ));
+
+      const response = await handleYahooCredentials(env, 'user_123', corsHeaders, 'req_cooldown_owner_miss');
+
+      expect(response.status).toBe(503);
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.error).toBe('refresh_temporarily_unavailable');
+      expect(body.retryable).toBe(true);
+      expect(body.retry_after).toBe(60);
+      expect(body.retry_after_source).toBe('fallback_default');
+      expect(mockStorage.releaseRefreshLease).not.toHaveBeenCalled();
+      expect(yahooRefreshDiagnostics(logSpy)).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            event: 'refresh_cooldown_marked',
+            correlation_id: 'req_cooldown_owner_miss',
+            diagnostic_class: 'yahoo_rate_limit',
+            reason: 'owner_guard_miss',
             retry_after: 60,
             retry_after_source: 'fallback_default',
           }),
@@ -2070,6 +2113,65 @@ describe('yahoo-connect-handlers', () => {
               correlation_id: 'req_loser_waits',
               diagnostic_class: 'lease_not_acquired',
               retry_after: 5,
+            }),
+          ])
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('loser: returns latest cooldown marker without calling Yahoo', async () => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+      vi.useFakeTimers();
+      const start = new Date('2026-05-21T18:45:00Z');
+      vi.setSystemTime(start);
+
+      try {
+        const activeWinnerLease = {
+          clerkUserId: 'user_123',
+          accessToken: 'old-token',
+          refreshToken: 'old-refresh',
+          expiresAt: new Date(start.getTime() + 2 * 60 * 1000),
+          needsRefresh: true,
+          refreshLeaseOwner: 'winner-owner',
+          refreshLeaseExpiresAt: new Date(start.getTime() + 30_000),
+        };
+        const activeCooldown = {
+          ...activeWinnerLease,
+          refreshLeaseOwner: 'cooldown:winner-owner',
+          refreshLeaseExpiresAt: new Date(start.getTime() + 28_000),
+        };
+
+        mockStorage.getYahooCredentials
+          .mockResolvedValueOnce(activeWinnerLease)
+          .mockResolvedValueOnce(activeCooldown);
+        mockStorage.acquireRefreshLease.mockResolvedValue(false);
+
+        const response = await handleYahooCredentials(env, 'user_123', corsHeaders, 'req_loser_cooldown');
+
+        expect(response.status).toBe(503);
+        const body = (await response.json()) as Record<string, unknown>;
+        expect(body.error).toBe('refresh_temporarily_unavailable');
+        expect(body.retryable).toBe(true);
+        expect(body.retry_after).toBe(28);
+        expect(body.retry_after_source).toBe('cooldown_remaining');
+        expect(response.headers.get('Retry-After')).toBe('28');
+        expect(mockFetch).not.toHaveBeenCalled();
+        expect(mockStorage.acquireRefreshLease).toHaveBeenCalledTimes(1);
+        expect(mockStorage.getYahooCredentials).toHaveBeenCalledTimes(2);
+        expect(yahooRefreshDiagnostics(logSpy)).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              event: 'lease_not_acquired',
+              correlation_id: 'req_loser_cooldown',
+            }),
+            expect.objectContaining({
+              event: 'refresh_cooldown_active',
+              correlation_id: 'req_loser_cooldown',
+              refresh_state: 'cooldown',
+              retry_after: 28,
+              retry_after_source: 'cooldown_remaining',
             }),
           ])
         );

--- a/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
@@ -952,7 +952,6 @@ describe('yahoo-connect-handlers', () => {
       expect(mockStorage.markRefreshCooldown).toHaveBeenCalledWith(
         'user_123',
         capturedOwnerId,
-        `cooldown:${capturedOwnerId}`,
         60_000
       );
       expect(mockStorage.releaseRefreshLease).not.toHaveBeenCalled();
@@ -976,6 +975,51 @@ describe('yahoo-connect-handlers', () => {
             outcome: 'rate_limited',
             diagnostic_class: 'yahoo_rate_limit',
             reason: 'cooldown_marked',
+          }),
+        ])
+      );
+    });
+
+    it('returns retryable failure when refresh cooldown marking hits storage error', async () => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+      vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      mockStorage.getYahooCredentials.mockResolvedValue({
+        clerkUserId: 'user_123',
+        accessToken: 'old-access-token',
+        refreshToken: 'refresh-token',
+        expiresAt: new Date(Date.now() + 2 * 60 * 1000),
+        needsRefresh: true,
+      });
+      mockStorage.acquireRefreshLease.mockResolvedValue(true);
+      mockStorage.markRefreshCooldown.mockRejectedValue(new Error('db unavailable'));
+      mockFetch.mockResolvedValue(new Response(
+        JSON.stringify({
+          error: 'rate_limited',
+          error_description: 'Too many token requests',
+        }),
+        { status: 429 }
+      ));
+
+      const response = await handleYahooCredentials(env, 'user_123', corsHeaders, 'req_cooldown_mark_failed');
+
+      expect(response.status).toBe(503);
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.error).toBe('refresh_temporarily_unavailable');
+      expect(body.error_description).toBe('Too many token requests');
+      expect(body.retryable).toBe(true);
+      expect(body.retry_after).toBe(60);
+      expect(body.retry_after_source).toBe('fallback_default');
+      expect(mockStorage.releaseRefreshLease).not.toHaveBeenCalled();
+      expect(mockStorage.updateYahooCredentials).not.toHaveBeenCalled();
+      expect(yahooRefreshDiagnostics(logSpy)).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            event: 'refresh_cooldown_mark_failed',
+            correlation_id: 'req_cooldown_mark_failed',
+            diagnostic_class: 'yahoo_rate_limit',
+            reason: 'storage_error',
+            retry_after: 60,
+            retry_after_source: 'fallback_default',
           }),
         ])
       );
@@ -1120,7 +1164,6 @@ describe('yahoo-connect-handlers', () => {
       expect(mockStorage.markRefreshCooldown).toHaveBeenCalledWith(
         'user_123',
         expect.any(String),
-        expect.stringMatching(/^cooldown:/),
         60_000
       );
       expect(mockStorage.releaseRefreshLease).not.toHaveBeenCalled();
@@ -1209,7 +1252,6 @@ describe('yahoo-connect-handlers', () => {
       expect(mockStorage.markRefreshCooldown).toHaveBeenCalledWith(
         'user_123',
         expect.any(String),
-        expect.stringMatching(/^cooldown:/),
         120_000
       );
       expect(mockStorage.releaseRefreshLease).not.toHaveBeenCalled();
@@ -1319,7 +1361,6 @@ describe('yahoo-connect-handlers', () => {
       expect(mockStorage.markRefreshCooldown).toHaveBeenCalledWith(
         'user_123',
         expect.any(String),
-        expect.stringMatching(/^cooldown:/),
         60_000
       );
       expect(mockStorage.releaseRefreshLease).not.toHaveBeenCalled();
@@ -1742,7 +1783,7 @@ describe('yahoo-connect-handlers', () => {
         expect(body.error_description).toBe('Yahoo token refresh is cooling down after a temporary Yahoo response. Please try again shortly.');
         expect(body.retryable).toBe(true);
         expect(body.retry_after).toBe(45);
-        expect(body.retry_after_source).toBe('fallback_default');
+        expect(body.retry_after_source).toBe('cooldown_remaining');
         expect(response.headers.get('Retry-After')).toBe('45');
         expect(mockStorage.releaseRefreshLease).not.toHaveBeenCalled();
         expect(mockStorage.acquireRefreshLease).not.toHaveBeenCalled();
@@ -1785,6 +1826,7 @@ describe('yahoo-connect-handlers', () => {
               refresh_state: 'cooldown',
               lease_remaining_seconds: 45,
               retry_after: 45,
+              retry_after_source: 'cooldown_remaining',
             }),
           ])
         );
@@ -2637,7 +2679,6 @@ describe('yahoo-connect-handlers', () => {
       expect(mockStorage.markRefreshCooldown).toHaveBeenCalledWith(
         'user_123',
         expect.any(String),
-        expect.stringMatching(/^cooldown:/),
         60_000
       );
       expect(mockStorage.releaseRefreshLease).not.toHaveBeenCalled();

--- a/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
@@ -1026,46 +1026,70 @@ describe('yahoo-connect-handlers', () => {
       );
     });
 
-    it('keeps retryable metadata when another owner wins before cooldown marking', async () => {
+    it('uses stored cooldown metadata when another owner wins before cooldown marking', async () => {
       const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
-      mockStorage.getYahooCredentials.mockResolvedValue({
-        clerkUserId: 'user_123',
-        accessToken: 'old-access-token',
-        refreshToken: 'refresh-token',
-        expiresAt: new Date(Date.now() + 2 * 60 * 1000),
-        needsRefresh: true,
-      });
-      mockStorage.acquireRefreshLease.mockResolvedValue(true);
-      mockStorage.markRefreshCooldown.mockResolvedValue(false);
-      mockFetch.mockResolvedValue(new Response(
-        JSON.stringify({
-          error: 'rate_limited',
-          error_description: 'Too many token requests',
-        }),
-        { status: 429 }
-      ));
-
-      const response = await handleYahooCredentials(env, 'user_123', corsHeaders, 'req_cooldown_owner_miss');
-
-      expect(response.status).toBe(503);
-      const body = (await response.json()) as Record<string, unknown>;
-      expect(body.error).toBe('refresh_temporarily_unavailable');
-      expect(body.retryable).toBe(true);
-      expect(body.retry_after).toBe(60);
-      expect(body.retry_after_source).toBe('fallback_default');
-      expect(mockStorage.releaseRefreshLease).not.toHaveBeenCalled();
-      expect(yahooRefreshDiagnostics(logSpy)).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            event: 'refresh_cooldown_marked',
-            correlation_id: 'req_cooldown_owner_miss',
-            diagnostic_class: 'yahoo_rate_limit',
-            reason: 'owner_guard_miss',
-            retry_after: 60,
-            retry_after_source: 'fallback_default',
+      vi.useFakeTimers();
+      const start = new Date('2026-05-21T18:45:00Z');
+      vi.setSystemTime(start);
+      try {
+        mockStorage.getYahooCredentials
+          .mockResolvedValueOnce({
+            clerkUserId: 'user_123',
+            accessToken: 'old-access-token',
+            refreshToken: 'refresh-token',
+            expiresAt: new Date(start.getTime() + 2 * 60 * 1000),
+            needsRefresh: true,
+          })
+          .mockResolvedValueOnce({
+            clerkUserId: 'user_123',
+            accessToken: 'old-access-token',
+            refreshToken: 'refresh-token',
+            expiresAt: new Date(start.getTime() + 2 * 60 * 1000),
+            needsRefresh: true,
+            refreshLeaseOwner: 'cooldown:other-owner',
+            refreshLeaseExpiresAt: new Date(start.getTime() + 120_000),
+          });
+        mockStorage.acquireRefreshLease.mockResolvedValue(true);
+        mockStorage.markRefreshCooldown.mockResolvedValue(false);
+        mockFetch.mockResolvedValue(new Response(
+          JSON.stringify({
+            error: 'rate_limited',
+            error_description: 'Too many token requests',
           }),
-        ])
-      );
+          { status: 429 }
+        ));
+
+        const response = await handleYahooCredentials(env, 'user_123', corsHeaders, 'req_cooldown_owner_miss');
+
+        expect(response.status).toBe(503);
+        const body = (await response.json()) as Record<string, unknown>;
+        expect(body.error).toBe('refresh_temporarily_unavailable');
+        expect(body.retryable).toBe(true);
+        expect(body.retry_after).toBe(120);
+        expect(body.retry_after_source).toBe('cooldown_remaining');
+        expect(mockStorage.releaseRefreshLease).not.toHaveBeenCalled();
+        expect(mockStorage.getYahooCredentials).toHaveBeenCalledTimes(2);
+        expect(yahooRefreshDiagnostics(logSpy)).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              event: 'refresh_cooldown_marked',
+              correlation_id: 'req_cooldown_owner_miss',
+              diagnostic_class: 'yahoo_rate_limit',
+              reason: 'owner_guard_miss',
+              retry_after: 60,
+              retry_after_source: 'fallback_default',
+            }),
+            expect.objectContaining({
+              event: 'refresh_cooldown_active',
+              correlation_id: 'req_cooldown_owner_miss',
+              retry_after: 120,
+              retry_after_source: 'cooldown_remaining',
+            }),
+          ])
+        );
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('does not treat permanent token failures as retryable just because the body says too many', async () => {

--- a/workers/auth-worker/src/__tests__/yahoo-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-storage.test.ts
@@ -580,6 +580,51 @@ describe('YahooStorage', () => {
     });
   });
 
+  describe('markRefreshCooldown', () => {
+    it('marks cooldown only for the current lease owner', async () => {
+      mockSelect.mockResolvedValue({ data: [{ clerk_user_id: 'user_123' }], error: null });
+
+      const result = await storage.markRefreshCooldown(
+        'user_123',
+        'owner-1',
+        'cooldown:owner-1',
+        60_000
+      );
+
+      expect(result).toBe(true);
+      expect(mockUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          refresh_lease_owner: 'cooldown:owner-1',
+          refresh_lease_expires_at: expect.any(String),
+        })
+      );
+      expect(mockEq).toHaveBeenNthCalledWith(1, 'clerk_user_id', 'user_123');
+      expect(mockEq).toHaveBeenNthCalledWith(2, 'refresh_lease_owner', 'owner-1');
+      expect(mockSelect).toHaveBeenCalledWith('clerk_user_id');
+    });
+
+    it('returns false when the current lease owner changed', async () => {
+      mockSelect.mockResolvedValue({ data: [], error: null });
+
+      const result = await storage.markRefreshCooldown(
+        'user_123',
+        'owner-1',
+        'cooldown:owner-1',
+        60_000
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('throws when cooldown marking hits a storage error', async () => {
+      mockSelect.mockResolvedValue({ data: null, error: { message: 'cooldown failed' } });
+
+      await expect(
+        storage.markRefreshCooldown('user_123', 'owner-1', 'cooldown:owner-1', 60_000)
+      ).rejects.toThrow('Failed to mark Yahoo refresh cooldown');
+    });
+  });
+
   describe('releaseRefreshLease', () => {
     it('clears the lease only for the current owner', async () => {
       await storage.releaseRefreshLease('user_123', 'owner-1');

--- a/workers/auth-worker/src/__tests__/yahoo-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-storage.test.ts
@@ -587,7 +587,6 @@ describe('YahooStorage', () => {
       const result = await storage.markRefreshCooldown(
         'user_123',
         'owner-1',
-        'cooldown:owner-1',
         60_000
       );
 
@@ -609,7 +608,6 @@ describe('YahooStorage', () => {
       const result = await storage.markRefreshCooldown(
         'user_123',
         'owner-1',
-        'cooldown:owner-1',
         60_000
       );
 
@@ -620,7 +618,7 @@ describe('YahooStorage', () => {
       mockSelect.mockResolvedValue({ data: null, error: { message: 'cooldown failed' } });
 
       await expect(
-        storage.markRefreshCooldown('user_123', 'owner-1', 'cooldown:owner-1', 60_000)
+        storage.markRefreshCooldown('user_123', 'owner-1', 60_000)
       ).rejects.toThrow('Failed to mark Yahoo refresh cooldown');
     });
   });

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -176,6 +176,10 @@ const LEASE_TTL_MS       = 30_000;
 const YAHOO_TOKEN_REQUEST_TIMEOUT_MS = 20_000;
 const YAHOO_REQUEST_LEASE_SAFETY_MS = 1_000;
 const REFRESH_COOLDOWN_OWNER_PREFIX = 'cooldown:';
+// Yahoo token refresh 429s often omit Retry-After. Keep our own no-Yahoo
+// window modest so interactive users are not blocked for 15 minutes while
+// still preventing rapid retry pile-ons.
+const YAHOO_REFRESH_RATE_LIMIT_FALLBACK_COOLDOWN_SECONDS = 60;
 
 /**
  * Get the OAuth callback URL based on environment
@@ -646,48 +650,32 @@ function isRefreshCooldown(credentials: { refreshLeaseOwner?: string; refreshLea
     && !leaseExpired(credentials);
 }
 
-async function clearLegacyYahooRefreshCooldown(
-  storage: YahooStorage,
-  credentials: YahooCredentials,
-  correlationId?: string
-): Promise<YahooCredentials> {
-  if (!credentials.refreshLeaseOwner?.startsWith(REFRESH_COOLDOWN_OWNER_PREFIX)) {
-    return credentials;
-  }
-
-  logYahooRefreshDiagnostic('cooldown_bypassed', {
-    correlationId,
-    userId: credentials.clerkUserId,
-    phase: 'cooldown',
-    outcome: 'cooldown_bypassed',
-    diagnosticClass: 'cooldown_active',
-    reason: 'legacy_cooldown_cleared',
-    leaseRemainingSeconds: retryAfterFromLease(credentials),
-    refreshState: yahooRefreshState(credentials),
-  });
-
-  try {
-    await storage.releaseRefreshLease(credentials.clerkUserId, credentials.refreshLeaseOwner);
-  } catch (releaseError) {
-    console.warn('[yahoo-connect] Failed to release legacy Yahoo refresh cooldown:', releaseError);
-    logYahooRefreshDiagnostic('cooldown_bypass_release_failed', {
-      correlationId,
-      userId: credentials.clerkUserId,
-      phase: 'cooldown',
-      outcome: 'cooldown_bypassed',
-      diagnosticClass: 'cooldown_active',
-      reason: 'release_failed',
-    });
-  }
-  return {
-    ...credentials,
-    refreshLeaseOwner: undefined,
-    refreshLeaseExpiresAt: undefined,
-  };
-}
-
 function retryAfterFromLease(credentials: { refreshLeaseExpiresAt?: Date } | null): number | undefined {
   return boundedPositiveSecondsUntil(credentials?.refreshLeaseExpiresAt);
+}
+
+function yahooRefreshCooldownResult(
+  credentials: YahooCredentials,
+  logDiagnostic: (event: string, fields?: YahooRefreshDiagnosticFields) => void
+): GetTokenResult {
+  const retryAfter = retryAfterFromLease(credentials) ?? YAHOO_REFRESH_IN_PROGRESS_RETRY_AFTER_SECONDS;
+  logDiagnostic('refresh_cooldown_active', {
+    userId: credentials.clerkUserId,
+    phase: 'cooldown',
+    outcome: 'retryable_failure',
+    diagnosticClass: 'cooldown_active',
+    refreshState: 'cooldown',
+    retryAfter,
+    retryAfterSource: 'fallback_default',
+    leaseRemainingSeconds: retryAfter,
+  });
+  return {
+    error: YahooAuthWorkerErrorCode.REFRESH_TEMPORARILY_UNAVAILABLE,
+    errorDescription: 'Yahoo token refresh is cooling down after a temporary Yahoo response. Please try again shortly.',
+    retryable: true,
+    retryAfter,
+    retryAfterSource: 'fallback_default',
+  };
 }
 
 function yahooTokenRequestDiagnosticFields(
@@ -814,15 +802,7 @@ async function getValidYahooAccessToken(
   }
 
   if (isRefreshCooldown(credentials)) {
-    credentials = await clearLegacyYahooRefreshCooldown(storage, credentials, correlationId);
-    if (!credentials.needsRefresh) {
-      logDiagnostic('cooldown_clear_found_fresh_token', {
-        userId,
-        accessTokenExpiresInSeconds: secondsUntil(credentials.expiresAt),
-        secondsSinceCredentialUpdate: secondsSince(credentials.updatedAt),
-      });
-      return toTokenResult(credentials);
-    }
+    return yahooRefreshCooldownResult(credentials, logDiagnostic);
   }
 
   const ownerId = crypto.randomUUID();
@@ -863,6 +843,9 @@ async function getValidYahooAccessToken(
         secondsSinceCredentialUpdate: secondsSince(latest.updatedAt),
       });
       return toTokenResult(latest);
+    }
+    if (isRefreshCooldown(latest)) {
+      return yahooRefreshCooldownResult(latest, logDiagnostic);
     }
     return {
       error: YahooAuthWorkerErrorCode.REFRESH_TEMPORARILY_UNAVAILABLE,
@@ -990,11 +973,14 @@ async function getValidYahooAccessToken(
     );
 
     if (failureKind === 'transient_http' || failureKind === 'transient_text') {
+      const isRateLimited = isYahooRateLimitStatus(result.status);
       const upstreamRetryAfter = result.retry_after_source === 'upstream_header'
         ? result.retry_after
         : undefined;
       const retryAfter = upstreamRetryAfter
-        ?? defaultYahooRetryAfterSeconds(result.status)
+        ?? (isRateLimited
+          ? YAHOO_REFRESH_RATE_LIMIT_FALLBACK_COOLDOWN_SECONDS
+          : defaultYahooRetryAfterSeconds(result.status))
         ?? YAHOO_DEFAULT_TRANSIENT_RETRY_AFTER_SECONDS;
       const retryAfterSource = upstreamRetryAfter !== undefined
         ? 'upstream_header'
@@ -1010,17 +996,54 @@ async function getValidYahooAccessToken(
         ...yahooTokenResponseDiagnosticFields(result),
         secondsSinceCredentialUpdate: secondsSince(credentials.updatedAt),
       });
-      logDiagnostic('refresh_failure_lease_retained', {
-        userId,
-        phase: 'refresh_response',
-        outcome: diagnosticOutcome,
-        diagnosticClass,
-        retryAfter,
-        retryAfterSource,
-        failureKind,
-        ...yahooTokenResponseDiagnosticFields(result),
-        secondsSinceCredentialUpdate: secondsSince(credentials.updatedAt),
-      });
+      if (isRateLimited) {
+        try {
+          const cooldownMarked = await storage.markRefreshCooldown(
+            userId,
+            ownerId,
+            `${REFRESH_COOLDOWN_OWNER_PREFIX}${ownerId}`,
+            retryAfter * 1000
+          );
+          logDiagnostic('refresh_cooldown_marked', {
+            userId,
+            phase: 'cooldown',
+            outcome: diagnosticOutcome,
+            diagnosticClass,
+            retryAfter,
+            retryAfterSource,
+            failureKind,
+            reason: cooldownMarked ? 'cooldown_marked' : 'owner_guard_miss',
+            ...yahooTokenResponseDiagnosticFields(result),
+            secondsSinceCredentialUpdate: secondsSince(credentials.updatedAt),
+          });
+        } catch (cooldownError) {
+          console.warn('[yahoo-connect] Failed to mark Yahoo refresh cooldown:', cooldownError);
+          logDiagnostic('refresh_cooldown_mark_failed', {
+            userId,
+            phase: 'cooldown',
+            outcome: 'retryable_failure',
+            diagnosticClass,
+            retryAfter,
+            retryAfterSource,
+            failureKind,
+            reason: 'storage_error',
+            ...yahooTokenResponseDiagnosticFields(result),
+            secondsSinceCredentialUpdate: secondsSince(credentials.updatedAt),
+          });
+        }
+      } else {
+        logDiagnostic('refresh_failure_lease_retained', {
+          userId,
+          phase: 'refresh_response',
+          outcome: diagnosticOutcome,
+          diagnosticClass,
+          retryAfter,
+          retryAfterSource,
+          failureKind,
+          ...yahooTokenResponseDiagnosticFields(result),
+          secondsSinceCredentialUpdate: secondsSince(credentials.updatedAt),
+        });
+      }
       return {
         error: YahooAuthWorkerErrorCode.REFRESH_TEMPORARILY_UNAVAILABLE,
         errorDescription: result.error_description || 'Yahoo token refresh temporarily unavailable. Please try again shortly.',

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -662,7 +662,7 @@ function yahooRefreshCooldownResult(
   credentials: YahooCredentials,
   logDiagnostic: (event: string, fields?: YahooRefreshDiagnosticFields) => void
 ): GetTokenResult {
-  const retryAfter = retryAfterFromLease(credentials) ?? YAHOO_REFRESH_IN_PROGRESS_RETRY_AFTER_SECONDS;
+  const retryAfter = retryAfterFromLease(credentials) ?? YAHOO_REFRESH_RATE_LIMIT_FALLBACK_COOLDOWN_SECONDS;
   logDiagnostic('refresh_cooldown_active', {
     userId: credentials.clerkUserId,
     phase: 'cooldown',
@@ -1019,6 +1019,12 @@ async function getValidYahooAccessToken(
             ...yahooTokenResponseDiagnosticFields(result),
             secondsSinceCredentialUpdate: secondsSince(credentials.updatedAt),
           });
+          if (!cooldownMarked) {
+            const latest = await storage.getYahooCredentials(userId);
+            if (latest && isRefreshCooldown(latest)) {
+              return yahooRefreshCooldownResult(latest, logDiagnostic);
+            }
+          }
         } catch (cooldownError) {
           console.warn('[yahoo-connect] Failed to mark Yahoo refresh cooldown:', cooldownError);
           logDiagnostic('refresh_cooldown_mark_failed', {

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -17,7 +17,12 @@
  * For the PROVIDER side (issuing tokens TO AI clients), see oauth-handlers.ts.
  */
 
-import { YahooStorage, type YahooCredentialHealth, type YahooCredentials } from './yahoo-storage';
+import {
+  REFRESH_COOLDOWN_OWNER_PREFIX,
+  YahooStorage,
+  type YahooCredentialHealth,
+  type YahooCredentials,
+} from './yahoo-storage';
 import { getFrontendUrl, resolvePreviewOrigin } from './preview-url';
 import {
   YAHOO_DEFAULT_TRANSIENT_RETRY_AFTER_SECONDS,
@@ -175,7 +180,6 @@ const LEASE_TTL_MS       = 30_000;
 // Used for both OAuth exchange and refresh token requests; must stay below LEASE_TTL_MS.
 const YAHOO_TOKEN_REQUEST_TIMEOUT_MS = 20_000;
 const YAHOO_REQUEST_LEASE_SAFETY_MS = 1_000;
-const REFRESH_COOLDOWN_OWNER_PREFIX = 'cooldown:';
 // Yahoo token refresh 429s often omit Retry-After. Keep our own no-Yahoo
 // window modest so interactive users are not blocked for 15 minutes while
 // still preventing rapid retry pile-ons.

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -71,7 +71,7 @@ interface YahooTokenResponse {
 
 type YahooCredentialRefreshState = 'none' | 'in_progress' | 'cooldown' | 'expired';
 type YahooTokenGrantType = 'authorization_code' | 'refresh_token';
-type YahooRetryAfterSource = 'upstream_header' | 'fallback_default';
+type YahooRetryAfterSource = 'upstream_header' | 'fallback_default' | 'cooldown_remaining';
 type YahooTokenBodyClass =
   | 'empty'
   | 'json_error'
@@ -666,7 +666,7 @@ function yahooRefreshCooldownResult(
     diagnosticClass: 'cooldown_active',
     refreshState: 'cooldown',
     retryAfter,
-    retryAfterSource: 'fallback_default',
+    retryAfterSource: 'cooldown_remaining',
     leaseRemainingSeconds: retryAfter,
   });
   return {
@@ -674,7 +674,7 @@ function yahooRefreshCooldownResult(
     errorDescription: 'Yahoo token refresh is cooling down after a temporary Yahoo response. Please try again shortly.',
     retryable: true,
     retryAfter,
-    retryAfterSource: 'fallback_default',
+    retryAfterSource: 'cooldown_remaining',
   };
 }
 
@@ -1001,7 +1001,6 @@ async function getValidYahooAccessToken(
           const cooldownMarked = await storage.markRefreshCooldown(
             userId,
             ownerId,
-            `${REFRESH_COOLDOWN_OWNER_PREFIX}${ownerId}`,
             retryAfter * 1000
           );
           logDiagnostic('refresh_cooldown_marked', {

--- a/workers/auth-worker/src/yahoo-storage.ts
+++ b/workers/auth-worker/src/yahoo-storage.ts
@@ -371,6 +371,37 @@ export class YahooStorage {
   }
 
   /**
+   * Convert the current refresh lease into a short cooldown marker.
+   * Only the active lease owner can mark cooldown, which prevents stale callers
+   * from extending backoff after another request has already taken over.
+   */
+  async markRefreshCooldown(
+    clerkUserId: string,
+    ownerId: string,
+    cooldownOwnerId: string,
+    ttlMs: number
+  ): Promise<boolean> {
+    const expiresAt = new Date(Date.now() + ttlMs).toISOString();
+
+    const { data, error } = await this.supabase
+      .from('yahoo_credentials')
+      .update({
+        refresh_lease_owner: cooldownOwnerId,
+        refresh_lease_expires_at: expiresAt,
+      })
+      .eq('clerk_user_id', clerkUserId)
+      .eq('refresh_lease_owner', ownerId)
+      .select('clerk_user_id');
+
+    if (error) {
+      console.error('[yahoo-storage] Failed to mark Yahoo refresh cooldown:', error);
+      throw new Error('Failed to mark Yahoo refresh cooldown');
+    }
+
+    return (data?.length ?? 0) > 0;
+  }
+
+  /**
    * Atomically acquire the refresh lease for a user.
    *
    * The update only succeeds if no other owner holds an unexpired lease

--- a/workers/auth-worker/src/yahoo-storage.ts
+++ b/workers/auth-worker/src/yahoo-storage.ts
@@ -16,6 +16,8 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { clearDefaultsForLeague as _clearDefaultsForLeague, clearDefaultsForPlatform as _clearDefaultsForPlatform } from './preference-defaults';
 
+const REFRESH_COOLDOWN_OWNER_PREFIX = 'cooldown:';
+
 // =============================================================================
 // TYPES
 // =============================================================================
@@ -378,7 +380,6 @@ export class YahooStorage {
   async markRefreshCooldown(
     clerkUserId: string,
     ownerId: string,
-    cooldownOwnerId: string,
     ttlMs: number
   ): Promise<boolean> {
     const expiresAt = new Date(Date.now() + ttlMs).toISOString();
@@ -386,7 +387,7 @@ export class YahooStorage {
     const { data, error } = await this.supabase
       .from('yahoo_credentials')
       .update({
-        refresh_lease_owner: cooldownOwnerId,
+        refresh_lease_owner: `${REFRESH_COOLDOWN_OWNER_PREFIX}${ownerId}`,
         refresh_lease_expires_at: expiresAt,
       })
       .eq('clerk_user_id', clerkUserId)

--- a/workers/auth-worker/src/yahoo-storage.ts
+++ b/workers/auth-worker/src/yahoo-storage.ts
@@ -16,7 +16,7 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { clearDefaultsForLeague as _clearDefaultsForLeague, clearDefaultsForPlatform as _clearDefaultsForPlatform } from './preference-defaults';
 
-const REFRESH_COOLDOWN_OWNER_PREFIX = 'cooldown:';
+export const REFRESH_COOLDOWN_OWNER_PREFIX = 'cooldown:';
 
 // =============================================================================
 // TYPES


### PR DESCRIPTION
## Summary

- honor active Yahoo refresh cooldown markers instead of clearing them as legacy state
- convert Yahoo token-endpoint rate-limit responses into a short shared cooldown stored on the existing refresh lease fields
- keep one caller from repeatedly reacquiring the lease and hitting Yahoo while another request has already observed a 429
- add storage and auth-worker tests for cooldown marking, owner guards, active cooldown responses, and Retry-After handling

## Why

Production saw clustered Yahoo token refresh failures where `/oauth2/get_token` returned HTTP 429 with `Too many failed requests` and no upstream `Retry-After`. The current code returned a retryable 503 with a long fallback retry value, but only retained the original 30s lease. After that lease expired, additional user retries could acquire a new lease and hit Yahoo again, feeding another 429 cluster.

This change makes the first rate-limited refresh request set a short shared cooldown marker in the database. Other concurrent or follow-up requests now return retryable cooldown responses without calling Yahoo until the marker expires.

## Behavior

- Yahoo token refresh 429/999 responses without upstream `Retry-After` use a 60s internal cooldown.
- If Yahoo provides a real `Retry-After`, that value is preserved.
- Non-rate-limit transient refresh failures keep the prior lease-retention behavior.
- No schema changes are required; this reuses `refresh_lease_owner` and `refresh_lease_expires_at`.

## Validation

- `corepack pnpm --dir workers/auth-worker test`
- `corepack pnpm --dir workers/auth-worker type-check`
- `git diff --check`

Local runs show the existing Node engine warning because this machine is on Node v26 while the repo expects Node 24.x.
