### PR TITLE
[codex] Make get_user_session read-only for stale defaults

### DIFF
--- a/workers/fantasy-mcp/src/__tests__/tools.test.ts
+++ b/workers/fantasy-mcp/src/__tests__/tools.test.ts
@@ -680,13 +680,14 @@ describe('fantasy-mcp tools', () => {
     expect(deleteCalled).toBe(false);
     expect(payload.defaultLeagues.football).toBeUndefined();
 
-    // Warning should mention the stale league
+    // Warning should mention the stale league without locking punctuation.
     expect(payload.warnings).toBeDefined();
     expect(payload.warnings!.length).toBeGreaterThan(0);
-    expect(payload.warnings![0]).toBe('Stale football default detected: league old-fb is no longer in your active leagues.');
+    expect(payload.warnings![0]).toContain('Stale football default detected');
+    expect(payload.warnings![0]).toContain('old-fb');
   });
 
-  it('get_user_session: stale default skips DELETE when platform fetch failed', async () => {
+  it('get_user_session: emits unavailability warning when platform fetch fails', async () => {
     const tool = getUnifiedTools().find((t) => t.name === 'get_user_session');
     expect(tool).toBeTruthy();
 
@@ -694,8 +695,6 @@ describe('fantasy-mcp tools', () => {
       defaultSport: 'football',
       defaultFootball: { platform: 'yahoo', leagueId: 'nfl.l.123', seasonYear: 2025 },
     };
-
-    let deleteCalled = false;
 
     const env = {
       INTERNAL_SERVICE_TOKEN: 'internal-secret',
@@ -721,10 +720,6 @@ describe('fantasy-mcp tools', () => {
               headers: { 'Content-Type': 'application/json' },
             });
           }
-          if (req.method === 'DELETE' && url.pathname.startsWith('/internal/leagues/default/')) {
-            deleteCalled = true;
-            return new Response(JSON.stringify({ success: true }), { status: 200 });
-          }
           return new Response(JSON.stringify({ leagues: [] }), {
             status: 200,
             headers: { 'Content-Type': 'application/json' },
@@ -736,9 +731,6 @@ describe('fantasy-mcp tools', () => {
     const result = await tool!.handler({}, env, 'Bearer test-token');
     const payload = JSON.parse(result.content[0].text) as { warnings?: string[] };
 
-    // DELETE must NOT fire when the platform fetch failed
-    expect(deleteCalled).toBe(false);
-    // A warning should appear mentioning the unavailability (not clearing)
     expect(payload.warnings?.some((w) => w.includes('temporarily unavailable'))).toBe(true);
   });
 

--- a/workers/fantasy-mcp/src/__tests__/tools.test.ts
+++ b/workers/fantasy-mcp/src/__tests__/tools.test.ts
@@ -678,6 +678,7 @@ describe('fantasy-mcp tools', () => {
 
     // get_user_session is advertised as read-only and must not clear stale defaults.
     expect(deleteCalled).toBe(false);
+    // Stale entries are filtered from the response even though storage is not mutated.
     expect(payload.defaultLeagues.football).toBeUndefined();
 
     // Warning should mention the stale league without locking punctuation.

--- a/workers/fantasy-mcp/src/__tests__/tools.test.ts
+++ b/workers/fantasy-mcp/src/__tests__/tools.test.ts
@@ -624,8 +624,8 @@ describe('fantasy-mcp tools', () => {
     expect(payload.defaultLeague?.sport).toBe('football');
   });
 
-  // Test C: stale default → DELETE fires with platform+leagueId params, warning appended
-  it('get_user_session: stale default fires conditional DELETE and appends warning', async () => {
+  // Test C: stale default → no mutation, warning appended
+  it('get_user_session: stale default does not DELETE and appends warning', async () => {
     const tool = getUnifiedTools().find((t) => t.name === 'get_user_session');
     expect(tool).toBeTruthy();
 
@@ -637,7 +637,6 @@ describe('fantasy-mcp tools', () => {
     };
 
     let deleteCalled = false;
-    let deleteUrl: URL | null = null;
 
     const env = {
       INTERNAL_SERVICE_TOKEN: 'internal-secret',
@@ -658,7 +657,6 @@ describe('fantasy-mcp tools', () => {
           }
           if (req.method === 'DELETE' && url.pathname.startsWith('/internal/leagues/default/')) {
             deleteCalled = true;
-            deleteUrl = url;
             return new Response(JSON.stringify({ success: true }), {
               status: 200,
               headers: { 'Content-Type': 'application/json' },
@@ -674,19 +672,18 @@ describe('fantasy-mcp tools', () => {
 
     const result = await tool!.handler({}, env, 'Bearer test-token');
     const payload = JSON.parse(result.content[0].text) as {
+      defaultLeagues: Record<string, unknown>;
       warnings?: string[];
     };
 
-    // DELETE should have been called with platform + leagueId + seasonYear query params
-    expect(deleteCalled).toBe(true);
-    expect(deleteUrl!.searchParams.get('platform')).toBe('espn');
-    expect(deleteUrl!.searchParams.get('leagueId')).toBe('old-fb');
-    expect(deleteUrl!.searchParams.get('seasonYear')).toBe('2024');
+    // get_user_session is advertised as read-only and must not clear stale defaults.
+    expect(deleteCalled).toBe(false);
+    expect(payload.defaultLeagues.football).toBeUndefined();
 
     // Warning should mention the stale league
     expect(payload.warnings).toBeDefined();
     expect(payload.warnings!.length).toBeGreaterThan(0);
-    expect(payload.warnings![0]).toContain('old-fb');
+    expect(payload.warnings![0]).toBe('Stale football default detected: league old-fb is no longer in your active leagues.');
   });
 
   it('get_user_session: stale default skips DELETE when platform fetch failed', async () => {

--- a/workers/fantasy-mcp/src/mcp/instructions.ts
+++ b/workers/fantasy-mcp/src/mcp/instructions.ts
@@ -8,10 +8,11 @@
 export const FLAIM_MCP_INSTRUCTIONS = `Flaim provides read-only fantasy league data across ESPN, Yahoo, and Sleeper.
 
 Scope resolution rules:
-1. Call get_user_session once at the start of the chat, before any data tool.
-2. For vague singular prompts ("how's my team?", "what's my matchup?"), use the applicable default from the session response: defaultLeague when present, otherwise the relevant sport entry in defaultLeagues. No fan-out and no clarifying question if a valid default exists.
-3. For explicit plural or comparative prompts ("each of my leagues", "compare my ESPN and Yahoo", "all my teams", "across my leagues"), enumerate every matching league in allLeagues and call the target tool once per league before synthesizing.
-4. For ambiguous prompts with no applicable default, ask which league.
-5. Call get_league_info early for any league-specific tool chain so team names, scoring, and roster slots are resolved before downstream calls. When fanning out, call it once per league.
-6. Never infer league ownership from a player's market_percent_owned or ownership_scope. For "who owns X in my league", enumerate teams via get_league_info and call get_roster per team.
-7. Do not retry the same tool with the same parameters on error. season_year is always the start year of the season.`;
+1. Only use Flaim for fantasy sports questions that need the user's connected league data; do not call Flaim for generic coding, scraping, weather, travel, betting, or non-fantasy sports questions.
+2. Call get_user_session once at the start of the chat, before any data tool.
+3. For vague singular prompts ("how's my team?", "what's my matchup?"), use the applicable default from the session response: defaultLeague when present, otherwise the relevant sport entry in defaultLeagues. No fan-out and no clarifying question if a valid default exists.
+4. For explicit plural or comparative prompts ("each of my leagues", "compare my ESPN and Yahoo", "all my teams", "across my leagues"), enumerate every matching league in allLeagues and call the target tool once per league before synthesizing.
+5. For ambiguous prompts with no applicable default, ask which league.
+6. Call get_league_info early for any league-specific tool chain so team names, scoring, and roster slots are resolved before downstream calls. When fanning out, call it once per league.
+7. Never infer league ownership from a player's market_percent_owned or ownership_scope. For "who owns X in my league", enumerate teams via get_league_info and call get_roster per team.
+8. Do not retry the same tool with the same parameters on error. season_year is always the start year of the season.`;

--- a/workers/fantasy-mcp/src/mcp/tools.ts
+++ b/workers/fantasy-mcp/src/mcp/tools.ts
@@ -456,7 +456,7 @@ export function getUnifiedTools(): UnifiedTool[] {
       openaiMeta: { invoking: 'Loading your leagues\u2026', invoked: 'Leagues loaded' },
       widgetUri: 'ui://widget/user-session.html',
       description:
-        "Call this exactly once at the start of each chat before any other Flaim tool. Returns the user's full league landscape: allLeagues (all active leagues), defaultLeagues (per-sport defaults), and defaultLeague (populated only when a single league exists or defaultSport matches). For vague singular prompts, use defaultLeague when present; otherwise use the relevant sport entry in defaultLeagues. For explicit plural or comparative prompts (each, all, compare, across leagues/platforms), enumerate every matching league in allLeagues and call the target tool once per league. In normal chat flows, do not skip this first step. After this, strongly consider calling get_league_info for the target league. season_year always represents the start year of the season. Read-only. If this call errors, do not repeat it unchanged.",
+        "Use only for fantasy sports questions that need the user's connected league data; do not call for generic coding, scraping, weather, travel, betting, or non-fantasy sports questions. Call this exactly once at the start of each chat before any other Flaim tool. Returns the user's full league landscape: allLeagues (all active leagues), defaultLeagues (per-sport defaults), and defaultLeague (populated only when a single league exists or defaultSport matches). For vague singular prompts, use defaultLeague when present; otherwise use the relevant sport entry in defaultLeagues. For explicit plural or comparative prompts (each, all, compare, across leagues/platforms), enumerate every matching league in allLeagues and call the target tool once per league. In normal chat flows, do not skip this first step. After this, strongly consider calling get_league_info for the target league. season_year always represents the start year of the season. Read-only. If this call errors, do not repeat it unchanged.",
       inputSchema: {},
       handler: async (_args, env, authHeader, correlationId, evalRunId, evalTraceId) => {
         return withToolLogging(correlationId, 'get_user_session', 'session', async () => {
@@ -621,35 +621,9 @@ export function getUnifiedTools(): UnifiedTool[] {
                   warnings.push(`Preserved non-current ${sport} default: league ${defaultInfo.leagueId} is not shown in active leagues.`);
                 } else {
                   // Platform fetch succeeded but league is missing — it's genuinely stale.
-                  // Fire a best-effort clear so future reads don't repeat this lookup.
-                  const staleBaseHeaders: Record<string, string> = {
-                    'Content-Type': 'application/json',
-                    ...(authHeader ? { Authorization: authHeader } : {}),
-                  };
-                  const withStaleCorrelation = correlationId ? withCorrelationId(staleBaseHeaders, correlationId) : new Headers(staleBaseHeaders);
-                  const withStaleInternal = withInternalServiceToken(withStaleCorrelation, env, `auth-worker /internal/leagues/default/${sport}`);
-                  const staleHeaders = withEvalHeaders(withStaleInternal, evalRunId, evalTraceId);
-                  const staleUrl = new URL(`https://internal/internal/leagues/default/${sport}`);
-                  staleUrl.searchParams.set('platform', defaultInfo.platform);
-                  staleUrl.searchParams.set('leagueId', defaultInfo.leagueId);
-                  staleUrl.searchParams.set('seasonYear', String(defaultInfo.seasonYear));
-                  let cleared = false;
-                  try {
-                    const clearResp = await env.AUTH_WORKER.fetch(
-                      new Request(staleUrl.toString(), { method: 'DELETE', headers: staleHeaders })
-                    );
-                    cleared = clearResp.ok;
-                    if (!clearResp.ok) {
-                      console.error(`[get_user_session] Stale ${sport} default DELETE returned ${clearResp.status}`);
-                    }
-                  } catch (e) {
-                    console.error(`[get_user_session] Network error clearing stale ${sport} default:`, e);
-                  }
-                  warnings.push(
-                    cleared
-                      ? `Cleared stale ${sport} default: league ${defaultInfo.leagueId} is no longer in your active leagues.`
-                      : `Stale ${sport} default detected (league ${defaultInfo.leagueId} is no longer active) — automatic cleanup failed, will retry next session.`
-                  );
+                  // Keep get_user_session truly read-only: report stale defaults
+                  // without mutating preferences from this tool call.
+                  warnings.push(`Stale ${sport} default detected: league ${defaultInfo.leagueId} is no longer in your active leagues.`);
                 }
               }
             }

--- a/workers/fantasy-mcp/src/mcp/tools.ts
+++ b/workers/fantasy-mcp/src/mcp/tools.ts
@@ -622,8 +622,9 @@ export function getUnifiedTools(): UnifiedTool[] {
                 } else {
                   // Platform fetch succeeded but league is missing — it's genuinely stale.
                   // Keep get_user_session truly read-only: report stale defaults
-                  // without mutating preferences from this tool call.
-                  warnings.push(`Stale ${sport} default detected: league ${defaultInfo.leagueId} is no longer in your active leagues.`);
+                  // without mutating preferences from this tool call. Preference
+                  // cleanup belongs in an explicit settings/write path.
+                  warnings.push(`Stale ${sport} default detected: league ${defaultInfo.leagueId} is no longer in your active leagues. Update your default league in Flaim league settings to clear this warning.`);
                 }
               }
             }


### PR DESCRIPTION
## Summary

- Add concise fantasy-only scope guidance to the MCP instructions and `get_user_session` description.
- Keep stale defaults out of `defaultLeagues`/`defaultLeague` without issuing a `DELETE` from `get_user_session`.
- Update the stale-default unit test to assert the tool remains read-only and emits a warning.

## Why

`get_user_session` is registered with `readOnlyHint: true`, but the stale-default path was mutating user preferences by clearing missing defaults. This keeps the advertised read-only contract while still surfacing stale defaults to the user/model.

## Validation

- `corepack pnpm --dir workers/fantasy-mcp exec vitest run src/__tests__/tools.test.ts -t get_user_session`
- `corepack pnpm --dir workers/fantasy-mcp exec vitest run -c vitest.integration.config.ts tests/integration/index.integration.test.ts -t emits`

## Notes

This is a fresh patch from `origin/main`; it does not merge or cherry-pick `codex/platform-status-ui`. It intentionally does not change widget metadata, `openWorldHint`, widget domains, external-link behavior, or current-season filtering.