### PR TITLE
Add Resend welcome automation

### DIFF
--- a/docs/EMAILS.md
+++ b/docs/EMAILS.md
@@ -58,6 +58,22 @@ Clerk is the source of truth for user identity. Resend is the product email audi
 
 The contact sync stores only email, first name, and last name. It intentionally does not resubscribe existing contacts during updates, so Resend unsubscribe state remains authoritative for product and broadcast email. If `RESEND_CONTACT_SEGMENT_ID` is set, new and updated contacts are assigned to that Resend Segment for future Broadcast targeting. Avoid writing custom Resend contact properties unless those properties have first been created in Resend.
 
+The first automated product email is a Resend Automation for new-user welcome email. Flaim does not queue or schedule this email itself. After a verified Clerk `user.created` webhook successfully syncs the Resend contact, the webhook emits the custom Resend event `flaim.user_created`. Resend owns the automation run, email rendering, unsubscribe handling, and run history.
+
+Keep the welcome automation behind `RESEND_WELCOME_AUTOMATION_ENABLED=true` until the Resend event, template, automation, and real inbox test are verified. The event emitter uses `RESEND_EVENTS_API_KEY` when set, otherwise it falls back to `RESEND_CONTACTS_API_KEY`; do not use the send-only `RESEND_API_KEY` for event/automation management.
+
+Before enabling the flag in production, confirm failed welcome event sends are visible in the production logs or alerting path. The Clerk webhook intentionally acknowledges verified user events even if the downstream Resend event call fails, so a Resend outage or expired events key will not retry through Clerk.
+
+Create or refresh the Resend-side resources with:
+
+```sh
+corepack pnpm --dir web exec node scripts/setup-resend-welcome-automation.mjs
+```
+
+The setup script creates the `flaim.user_created` event, publishes the `flaim-welcome-v1` template, and creates/updates the `Flaim Welcome Email` automation as `disabled`. Re-running the script intentionally disables the automation again as a safety guard while templates are being revised. Enable the automation in Resend only after the production webhook event path has been tested.
+
+The Resend automation template is currently hand-built in `web/scripts/setup-resend-welcome-automation.mjs` and must stay visually synchronized with `web/emails/welcome.tsx`. Shared action URLs live in `web/emails/flaim-email-links.json`. When changing the welcome email, update the React preview and setup-script HTML together, run `corepack pnpm --dir web run email:export`, rerun the setup script, and send a real test email before enabling or re-enabling the automation.
+
 Existing users are backfilled with a separate dry-run-first script. Run it from the repo root:
 
 ```sh

--- a/web/.env.example
+++ b/web/.env.example
@@ -53,5 +53,10 @@ SUPABASE_SERVICE_KEY=sb_secret_...
 RESEND_API_KEY=re_...
 FLAIM_EMAILS_ENABLED=false
 RESEND_CONTACT_SYNC_ENABLED=false
+RESEND_CONTACTS_API_KEY=
+# Optional: separate key for Resend event and automation APIs. Falls back to
+# RESEND_CONTACTS_API_KEY when unset.
+RESEND_EVENTS_API_KEY=
+RESEND_WELCOME_AUTOMATION_ENABLED=false
 # Optional: assign synced Clerk contacts to a Resend Segment for future Broadcasts.
 RESEND_CONTACT_SEGMENT_ID=

--- a/web/app/api/webhooks/clerk/route.ts
+++ b/web/app/api/webhooks/clerk/route.ts
@@ -1,9 +1,13 @@
 import { verifyWebhook } from "@clerk/nextjs/webhooks";
-import { NextRequest, NextResponse } from "next/server";
+import { after, NextRequest, NextResponse } from "next/server";
 import {
   syncClerkUserToResendContact,
   type ClerkUserEmailSyncPayload,
 } from "@/lib/server/resend-contact-sync";
+import {
+  isWelcomeAutomationEnabled,
+  sendWelcomeAutomationEvent,
+} from "@/lib/server/resend-welcome-automation";
 
 const CONTACT_SYNC_EVENTS = new Set(["user.created", "user.updated"]);
 
@@ -47,5 +51,26 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Contact sync failed", received: true, sync: result });
   }
 
-  return NextResponse.json({ received: true, sync: result });
+  if (event.type !== "user.created" || !result.ok) {
+    return NextResponse.json({ received: true, sync: result });
+  }
+
+  if (!isWelcomeAutomationEnabled()) {
+    return NextResponse.json({
+      received: true,
+      sync: result,
+      welcome: { skipped: true, error: "Resend welcome automation is disabled" },
+    });
+  }
+
+  after(async () => {
+    // The request-level guard already checked the feature flag; pass an explicit
+    // enabled override so this queued side effect reflects that same decision.
+    const welcome = await sendWelcomeAutomationEvent(event.data, { enabled: true });
+    if (!welcome.ok && !welcome.skipped) {
+      console.error("Resend welcome automation event failed:", welcome.error);
+    }
+  });
+
+  return NextResponse.json({ received: true, sync: result, welcome: { queued: true } });
 }

--- a/web/emails/flaim-email-links.json
+++ b/web/emails/flaim-email-links.json
@@ -1,0 +1,4 @@
+{
+  "chatGptAppUrl": "https://chatgpt.com/apps/flaim-fantasy/asdk_app_69a8f78087e081919e52cacacf00ff36",
+  "leaguesUrl": "https://flaim.app/leagues"
+}

--- a/web/emails/welcome.tsx
+++ b/web/emails/welcome.tsx
@@ -1,29 +1,117 @@
 import * as React from "react";
 import {
-  FlaimButton,
-  FlaimCallout,
-  FlaimCalloutText,
   FlaimEmailLayout,
   FlaimFooterLink,
   FlaimText,
 } from "./components/FlaimEmailLayout";
+import emailLinks from "./flaim-email-links.json";
 
 interface WelcomeEmailProps {
+  chatGptAppUrl?: string;
   firstName?: string;
-  leaguesUrl: string;
+  leaguesUrl?: string;
   /** Must be a real unsubscribe or notification-preferences URL before connecting to a live sender. */
-  unsubscribeUrl: string;
+  unsubscribeUrl?: string;
+}
+
+function WelcomeSetupPath({
+  chatGptAppUrl,
+  leaguesUrl,
+}: {
+  chatGptAppUrl: string;
+  leaguesUrl: string;
+}) {
+  return (
+    <div
+      style={{
+        backgroundColor: "#f9fafb",
+        border: "1px solid #e5e7eb",
+        borderRadius: "8px",
+        margin: "8px 0 20px",
+        padding: "16px",
+      }}
+    >
+      <p style={{ color: "#030712", fontSize: "14px", fontWeight: "700", lineHeight: "22px", margin: "0 0 12px" }}>
+        Finish your setup
+      </p>
+      <table cellPadding="0" cellSpacing="0" role="presentation" style={{ marginBottom: "10px", width: "100%" }}>
+        <tbody>
+          <tr>
+            <td style={{ padding: "0", verticalAlign: "middle", width: "33.333%" }}>
+              <div style={{ backgroundColor: "#22c55e", borderRadius: "999px 0 0 999px", height: "6px", width: "100%" }} />
+            </td>
+            <td style={{ padding: "0", verticalAlign: "middle", width: "33.333%" }}>
+              <div style={{ backgroundColor: "#e5e7eb", height: "6px", width: "100%" }} />
+            </td>
+            <td style={{ padding: "0", verticalAlign: "middle", width: "33.333%" }}>
+              <div style={{ backgroundColor: "#e5e7eb", borderRadius: "0 999px 999px 0", height: "6px", width: "100%" }} />
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <table cellPadding="0" cellSpacing="0" role="presentation" style={{ width: "100%" }}>
+        <tbody>
+          <tr>
+            <td style={{ padding: "0 6px 0 0", verticalAlign: "top", width: "33.333%" }}>
+              <p style={{ color: "#166534", fontSize: "11px", fontWeight: "700", lineHeight: "16px", margin: "0", textTransform: "uppercase" }}>
+                Done
+              </p>
+              <p style={{ color: "#030712", fontSize: "12px", lineHeight: "17px", margin: "2px 0 0" }}>
+                Account
+              </p>
+            </td>
+            <td style={{ padding: "0 6px", verticalAlign: "top", width: "33.333%" }}>
+              <p style={{ color: "#030712", fontSize: "11px", fontWeight: "700", lineHeight: "16px", margin: "0", textTransform: "uppercase" }}>
+                Next
+              </p>
+              <a
+                href={leaguesUrl}
+                style={{
+                  color: "#030712",
+                  fontSize: "12px",
+                  fontWeight: "700",
+                  lineHeight: "17px",
+                  textDecoration: "underline",
+                  textUnderlineOffset: "3px",
+                }}
+              >
+                Connect a league →
+              </a>
+            </td>
+            <td style={{ padding: "0 0 0 6px", verticalAlign: "top", width: "33.333%" }}>
+              <p style={{ color: "#6b7280", fontSize: "11px", fontWeight: "700", lineHeight: "16px", margin: "0", textTransform: "uppercase" }}>
+                Then
+              </p>
+              <a
+                href={chatGptAppUrl}
+                style={{
+                  color: "#6b7280",
+                  fontSize: "12px",
+                  fontWeight: "700",
+                  lineHeight: "17px",
+                  textDecoration: "underline",
+                  textUnderlineOffset: "3px",
+                }}
+              >
+                Open in ChatGPT →
+              </a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
 }
 
 export default function WelcomeEmail({
+  chatGptAppUrl = emailLinks.chatGptAppUrl,
   firstName = "Alex",
-  leaguesUrl,
-  unsubscribeUrl,
+  leaguesUrl = emailLinks.leaguesUrl,
+  unsubscribeUrl = "mailto:support@flaim.app?subject=Unsubscribe%20from%20Flaim%20product%20updates",
 }: WelcomeEmailProps) {
   return (
     <FlaimEmailLayout
       eyebrow="WELCOME"
-      footerDescription="Flaim connects your real fantasy leagues to your AI assistant for read-only, league-specific analysis."
       footerDisclosure={
         <>
           You are receiving this because you created a Flaim account.{" "}
@@ -36,24 +124,33 @@ export default function WelcomeEmail({
     >
       <FlaimText>Hi {firstName},</FlaimText>
       <FlaimText>
-        Flaim is ready when you are. Connect ESPN, Yahoo, or Sleeper to ChatGPT
-        to ask questions using your actual roster, standings, and league data.
-        Include web search to get updated stats, waiver wire adds, trade
-        targets, and more. Enjoy.
+        Flaim lets you ask fantasy questions using your real league data,
+        including your roster, standings, matchups, and transactions. Once
+        connected, you can ask about waiver adds, trade ideas, roster decisions,
+        and league trends.
       </FlaimText>
-      <FlaimButton href={leaguesUrl}>Open league setup</FlaimButton>
-      <FlaimCallout>
-        <FlaimCalloutText>
-          Flaim is read-only. It can access your league data, but it cannot set
-          lineups, drop players, make trades, or change league settings.
-        </FlaimCalloutText>
-      </FlaimCallout>
+      <WelcomeSetupPath chatGptAppUrl={chatGptAppUrl} leaguesUrl={leaguesUrl} />
+      <p
+        style={{
+          borderTop: "1px solid #e5e7eb",
+          color: "#6b7280",
+          fontSize: "13px",
+          lineHeight: "21px",
+          margin: "22px 0 0",
+          paddingTop: "16px",
+        }}
+      >
+        Flaim is read-only. It can access your league data, but it cannot set
+        lineups, drop players, make trades, or change league settings.
+      </p>
     </FlaimEmailLayout>
   );
 }
 
 WelcomeEmail.PreviewProps = {
+  chatGptAppUrl: emailLinks.chatGptAppUrl,
   firstName: "Alex",
-  leaguesUrl: "https://flaim.app/leagues",
-  unsubscribeUrl: "https://flaim.app/notifications/unsubscribe?token=PREVIEW_ONLY",
+  leaguesUrl: emailLinks.leaguesUrl,
+  unsubscribeUrl:
+    "mailto:support@flaim.app?subject=Unsubscribe%20from%20Flaim%20product%20updates",
 } satisfies WelcomeEmailProps;

--- a/web/lib/server/__tests__/resend-welcome-automation.test.ts
+++ b/web/lib/server/__tests__/resend-welcome-automation.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  isWelcomeAutomationEnabled,
+  sendWelcomeAutomationEvent,
+  WELCOME_AUTOMATION_EVENT_NAME,
+} from "../resend-welcome-automation";
+import type { ClerkUserEmailSyncPayload } from "../resend-contact-sync";
+
+const clerkUser: ClerkUserEmailSyncPayload = {
+  email_addresses: [
+    {
+      id: "primary",
+      email_address: "Gerry@Example.com",
+      verification: { status: "verified" },
+    },
+  ],
+  first_name: " Gerry ",
+  id: "user_123",
+  last_name: " Gugger ",
+  primary_email_address_id: "primary",
+};
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("isWelcomeAutomationEnabled", () => {
+  it("uses the welcome automation environment flag when no override is passed", () => {
+    vi.stubEnv("RESEND_WELCOME_AUTOMATION_ENABLED", "true");
+
+    expect(isWelcomeAutomationEnabled()).toBe(true);
+
+    vi.stubEnv("RESEND_WELCOME_AUTOMATION_ENABLED", "false");
+
+    expect(isWelcomeAutomationEnabled()).toBe(false);
+    expect(isWelcomeAutomationEnabled({ enabled: true })).toBe(true);
+  });
+});
+
+describe("sendWelcomeAutomationEvent", () => {
+  it("skips when the welcome automation is disabled", async () => {
+    const send = vi.fn();
+
+    const result = await sendWelcomeAutomationEvent(clerkUser, {
+      client: { events: { send } },
+      enabled: false,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      skipped: true,
+      error: "Resend welcome automation is disabled",
+    });
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("sends the configured Resend event for the Clerk primary email", async () => {
+    const send = vi.fn(async () => ({
+      data: { event: WELCOME_AUTOMATION_EVENT_NAME, object: "event" },
+      error: null,
+    }));
+
+    const result = await sendWelcomeAutomationEvent(clerkUser, {
+      client: { events: { send } },
+      enabled: true,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      email: "gerry@example.com",
+      event: WELCOME_AUTOMATION_EVENT_NAME,
+    });
+    expect(send).toHaveBeenCalledWith({
+      email: "gerry@example.com",
+      event: WELCOME_AUTOMATION_EVENT_NAME,
+      payload: {
+        clerk_user_id: "user_123",
+        first_name: "Gerry",
+        last_name: "Gugger",
+        source: "clerk.user_created",
+      },
+    });
+  });
+
+  it("falls back to a plain greeting name", async () => {
+    const send = vi.fn(async () => ({
+      data: { event: WELCOME_AUTOMATION_EVENT_NAME, object: "event" },
+      error: null,
+    }));
+
+    await sendWelcomeAutomationEvent(
+      { ...clerkUser, first_name: " " },
+      {
+        client: { events: { send } },
+        enabled: true,
+      },
+    );
+
+    expect(send).toHaveBeenCalledWith(expect.objectContaining({
+      payload: expect.objectContaining({ first_name: "there" }),
+    }));
+  });
+
+  it("skips when the Clerk user has no primary email", async () => {
+    const send = vi.fn();
+
+    const result = await sendWelcomeAutomationEvent(
+      { ...clerkUser, email_addresses: [], primary_email_address_id: null },
+      {
+        client: { events: { send } },
+        enabled: true,
+      },
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      skipped: true,
+      error: "Clerk user has no email address",
+    });
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("reports a missing Resend events client", async () => {
+    vi.stubEnv("RESEND_EVENTS_API_KEY", undefined);
+    vi.stubEnv("RESEND_CONTACTS_API_KEY", undefined);
+
+    const result = await sendWelcomeAutomationEvent(clerkUser, {
+      enabled: true,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: "RESEND_EVENTS_API_KEY or RESEND_CONTACTS_API_KEY is not configured",
+    });
+  });
+
+  it("reports a Resend event send error", async () => {
+    const send = vi.fn(async () => ({
+      data: null,
+      error: { message: "event rejected" },
+    }));
+
+    const result = await sendWelcomeAutomationEvent(clerkUser, {
+      client: { events: { send } },
+      enabled: true,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      email: "gerry@example.com",
+      event: WELCOME_AUTOMATION_EVENT_NAME,
+      error: "event rejected",
+    });
+  });
+});

--- a/web/lib/server/resend-client.ts
+++ b/web/lib/server/resend-client.ts
@@ -9,6 +9,8 @@ let resend: Resend | null = null;
 let resendApiKey: string | null = null;
 let resendContacts: Resend | null = null;
 let resendContactsApiKey: string | null = null;
+let resendEvents: Resend | null = null;
+let resendEventsApiKey: string | null = null;
 
 export function getResendClient() {
   const apiKey = process.env.RESEND_API_KEY;
@@ -32,6 +34,18 @@ export function getResendContactsClient() {
   }
 
   return resendContacts;
+}
+
+export function getResendEventsClient() {
+  const apiKey = process.env.RESEND_EVENTS_API_KEY ?? process.env.RESEND_CONTACTS_API_KEY;
+  if (!apiKey) return null;
+
+  if (!resendEvents || resendEventsApiKey !== apiKey) {
+    resendEvents = new Resend(apiKey);
+    resendEventsApiKey = apiKey;
+  }
+
+  return resendEvents;
 }
 
 export function getResendErrorMessage(error: ResendApiError | unknown) {

--- a/web/lib/server/resend-welcome-automation.ts
+++ b/web/lib/server/resend-welcome-automation.ts
@@ -1,0 +1,98 @@
+import "server-only";
+import type { SendEventOptions } from "resend";
+import {
+  getResendErrorMessage,
+  getResendEventsClient,
+} from "@/lib/server/resend-client";
+import {
+  getClerkUserPrimaryEmail,
+  type ClerkUserEmailSyncPayload,
+} from "@/lib/server/resend-contact-sync";
+
+export const WELCOME_AUTOMATION_EVENT_NAME = "flaim.user_created";
+
+export interface WelcomeAutomationEventResult {
+  email?: string;
+  error?: string;
+  event?: string;
+  ok: boolean;
+  skipped?: boolean;
+}
+
+type ResendEventApiError = {
+  message?: string;
+};
+
+type ResendEventApiResponse<T> =
+  | { data: T; error: null }
+  | { data: null; error: ResendEventApiError };
+
+interface WelcomeAutomationEventClient {
+  events: {
+    send: (
+      payload: SendEventOptions,
+    ) => Promise<ResendEventApiResponse<{ event: string; object: string }>>;
+  };
+}
+
+interface SendWelcomeAutomationEventOptions {
+  client?: WelcomeAutomationEventClient;
+  enabled?: boolean;
+  eventName?: string;
+}
+
+function cleanString(value: string | null | undefined) {
+  const cleaned = value?.trim();
+  return cleaned || null;
+}
+
+export function isWelcomeAutomationEnabled(options: SendWelcomeAutomationEventOptions = {}) {
+  return options.enabled ?? process.env.RESEND_WELCOME_AUTOMATION_ENABLED === "true";
+}
+
+export async function sendWelcomeAutomationEvent(
+  user: ClerkUserEmailSyncPayload,
+  options: SendWelcomeAutomationEventOptions = {},
+): Promise<WelcomeAutomationEventResult> {
+  if (!isWelcomeAutomationEnabled(options)) {
+    return { ok: false, skipped: true, error: "Resend welcome automation is disabled" };
+  }
+
+  const email = getClerkUserPrimaryEmail(user);
+  if (!email) {
+    return { ok: false, skipped: true, error: "Clerk user has no email address" };
+  }
+
+  const client = options.client ?? getResendEventsClient();
+  if (!client) {
+    return {
+      ok: false,
+      error: "RESEND_EVENTS_API_KEY or RESEND_CONTACTS_API_KEY is not configured",
+    };
+  }
+
+  const event = cleanString(options.eventName) ?? WELCOME_AUTOMATION_EVENT_NAME;
+  const firstName = cleanString(user.first_name);
+  const lastName = cleanString(user.last_name);
+
+  try {
+    const { data, error } = await client.events.send({
+      email,
+      event,
+      payload: {
+        clerk_user_id: user.id,
+        first_name: firstName ?? "there",
+        last_name: lastName ?? "",
+        source: "clerk.user_created",
+      },
+    });
+
+    if (error) {
+      return { ok: false, email, event, error: getResendErrorMessage(error) };
+    }
+
+    return { ok: true, email, event: data.event };
+  } catch (error) {
+    return { ok: false, email, event, error: getResendErrorMessage(error) };
+  }
+}

--- a/web/scripts/setup-resend-welcome-automation.mjs
+++ b/web/scripts/setup-resend-welcome-automation.mjs
@@ -1,0 +1,290 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Resend } from "resend";
+
+const EVENT_NAME = "flaim.user_created";
+const TEMPLATE_ALIAS = "flaim-welcome-v1";
+const TEMPLATE_NAME = "Flaim Welcome";
+const AUTOMATION_NAME = "Flaim Welcome Email";
+const RESEND_PROPAGATION_DELAY_MS = 300;
+const MAX_TEMPLATE_LIST_PAGES = 20;
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const emailLinks = JSON.parse(
+  readFileSync(join(scriptDir, "../emails/flaim-email-links.json"), "utf8"),
+);
+const CHATGPT_APP_URL = emailLinks.chatGptAppUrl;
+const LEAGUES_URL = emailLinks.leaguesUrl;
+
+const apiKey = process.env.RESEND_EVENTS_API_KEY ?? process.env.RESEND_CONTACTS_API_KEY;
+
+if (!apiKey) {
+  throw new Error("RESEND_EVENTS_API_KEY or RESEND_CONTACTS_API_KEY is required");
+}
+
+const resend = new Resend(apiKey);
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function assertSuccess(result, label) {
+  if (result.error) {
+    throw new Error(`${label}: ${result.error.message ?? "Unknown Resend error"}`);
+  }
+
+  return result.data;
+}
+
+async function ensureEvent() {
+  const events = assertSuccess(await resend.events.list(), "List Resend events");
+  const existing = events.data.find((event) => event.name === EVENT_NAME);
+  const schema = {
+    clerk_user_id: "string",
+    first_name: "string",
+    last_name: "string",
+    source: "string",
+  };
+
+  if (existing) {
+    assertSuccess(
+      await resend.events.update(existing.id, { schema }),
+      "Update Resend welcome event",
+    );
+    return existing.id;
+  }
+
+  const created = assertSuccess(
+    await resend.events.create({ name: EVENT_NAME, schema }),
+    "Create Resend welcome event",
+  );
+  return created.id;
+}
+
+function buildWelcomeHtml() {
+  // This mirrors web/emails/welcome.tsx for Resend Automations, which are
+  // managed through Resend's API. Update both when changing the welcome email.
+  return `<!doctype html>
+<html>
+  <body style="margin:0;padding:0;background:#f9fafb;color:#030712;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;">
+    <div style="display:none;overflow:hidden;line-height:1px;opacity:0;max-height:0;max-width:0;">Connect a league to start using Flaim with your AI assistant.</div>
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#f9fafb;padding:32px 16px;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:560px;margin:0 auto;">
+            <tr>
+              <td style="padding:0 0 16px 0;">
+                <a href="https://flaim.app" style="text-decoration:none;"><img alt="" src="https://flaim.app/flaim-mark-hero.png" width="28" height="28" style="display:inline-block;margin:0 8px 0 0;vertical-align:middle;" /></a><a href="https://flaim.app" style="color:#030712;display:inline-block;font-size:18px;font-weight:700;line-height:24px;margin:0;text-decoration:none;vertical-align:middle;">Flaim</a>
+              </td>
+            </tr>
+            <tr>
+              <td style="background:#ffffff;border:1px solid #e5e7eb;border-radius:8px;padding:28px;">
+                <p style="margin:0 0 10px 0;font-size:12px;line-height:18px;font-weight:700;color:#6b7280;">WELCOME</p>
+                <h1 style="margin:0 0 18px 0;font-size:24px;line-height:32px;font-weight:700;color:#030712;">Connect your first league</h1>
+                <p style="margin:0 0 16px 0;font-size:15px;line-height:24px;color:#030712;">Hi {{GIVEN_NAME}},</p>
+                <p style="margin:0 0 16px 0;font-size:15px;line-height:24px;color:#030712;">Flaim lets you ask fantasy questions using your real league data, including your roster, standings, matchups, and transactions. Once connected, you can ask about waiver adds, trade ideas, roster decisions, and league trends.</p>
+                <div style="margin:8px 0 20px;padding:16px;border-radius:8px;border:1px solid #e5e7eb;background:#f9fafb;">
+                  <p style="margin:0 0 12px 0;font-size:14px;line-height:22px;font-weight:700;color:#030712;">Finish your setup</p>
+                  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-bottom:10px;width:100%;">
+                    <tr>
+                      <td style="padding:0;vertical-align:middle;width:33.333%;"><div style="background:#22c55e;border-radius:999px 0 0 999px;height:6px;width:100%;"></div></td>
+                      <td style="padding:0;vertical-align:middle;width:33.333%;"><div style="background:#e5e7eb;height:6px;width:100%;"></div></td>
+                      <td style="padding:0;vertical-align:middle;width:33.333%;"><div style="background:#e5e7eb;border-radius:0 999px 999px 0;height:6px;width:100%;"></div></td>
+                    </tr>
+                  </table>
+                  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="width:100%;">
+                    <tr>
+                      <td style="padding:0 6px 0 0;vertical-align:top;width:33.333%;">
+                        <p style="margin:0;color:#166534;font-size:11px;font-weight:700;line-height:16px;text-transform:uppercase;">Done</p>
+                        <p style="margin:2px 0 0;color:#030712;font-size:12px;line-height:17px;">Account</p>
+                      </td>
+                      <td style="padding:0 6px;vertical-align:top;width:33.333%;">
+                        <p style="margin:0;color:#030712;font-size:11px;font-weight:700;line-height:16px;text-transform:uppercase;">Next</p>
+                        <a href="${LEAGUES_URL}" style="color:#030712;font-size:12px;font-weight:700;line-height:17px;text-decoration:underline;">Connect a league →</a>
+                      </td>
+                      <td style="padding:0 0 0 6px;vertical-align:top;width:33.333%;">
+                        <p style="margin:0;color:#6b7280;font-size:11px;font-weight:700;line-height:16px;text-transform:uppercase;">Then</p>
+                        <a href="${CHATGPT_APP_URL}" style="color:#6b7280;font-size:12px;font-weight:700;line-height:17px;text-decoration:underline;">Open in ChatGPT →</a>
+                      </td>
+                    </tr>
+                  </table>
+                </div>
+                <p style="margin:22px 0 0;padding-top:16px;border-top:1px solid #e5e7eb;font-size:13px;line-height:21px;color:#6b7280;">Flaim is read-only. It can access your league data, but it cannot set lineups, drop players, make trades, or change league settings.</p>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:18px 4px 0;color:#6b7280;font-size:12px;line-height:18px;">
+                <p style="margin:0 0 8px 0;">You are receiving this because you created a Flaim account. <a href="{{{RESEND_UNSUBSCRIBE_URL}}}" style="color:#030712;text-decoration:underline;">Unsubscribe</a>.</p>
+                <p style="margin:0 0 8px 0;">Need help? Email <a href="mailto:support@flaim.app" style="color:#030712;text-decoration:underline;">support@flaim.app</a>.</p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`;
+}
+
+function buildWelcomeText() {
+  // Custom values use escaped double braces. Resend's built-in unsubscribe URL
+  // is inserted as a trusted URL, so it intentionally uses triple braces.
+  return `Welcome to Flaim
+
+Hi {{GIVEN_NAME}},
+
+Flaim lets you ask fantasy questions using your real league data, including your roster, standings, matchups, and transactions. Once connected, you can ask about waiver adds, trade ideas, roster decisions, and league trends.
+
+Finish your setup:
+
+DONE: Account
+NEXT: Connect a league: ${LEAGUES_URL}
+THEN: Open in ChatGPT: ${CHATGPT_APP_URL}
+
+Flaim is read-only. It can access your league data, but it cannot set lineups, drop players, make trades, or change league settings.
+
+Need help? Email support@flaim.app.
+Unsubscribe: {{{RESEND_UNSUBSCRIBE_URL}}}`;
+}
+
+async function ensureTemplate() {
+  const payload = {
+    alias: TEMPLATE_ALIAS,
+    from: "Flaim <updates@flaim.app>",
+    html: buildWelcomeHtml(),
+    name: TEMPLATE_NAME,
+    replyTo: "support@flaim.app",
+    subject: "Welcome to Flaim",
+    text: buildWelcomeText(),
+    variables: [
+      {
+        fallbackValue: "there",
+        key: "GIVEN_NAME",
+        type: "string",
+      },
+    ],
+  };
+  const existing = await findTemplateByAlias(TEMPLATE_ALIAS);
+
+  if (existing) {
+    assertSuccess(
+      await resend.templates.update(existing.id, payload),
+      "Update Resend welcome template",
+    );
+    assertSuccess(
+      await resend.templates.publish(existing.id),
+      "Publish Resend welcome template",
+    );
+    return existing.id;
+  }
+
+  const created = assertSuccess(
+    await resend.templates.create(payload),
+    "Create Resend welcome template",
+  );
+  assertSuccess(
+    await resend.templates.publish(created.id),
+    "Publish Resend welcome template",
+  );
+  return created.id;
+}
+
+async function findTemplateByAlias(alias) {
+  let cursor;
+  let pagesFetched = 0;
+
+  while (true) {
+    pagesFetched += 1;
+    if (pagesFetched > MAX_TEMPLATE_LIST_PAGES) {
+      throw new Error(`Resend template lookup exceeded ${MAX_TEMPLATE_LIST_PAGES} pages`);
+    }
+
+    const page = assertSuccess(
+      await resend.templates.list({ limit: 100, ...(cursor ? { after: cursor } : {}) }),
+      "List Resend templates",
+    );
+    const existing = page.data.find((template) => template.alias === alias);
+
+    if (existing) return existing;
+    if (!page.has_more || page.data.length === 0) return null;
+
+    cursor = page.data[page.data.length - 1].id;
+  }
+}
+
+function buildAutomation(templateId) {
+  return {
+    connections: [{ from: "start", to: "welcome" }],
+    name: AUTOMATION_NAME,
+    status: "disabled",
+    steps: [
+      {
+        key: "start",
+        type: "trigger",
+        config: { eventName: EVENT_NAME },
+      },
+      {
+        key: "welcome",
+        type: "send_email",
+        config: {
+          from: "Flaim <updates@flaim.app>",
+          replyTo: "support@flaim.app",
+          subject: "Welcome to Flaim",
+          template: {
+            id: templateId,
+            variables: {
+              // Coupled to the event payload in resend-welcome-automation.ts.
+              GIVEN_NAME: { var: "event.first_name" },
+            },
+          },
+        },
+      },
+    ],
+  };
+}
+
+async function ensureAutomation(templateId) {
+  const automations = assertSuccess(
+    await resend.automations.list(),
+    "List Resend automations",
+  );
+  const payload = buildAutomation(templateId);
+  const existing = automations.data.find(
+    (automation) => automation.name === AUTOMATION_NAME,
+  );
+
+  if (existing) {
+    assertSuccess(
+      await resend.automations.update(existing.id, payload),
+      "Update Resend welcome automation",
+    );
+    return existing.id;
+  }
+
+  const created = assertSuccess(
+    await resend.automations.create(payload),
+    "Create Resend welcome automation",
+  );
+  return created.id;
+}
+
+const eventId = await ensureEvent();
+// Resend's management API can briefly lag between dependent resource writes.
+await sleep(RESEND_PROPAGATION_DELAY_MS);
+const templateId = await ensureTemplate();
+await sleep(RESEND_PROPAGATION_DELAY_MS);
+const automationId = await ensureAutomation(templateId);
+
+console.log(JSON.stringify({
+  automationId,
+  automationStatus: "disabled",
+  // Informational only. The automation binds to the event by name.
+  eventId,
+  eventName: EVENT_NAME,
+  templateAlias: TEMPLATE_ALIAS,
+  templateId,
+}, null, 2));


### PR DESCRIPTION
## Summary
- add a Resend welcome automation event emitter from verified Clerk user.created webhook syncs
- add the approved welcome email template with setup progress links and read-only reassurance
- add a Resend setup script that publishes the event/template and keeps the automation disabled by default
- document the welcome automation flow and safeguards

## Validation
- corepack pnpm --dir web lint
- corepack pnpm --dir web test
- corepack pnpm --dir web email:export
- node --check web/scripts/setup-resend-welcome-automation.mjs
- sent Resend proof email to iCloud and verified corrected links