### PR TITLE
Fix ESPN trade and category matchup contracts

### DIFF
--- a/workers/espn-client/src/shared/__tests__/espn-transactions.test.ts
+++ b/workers/espn-client/src/shared/__tests__/espn-transactions.test.ts
@@ -83,6 +83,54 @@ describe('espn-transactions', () => {
     });
   });
 
+  describe('enrichTransactions', () => {
+    it('enriches nested trade sides', async () => {
+      const { enrichTransactions } = await import('../espn-transactions');
+      const transactions: NormalizedTransaction[] = [
+        {
+          transaction_id: 'trade-1',
+          type: 'trade',
+          status: 'complete',
+          timestamp: 1700300000000,
+          date: '2023-11-18',
+          week: 9,
+          team_ids: ['1', '2'],
+          players_added: [],
+          players_dropped: [],
+          trade_sides: [
+            { team_id: '1', acquired: [{ id: '1002' }], gave_up: [{ id: '1001' }] },
+            { team_id: '2', acquired: [{ id: '1001' }], gave_up: [{ id: '1002' }] },
+          ],
+          faab_bid: null,
+        },
+      ];
+      const playerMap = new Map([
+        ['1001', { fullName: 'Player One', defaultPositionId: 1, proTeamId: 10 }],
+        ['1002', { fullName: 'Player Two', defaultPositionId: 2, proTeamId: 20 }],
+      ]);
+
+      const result = enrichTransactions(
+        transactions,
+        playerMap,
+        (id) => `POS_${id}`,
+        (id) => `TEAM_${id}`,
+      );
+
+      expect(result[0].trade_sides?.[0]?.acquired[0]).toEqual({
+        id: '1002',
+        name: 'Player Two',
+        position: 'POS_2',
+        team: 'TEAM_20',
+      });
+      expect(result[0].trade_sides?.[1]?.acquired[0]).toEqual({
+        id: '1001',
+        name: 'Player One',
+        position: 'POS_1',
+        team: 'TEAM_10',
+      });
+    });
+  });
+
   it('maps all six message type IDs to correct transaction types', async () => {
     mockFetch
       .mockResolvedValueOnce(jsonResponse({
@@ -115,6 +163,61 @@ describe('espn-transactions', () => {
     expect(byId['13']?.type).toBe('drop');
     expect(byId['14']?.type).toBe('drop');
     expect(byId['15']?.type).toBe('trade');
+    expect(byId['15']?.trade_sides).toEqual([
+      {
+        team_id: '2',
+        acquired: [],
+        gave_up: [{ id: '6' }],
+      },
+      {
+        team_id: '3',
+        acquired: [{ id: '6' }],
+        gave_up: [],
+      },
+    ]);
+  });
+
+  it('groups trade activity messages into directional trade sides', async () => {
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse({
+        topics: [
+          {
+            id: 99,
+            date: 1700300000000,
+            scoringPeriodId: 9,
+            messages: [
+              { id: 101, messageTypeId: 244, targetId: 1001, from: 1, to: 2 },
+              { id: 102, messageTypeId: 244, targetId: 1002, from: 2, to: 1 },
+            ],
+          },
+        ],
+      }))
+      .mockResolvedValueOnce(jsonResponse({ topics: [] }));
+
+    const rows = await fetchEspnTransactionsByWeeks('ffl', '123', 2025, { s2: 'x', swid: '{y}' }, [9]);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      transaction_id: '99',
+      type: 'trade',
+      status: 'complete',
+      week: 9,
+      team_ids: ['1', '2'],
+      players_added: [],
+      players_dropped: [],
+    });
+    expect(rows[0].trade_sides).toEqual([
+      {
+        team_id: '1',
+        acquired: [{ id: '1002' }],
+        gave_up: [{ id: '1001' }],
+      },
+      {
+        team_id: '2',
+        acquired: [{ id: '1001' }],
+        gave_up: [{ id: '1002' }],
+      },
+    ]);
   });
 
   it('normalizes activity feed rows across pages and weeks', async () => {
@@ -579,6 +682,54 @@ describe('espn-transactions', () => {
       expect(result).toHaveLength(1);
       expect(result[0].players_added).toEqual([{ id: '2001' }]);
       expect(result[0].players_dropped).toEqual([{ id: '2002' }]);
+      expect(result[0].team_ids).toEqual(['1', '3']);
+    });
+
+    it('fills directional trade sides from activity feed rows', () => {
+      const mTxns: NormalizedTransaction[] = [
+        {
+          transaction_id: '400',
+          type: 'trade',
+          status: 'complete',
+          timestamp: 1700300000000,
+          date: '2023-11-18',
+          week: 9,
+          team_ids: ['1'],
+          players_added: [],
+          players_dropped: [],
+          faab_bid: null,
+        },
+      ];
+
+      const activityTxns: NormalizedTransaction[] = [
+        {
+          transaction_id: 'act-trade-1',
+          type: 'trade',
+          status: 'complete',
+          timestamp: 1700300000000,
+          date: '2023-11-18',
+          week: 9,
+          team_ids: ['1', '3'],
+          players_added: [],
+          players_dropped: [],
+          trade_sides: [
+            {
+              team_id: '1',
+              acquired: [{ id: '2002' }],
+              gave_up: [{ id: '2001' }],
+            },
+            {
+              team_id: '3',
+              acquired: [{ id: '2001' }],
+              gave_up: [{ id: '2002' }],
+            },
+          ],
+          faab_bid: null,
+        },
+      ];
+
+      const result = mergeTradePlayerDetails(mTxns, activityTxns);
+      expect(result[0].trade_sides).toEqual(activityTxns[0].trade_sides);
       expect(result[0].team_ids).toEqual(['1', '3']);
     });
 

--- a/workers/espn-client/src/shared/__tests__/espn-transactions.test.ts
+++ b/workers/espn-client/src/shared/__tests__/espn-transactions.test.ts
@@ -781,6 +781,49 @@ describe('espn-transactions', () => {
       expect(result[0].players_dropped).toEqual([{ id: '3002' }]);
     });
 
+    it('treats empty trade sides as missing player data', () => {
+      const mTxns: NormalizedTransaction[] = [
+        {
+          transaction_id: '501',
+          type: 'trade',
+          status: 'complete',
+          timestamp: 1700400000000,
+          date: '2023-11-19',
+          week: 10,
+          team_ids: ['3'],
+          players_added: [],
+          players_dropped: [],
+          trade_sides: [
+            { team_id: '3', acquired: [], gave_up: [] },
+            { team_id: '7', acquired: [], gave_up: [] },
+          ],
+          faab_bid: null,
+        },
+      ];
+
+      const activityTxns: NormalizedTransaction[] = [
+        {
+          transaction_id: 'act-trade-empty-side-fill',
+          type: 'trade',
+          status: 'complete',
+          timestamp: 1700400000000,
+          date: '2023-11-19',
+          week: 10,
+          team_ids: ['3', '7'],
+          players_added: [],
+          players_dropped: [],
+          trade_sides: [
+            { team_id: '3', acquired: [{ id: '7001' }], gave_up: [{ id: '7002' }] },
+            { team_id: '7', acquired: [{ id: '7002' }], gave_up: [{ id: '7001' }] },
+          ],
+          faab_bid: null,
+        },
+      ];
+
+      const result = mergeTradePlayerDetails(mTxns, activityTxns);
+      expect(result[0].trade_sides).toEqual(activityTxns[0].trade_sides);
+    });
+
     it('matches by team overlap and does not reuse the same activity trade', () => {
       const mTxns: NormalizedTransaction[] = [
         {

--- a/workers/espn-client/src/shared/__tests__/espn-transactions.test.ts
+++ b/workers/espn-client/src/shared/__tests__/espn-transactions.test.ts
@@ -122,11 +122,23 @@ describe('espn-transactions', () => {
         position: 'POS_2',
         team: 'TEAM_20',
       });
+      expect(result[0].trade_sides?.[0]?.gave_up[0]).toEqual({
+        id: '1001',
+        name: 'Player One',
+        position: 'POS_1',
+        team: 'TEAM_10',
+      });
       expect(result[0].trade_sides?.[1]?.acquired[0]).toEqual({
         id: '1001',
         name: 'Player One',
         position: 'POS_1',
         team: 'TEAM_10',
+      });
+      expect(result[0].trade_sides?.[1]?.gave_up[0]).toEqual({
+        id: '1002',
+        name: 'Player Two',
+        position: 'POS_2',
+        team: 'TEAM_20',
       });
     });
   });
@@ -162,8 +174,8 @@ describe('espn-transactions', () => {
     expect(byId['12']?.faab_bid).toBe(10);
     expect(byId['13']?.type).toBe('drop');
     expect(byId['14']?.type).toBe('drop');
-    expect(byId['15']?.type).toBe('trade');
-    expect(byId['15']?.trade_sides).toEqual([
+    expect(byId['1']?.type).toBe('trade');
+    expect(byId['1']?.trade_sides).toEqual([
       {
         team_id: '2',
         acquired: [],
@@ -255,7 +267,7 @@ describe('espn-transactions', () => {
       faab_bid: 12,
     });
     expect(rows[1]).toMatchObject({
-      transaction_id: '11',
+      transaction_id: '1',
       type: 'trade',
       week: 6,
     });

--- a/workers/espn-client/src/shared/espn-transactions.ts
+++ b/workers/espn-client/src/shared/espn-transactions.ts
@@ -21,6 +21,17 @@ export interface NormalizedTransaction {
   faab_bid?: number | null;
 }
 
+export function collectTransactionPlayerIds(txn: NormalizedTransaction): string[] {
+  return [
+    ...(txn.players_added ?? []).map((p) => p.id),
+    ...(txn.players_dropped ?? []).map((p) => p.id),
+    ...(txn.trade_sides ?? []).flatMap((side) => [
+      ...side.acquired.map((p) => p.id),
+      ...side.gave_up.map((p) => p.id),
+    ]),
+  ];
+}
+
 export interface EspnPlayerBasic {
   fullName?: string;
   defaultPositionId?: number;

--- a/workers/espn-client/src/shared/espn-transactions.ts
+++ b/workers/espn-client/src/shared/espn-transactions.ts
@@ -267,13 +267,18 @@ export function mergeTradePlayerDetails(
   mTxns: NormalizedTransaction[],
   activityTxns: NormalizedTransaction[],
 ): NormalizedTransaction[] {
+  // The activity feed labels raw trade movements as "trade"; mTransactions2 can
+  // label resolved rows as "trade_uphold". Timestamp/team matching bridges them.
   const activityTrades = activityTxns.filter((t) => t.type === 'trade');
   const used = new Set<number>();
 
   return mTxns.map((txn) => {
     if (!TRADE_TYPES.includes(txn.type)) return txn;
 
-    const hasPlayers = (txn.players_added?.length ?? 0) + (txn.players_dropped?.length ?? 0) > 0;
+    const hasPlayers =
+      (txn.players_added?.length ?? 0) +
+      (txn.players_dropped?.length ?? 0) +
+      (txn.trade_sides?.length ?? 0) > 0;
     if (hasPlayers) return txn;
 
     const txnTeams = new Set(txn.team_ids ?? []);
@@ -359,7 +364,11 @@ function buildTradeSides(movements: TradeMovement[]): NonNullable<NormalizedTran
   }));
 }
 
-function normalizeTradeTopic(topic: EspnActivityTopic, topicIndex: number, requestedWeeks: Set<number>, explicitSingleWeek: boolean): NormalizedTransaction | null {
+function normalizeTradeTopic(
+  topic: EspnActivityTopic,
+  requestedWeeks: Set<number>,
+  explicitSingleWeek: boolean,
+): NormalizedTransaction | null {
   const messages = topic.messages ?? [];
   const tradeMessages = messages.filter(
     (msg) =>
@@ -372,7 +381,7 @@ function normalizeTradeTopic(topic: EspnActivityTopic, topicIndex: number, reque
   );
   if (tradeMessages.length === 0) return null;
 
-  const week = getWeekFromActivity(topic, tradeMessages[0] ?? {});
+  const week = getWeekFromActivity(topic, tradeMessages[0]);
   if (week !== null && requestedWeeks.size > 0 && !requestedWeeks.has(week)) {
     return null;
   }
@@ -392,9 +401,7 @@ function normalizeTradeTopic(topic: EspnActivityTopic, topicIndex: number, reque
   ]))).sort((a, b) => Number(a) - Number(b));
 
   return {
-    transaction_id: tradeMessages.length === 1 && tradeMessages[0]?.id !== undefined
-      ? String(tradeMessages[0].id)
-      : String(topic.id ?? `topic-${topicIndex}-trade-${timestamp}-${teamIds.join('-')}`),
+    transaction_id: String(topic.id ?? `trade-${timestamp}-${teamIds.join('-')}`),
     type: 'trade',
     status: 'complete',
     timestamp,
@@ -478,7 +485,7 @@ export async function fetchEspnTransactionsByWeeks(
 
     for (let topicIndex = 0; topicIndex < topics.length; topicIndex += 1) {
       const topic = topics[topicIndex];
-      const tradeRow = normalizeTradeTopic(topic, topicIndex, requestedWeeks, explicitSingleWeek);
+      const tradeRow = normalizeTradeTopic(topic, requestedWeeks, explicitSingleWeek);
       const messages = topic.messages ?? [];
       const topicTimestamp = topic.date ?? 0;
       for (let msgIndex = 0; msgIndex < messages.length; msgIndex += 1) {

--- a/workers/espn-client/src/shared/espn-transactions.ts
+++ b/workers/espn-client/src/shared/espn-transactions.ts
@@ -400,7 +400,7 @@ function normalizeTradeTopic(
     return null;
   }
 
-  const timestamp = tradeMessages[0]?.date ?? topic.date ?? 0;
+  const timestamp = tradeMessages[0].date ?? topic.date ?? 0;
   const movements = tradeMessages.map((msg) => ({
     playerId: String(msg.targetId),
     fromTeamId: String(msg.from),

--- a/workers/espn-client/src/shared/espn-transactions.ts
+++ b/workers/espn-client/src/shared/espn-transactions.ts
@@ -286,10 +286,7 @@ export function mergeTradePlayerDetails(
   return mTxns.map((txn) => {
     if (!TRADE_TYPES.includes(txn.type)) return txn;
 
-    const hasPlayers =
-      (txn.players_added?.length ?? 0) +
-      (txn.players_dropped?.length ?? 0) +
-      (txn.trade_sides?.length ?? 0) > 0;
+    const hasPlayers = collectTransactionPlayerIds(txn).length > 0;
     if (hasPlayers) return txn;
 
     const txnTeams = new Set(txn.team_ids ?? []);

--- a/workers/espn-client/src/shared/espn-transactions.ts
+++ b/workers/espn-client/src/shared/espn-transactions.ts
@@ -13,6 +13,11 @@ export interface NormalizedTransaction {
   team_ids?: string[];
   players_added?: Array<{ id: string; name?: string; position?: string; team?: string }>;
   players_dropped?: Array<{ id: string; name?: string; position?: string; team?: string }>;
+  trade_sides?: Array<{
+    team_id: string;
+    acquired: Array<{ id: string; name?: string; position?: string; team?: string }>;
+    gave_up: Array<{ id: string; name?: string; position?: string; team?: string }>;
+  }>;
   faab_bid?: number | null;
 }
 
@@ -44,6 +49,12 @@ interface EspnActivityTopic {
 
 interface EspnActivityResponse {
   topics?: EspnActivityTopic[];
+}
+
+interface TradeMovement {
+  playerId: string;
+  fromTeamId: string;
+  toTeamId: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -284,6 +295,7 @@ export function mergeTradePlayerDetails(
       ...txn,
       players_added: match.players_added,
       players_dropped: match.players_dropped,
+      trade_sides: match.trade_sides,
       team_ids: match.team_ids?.length ? match.team_ids : txn.team_ids,
     };
   });
@@ -327,6 +339,73 @@ function getTeamIds(messageTypeId: number, message: EspnActivityMessage): string
     if (typeof message.for === 'number' && message.for > 0) set.add(String(message.for));
   }
   return Array.from(set);
+}
+
+function buildTradeSides(movements: TradeMovement[]): NonNullable<NormalizedTransaction['trade_sides']> {
+  const teamIds = new Set<string>();
+  for (const movement of movements) {
+    teamIds.add(movement.fromTeamId);
+    teamIds.add(movement.toTeamId);
+  }
+
+  return Array.from(teamIds).sort((a, b) => Number(a) - Number(b)).map((teamId) => ({
+    team_id: teamId,
+    acquired: movements
+      .filter((movement) => movement.toTeamId === teamId)
+      .map((movement) => ({ id: movement.playerId })),
+    gave_up: movements
+      .filter((movement) => movement.fromTeamId === teamId)
+      .map((movement) => ({ id: movement.playerId })),
+  }));
+}
+
+function normalizeTradeTopic(topic: EspnActivityTopic, topicIndex: number, requestedWeeks: Set<number>, explicitSingleWeek: boolean): NormalizedTransaction | null {
+  const messages = topic.messages ?? [];
+  const tradeMessages = messages.filter(
+    (msg) =>
+      msg.messageTypeId === 244 &&
+      msg.targetId !== undefined &&
+      typeof msg.from === 'number' &&
+      msg.from > 0 &&
+      typeof msg.to === 'number' &&
+      msg.to > 0,
+  );
+  if (tradeMessages.length === 0) return null;
+
+  const week = getWeekFromActivity(topic, tradeMessages[0] ?? {});
+  if (week !== null && requestedWeeks.size > 0 && !requestedWeeks.has(week)) {
+    return null;
+  }
+  if (week === null && explicitSingleWeek) {
+    return null;
+  }
+
+  const timestamp = tradeMessages[0]?.date ?? topic.date ?? 0;
+  const movements = tradeMessages.map((msg) => ({
+    playerId: String(msg.targetId),
+    fromTeamId: String(msg.from),
+    toTeamId: String(msg.to),
+  }));
+  const teamIds = Array.from(new Set(movements.flatMap((movement) => [
+    movement.fromTeamId,
+    movement.toTeamId,
+  ]))).sort((a, b) => Number(a) - Number(b));
+
+  return {
+    transaction_id: tradeMessages.length === 1 && tradeMessages[0]?.id !== undefined
+      ? String(tradeMessages[0].id)
+      : String(topic.id ?? `topic-${topicIndex}-trade-${timestamp}-${teamIds.join('-')}`),
+    type: 'trade',
+    status: 'complete',
+    timestamp,
+    date: new Date(timestamp).toISOString().slice(0, 10),
+    week,
+    team_ids: teamIds,
+    players_added: [],
+    players_dropped: [],
+    trade_sides: buildTradeSides(movements),
+    faab_bid: null,
+  };
 }
 
 export interface EspnLeagueContext {
@@ -399,12 +478,14 @@ export async function fetchEspnTransactionsByWeeks(
 
     for (let topicIndex = 0; topicIndex < topics.length; topicIndex += 1) {
       const topic = topics[topicIndex];
+      const tradeRow = normalizeTradeTopic(topic, topicIndex, requestedWeeks, explicitSingleWeek);
       const messages = topic.messages ?? [];
       const topicTimestamp = topic.date ?? 0;
       for (let msgIndex = 0; msgIndex < messages.length; msgIndex += 1) {
         const msg = messages[msgIndex];
         const normalizedType = toTxnTypeFromMessageId(msg.messageTypeId);
         if (!normalizedType) continue;
+        if (normalizedType === 'trade') continue;
 
         const inferredWeek = getWeekFromActivity(topic, msg);
         if (inferredWeek !== null && requestedWeeks.size > 0 && !requestedWeeks.has(inferredWeek)) {
@@ -442,6 +523,11 @@ export async function fetchEspnTransactionsByWeeks(
           players_dropped: dropped,
           faab_bid: msg.messageTypeId === 180 && typeof msg.from === 'number' ? msg.from : null,
         });
+      }
+
+      if (tradeRow && !seen.has(tradeRow.transaction_id)) {
+        seen.add(tradeRow.transaction_id);
+        out.push(tradeRow);
       }
     }
 
@@ -505,5 +591,10 @@ export function enrichTransactions(
     ...txn,
     players_added: enrich(txn.players_added),
     players_dropped: enrich(txn.players_dropped),
+    trade_sides: txn.trade_sides?.map((side) => ({
+      ...side,
+      acquired: enrich(side.acquired) ?? [],
+      gave_up: enrich(side.gave_up) ?? [],
+    })),
   }));
 }

--- a/workers/espn-client/src/shared/espn-transactions.ts
+++ b/workers/espn-client/src/shared/espn-transactions.ts
@@ -395,10 +395,8 @@ function normalizeTradeTopic(
     fromTeamId: String(msg.from),
     toTeamId: String(msg.to),
   }));
-  const teamIds = Array.from(new Set(movements.flatMap((movement) => [
-    movement.fromTeamId,
-    movement.toTeamId,
-  ]))).sort((a, b) => Number(a) - Number(b));
+  const tradeSides = buildTradeSides(movements);
+  const teamIds = tradeSides.map((side) => side.team_id);
 
   return {
     transaction_id: String(topic.id ?? `trade-${timestamp}-${teamIds.join('-')}`),
@@ -410,7 +408,7 @@ function normalizeTradeTopic(
     team_ids: teamIds,
     players_added: [],
     players_dropped: [],
-    trade_sides: buildTradeSides(movements),
+    trade_sides: tradeSides,
     faab_bid: null,
   };
 }

--- a/workers/espn-client/src/sports/__tests__/transactions-cross-sport.test.ts
+++ b/workers/espn-client/src/sports/__tests__/transactions-cross-sport.test.ts
@@ -11,29 +11,21 @@ vi.mock('../../shared/auth', () => ({
   getCredentials: vi.fn(),
 }));
 
-vi.mock('../../shared/espn-transactions', () => ({
-  getEspnLeagueContext: vi.fn(),
-  fetchEspnTransactionsByWeeks: vi.fn(),
-  fetchEspnMTransactions2: vi.fn(),
-  mergeTradePlayerDetails: vi.fn((mTxns) => mTxns),
-  fetchEspnPlayersByIds: vi.fn(),
-  enrichTransactions: vi.fn((txns) => txns),
-  collectTransactionPlayerIds: vi.fn((txn: {
-    players_added?: Array<{ id: string }>;
-    players_dropped?: Array<{ id: string }>;
-    trade_sides?: Array<{
-      acquired: Array<{ id: string }>;
-      gave_up: Array<{ id: string }>;
-    }>;
-  }) => [
-    ...(txn.players_added ?? []).map((p) => p.id),
-    ...(txn.players_dropped ?? []).map((p) => p.id),
-    ...(txn.trade_sides ?? []).flatMap((side) => [
-      ...side.acquired.map((p) => p.id),
-      ...side.gave_up.map((p) => p.id),
-    ]),
-  ]),
-}));
+vi.mock('../../shared/espn-transactions', async () => {
+  const actual = await vi.importActual<typeof import('../../shared/espn-transactions')>(
+    '../../shared/espn-transactions',
+  );
+
+  return {
+    getEspnLeagueContext: vi.fn(),
+    fetchEspnTransactionsByWeeks: vi.fn(),
+    fetchEspnMTransactions2: vi.fn(),
+    mergeTradePlayerDetails: vi.fn((mTxns) => mTxns),
+    fetchEspnPlayersByIds: vi.fn(),
+    enrichTransactions: vi.fn((txns) => txns),
+    collectTransactionPlayerIds: actual.collectTransactionPlayerIds,
+  };
+});
 
 const scenarios = [
   { label: 'baseball', sport: 'baseball', gameId: 'flb', handlers: baseballHandlers, expectedEspnYear: 2024, expectedResponseSeasonYear: 2024 },

--- a/workers/espn-client/src/sports/__tests__/transactions-cross-sport.test.ts
+++ b/workers/espn-client/src/sports/__tests__/transactions-cross-sport.test.ts
@@ -18,6 +18,21 @@ vi.mock('../../shared/espn-transactions', () => ({
   mergeTradePlayerDetails: vi.fn((mTxns) => mTxns),
   fetchEspnPlayersByIds: vi.fn(),
   enrichTransactions: vi.fn((txns) => txns),
+  collectTransactionPlayerIds: vi.fn((txn: {
+    players_added?: Array<{ id: string }>;
+    players_dropped?: Array<{ id: string }>;
+    trade_sides?: Array<{
+      acquired: Array<{ id: string }>;
+      gave_up: Array<{ id: string }>;
+    }>;
+  }) => [
+    ...(txn.players_added ?? []).map((p) => p.id),
+    ...(txn.players_dropped ?? []).map((p) => p.id),
+    ...(txn.trade_sides ?? []).flatMap((side) => [
+      ...side.acquired.map((p) => p.id),
+      ...side.gave_up.map((p) => p.id),
+    ]),
+  ]),
 }));
 
 const scenarios = [

--- a/workers/espn-client/src/sports/baseball/__tests__/matchups.test.ts
+++ b/workers/espn-client/src/sports/baseball/__tests__/matchups.test.ts
@@ -88,7 +88,7 @@ describe('baseball get_matchups handler', () => {
   it('returns H2H category scores without fake point totals', async () => {
     getCredentialsMock.mockResolvedValue({ s2: 'token', swid: '{swid}' });
     espnFetchMock.mockResolvedValue(
-      new Response(JSON.stringify({
+      jsonResponse({
         scoringPeriodId: 63,
         currentMatchupPeriod: 9,
         settings: {
@@ -130,7 +130,7 @@ describe('baseball get_matchups handler', () => {
             winner: 'AWAY',
           },
         ],
-      }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+      }),
     );
 
     const params = withSeasonContext({ sport: 'baseball', league_id: '30201', season_year: 2026 });
@@ -145,7 +145,14 @@ describe('baseball get_matchups handler', () => {
           totalPoints: number | null;
           scoreAvailable: boolean;
           categoryScore: { wins: number; losses: number; ties: number } | null;
-          categories?: Array<{ statId: number; name: string; value: number | null; result: string | null }>;
+          categories?: Array<{
+            statId: number;
+            name: string;
+            value: number | null;
+            result: string | null;
+            rank?: number;
+            ineligible?: boolean;
+          }>;
         } | null;
       }>;
     };
@@ -157,15 +164,15 @@ describe('baseball get_matchups handler', () => {
       categoryScore: { wins: 4, losses: 5, ties: 1 },
     }));
     expect(data.matchups[0]?.home?.categories).toEqual([
-      expect.objectContaining({ statId: 20, name: 'R', value: 31, result: 'WIN' }),
-      expect.objectContaining({ statId: 47, name: 'ERA', value: 3.42, result: 'LOSS' }),
+      { statId: 20, name: 'R', value: 31, result: 'WIN', rank: 1, ineligible: false },
+      { statId: 47, name: 'ERA', value: 3.42, result: 'LOSS', rank: 2, ineligible: false },
     ]);
   });
 
   it('marks category scores unavailable instead of inventing zeroes', async () => {
     getCredentialsMock.mockResolvedValue({ s2: 'token', swid: '{swid}' });
     espnFetchMock.mockResolvedValue(
-      new Response(JSON.stringify({
+      jsonResponse({
         scoringPeriodId: 63,
         currentMatchupPeriod: 9,
         settings: {
@@ -179,7 +186,7 @@ describe('baseball get_matchups handler', () => {
             winner: 'UNDECIDED',
           },
         ],
-      }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+      }),
     );
 
     const params = withSeasonContext({ sport: 'baseball', league_id: '30201', season_year: 2026 });
@@ -198,7 +205,7 @@ describe('baseball get_matchups handler', () => {
   it('keeps point totals for non-category baseball leagues', async () => {
     getCredentialsMock.mockResolvedValue({ s2: 'token', swid: '{swid}' });
     espnFetchMock.mockResolvedValue(
-      new Response(JSON.stringify({
+      jsonResponse({
         scoringPeriodId: 3,
         settings: {
           scoringSettings: { scoringType: 'H2H_POINTS' },
@@ -211,7 +218,7 @@ describe('baseball get_matchups handler', () => {
             winner: 'HOME',
           },
         ],
-      }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+      }),
     );
 
     const params = withSeasonContext({ sport: 'baseball', league_id: '30201', season_year: 2026 });

--- a/workers/espn-client/src/sports/baseball/__tests__/matchups.test.ts
+++ b/workers/espn-client/src/sports/baseball/__tests__/matchups.test.ts
@@ -145,14 +145,14 @@ describe('baseball get_matchups handler', () => {
           totalPoints: number | null;
           scoreAvailable: boolean;
           categoryScore: { wins: number; losses: number; ties: number } | null;
-          categories?: Array<{
+          categories: Array<{
             statId: number;
             name: string;
             value: number | null;
             result: string | null;
             rank?: number;
             ineligible?: boolean;
-          }>;
+          }> | null;
         } | null;
       }>;
     };
@@ -194,11 +194,12 @@ describe('baseball get_matchups handler', () => {
 
     expect(result.success).toBe(true);
     if (!result.success) return;
-    const data = result.data as { matchups: Array<{ home: { totalPoints: number | null; scoreAvailable: boolean; categoryScore: null } | null }> };
+    const data = result.data as { matchups: Array<{ home: { totalPoints: number | null; scoreAvailable: boolean; categoryScore: null; categories: null } | null }> };
     expect(data.matchups[0]?.home).toEqual(expect.objectContaining({
       totalPoints: null,
       scoreAvailable: false,
       categoryScore: null,
+      categories: null,
     }));
   });
 
@@ -226,11 +227,12 @@ describe('baseball get_matchups handler', () => {
 
     expect(result.success).toBe(true);
     if (!result.success) return;
-    const data = result.data as { matchups: Array<{ home: { totalPoints: number | null; totalProjectedPoints: number | null; categoryScore: null } | null }> };
+    const data = result.data as { matchups: Array<{ home: { totalPoints: number | null; totalProjectedPoints: number | null; categoryScore: null; categories: null } | null }> };
     expect(data.matchups[0]?.home).toEqual(expect.objectContaining({
       totalPoints: 112.4,
       totalProjectedPoints: 145.2,
       categoryScore: null,
+      categories: null,
     }));
   });
 });

--- a/workers/espn-client/src/sports/baseball/__tests__/matchups.test.ts
+++ b/workers/espn-client/src/sports/baseball/__tests__/matchups.test.ts
@@ -203,6 +203,57 @@ describe('baseball get_matchups handler', () => {
     }));
   });
 
+  it('does not invent category aggregates when ESPN omits wins and losses', async () => {
+    getCredentialsMock.mockResolvedValue({ s2: 'token', swid: '{swid}' });
+    espnFetchMock.mockResolvedValue(
+      jsonResponse({
+        scoringPeriodId: 63,
+        currentMatchupPeriod: 9,
+        settings: {
+          scoringSettings: { scoringType: 'H2H_CATEGORY' },
+        },
+        schedule: [
+          {
+            matchupPeriodId: 9,
+            home: {
+              teamId: 1,
+              totalPoints: 0,
+              cumulativeScore: {
+                scoreByStat: {
+                  '20': { score: 31, result: 'WIN', rank: 1, ineligible: false },
+                },
+              },
+            },
+            away: { teamId: 7, totalPoints: 0 },
+            winner: 'UNDECIDED',
+          },
+        ],
+      }),
+    );
+
+    const params = withSeasonContext({ sport: 'baseball', league_id: '30201', season_year: 2026 });
+    const result = await baseballHandlers.get_matchups({} as never, params, 'Bearer x', 'cid');
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const data = result.data as {
+      matchups: Array<{
+        home: {
+          scoreAvailable: boolean;
+          categoryScore: null;
+          categories: Array<{ statId: number; value: number | null }> | null;
+        } | null;
+      }>;
+    };
+    expect(data.matchups[0]?.home).toEqual(expect.objectContaining({
+      scoreAvailable: true,
+      categoryScore: null,
+    }));
+    expect(data.matchups[0]?.home?.categories).toEqual([
+      expect.objectContaining({ statId: 20, value: 31 }),
+    ]);
+  });
+
   it('keeps point totals for non-category baseball leagues', async () => {
     getCredentialsMock.mockResolvedValue({ s2: 'token', swid: '{swid}' });
     espnFetchMock.mockResolvedValue(

--- a/workers/espn-client/src/sports/baseball/__tests__/matchups.test.ts
+++ b/workers/espn-client/src/sports/baseball/__tests__/matchups.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it, vi, type MockedFunction } from 'vitest';
 import { baseballHandlers } from '../handlers';
+import { withSeasonContext } from '../../../shared/season';
 import { getCredentials } from '../../../shared/auth';
 import { espnFetch } from '../../../shared/espn-api';
-import { withSeasonContext } from '../../../shared/season';
 
 vi.mock('../../../shared/auth', () => ({
   getCredentials: vi.fn(),
@@ -29,10 +29,10 @@ describe('baseball get_matchups handler', () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
-    getCredentialsMock.mockResolvedValue({ s2: 'token', swid: '{swid}' });
   });
 
   it('defaults to currentMatchupPeriod instead of daily scoringPeriodId', async () => {
+    getCredentialsMock.mockResolvedValue({ s2: 'token', swid: '{swid}' });
     espnFetchMock.mockResolvedValue(jsonResponse({
       scoringPeriodId: 130,
       status: { currentMatchupPeriod: 10 },
@@ -66,6 +66,7 @@ describe('baseball get_matchups handler', () => {
   });
 
   it('keeps explicit week ahead of currentMatchupPeriod', async () => {
+    getCredentialsMock.mockResolvedValue({ s2: 'token', swid: '{swid}' });
     espnFetchMock.mockResolvedValue(jsonResponse({
       scoringPeriodId: 130,
       status: { currentMatchupPeriod: 10 },
@@ -82,5 +83,147 @@ describe('baseball get_matchups handler', () => {
     const data = result.data as { matchupPeriod: number | null; matchups: unknown[] };
     expect(data.matchupPeriod).toBe(9);
     expect(data.matchups).toHaveLength(1);
+  });
+
+  it('returns H2H category scores without fake point totals', async () => {
+    getCredentialsMock.mockResolvedValue({ s2: 'token', swid: '{swid}' });
+    espnFetchMock.mockResolvedValue(
+      new Response(JSON.stringify({
+        scoringPeriodId: 63,
+        currentMatchupPeriod: 9,
+        settings: {
+          scoringSettings: { scoringType: 'H2H_CATEGORY' },
+        },
+        teams: [
+          { id: 1, location: 'Troll', nickname: 'Tolle' },
+          { id: 7, name: 'The 1 Time Champs' },
+        ],
+        schedule: [
+          {
+            matchupPeriodId: 9,
+            home: {
+              teamId: 1,
+              totalPoints: 0,
+              cumulativeScore: {
+                wins: 4,
+                losses: 5,
+                ties: 1,
+                scoreByStat: {
+                  '20': { score: 31, result: 'WIN', rank: 1, ineligible: false },
+                  '47': { score: 3.42, result: 'LOSS', rank: 2, ineligible: false },
+                },
+              },
+            },
+            away: {
+              teamId: 7,
+              totalPoints: 0,
+              cumulativeScore: {
+                wins: 5,
+                losses: 4,
+                ties: 1,
+                scoreByStat: {
+                  '20': { score: 28, result: 'LOSS', rank: 2, ineligible: false },
+                  '47': { score: 2.87, result: 'WIN', rank: 1, ineligible: false },
+                },
+              },
+            },
+            winner: 'AWAY',
+          },
+        ],
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    );
+
+    const params = withSeasonContext({ sport: 'baseball', league_id: '30201', season_year: 2026 });
+    const result = await baseballHandlers.get_matchups({} as never, params, 'Bearer x', 'cid');
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const data = result.data as {
+      scoringType?: string;
+      matchups: Array<{
+        home: {
+          totalPoints: number | null;
+          scoreAvailable: boolean;
+          categoryScore: { wins: number; losses: number; ties: number } | null;
+          categories?: Array<{ statId: number; name: string; value: number | null; result: string | null }>;
+        } | null;
+      }>;
+    };
+
+    expect(data.scoringType).toBe('H2H_CATEGORY');
+    expect(data.matchups[0]?.home).toEqual(expect.objectContaining({
+      totalPoints: null,
+      scoreAvailable: true,
+      categoryScore: { wins: 4, losses: 5, ties: 1 },
+    }));
+    expect(data.matchups[0]?.home?.categories).toEqual([
+      expect.objectContaining({ statId: 20, name: 'R', value: 31, result: 'WIN' }),
+      expect.objectContaining({ statId: 47, name: 'ERA', value: 3.42, result: 'LOSS' }),
+    ]);
+  });
+
+  it('marks category scores unavailable instead of inventing zeroes', async () => {
+    getCredentialsMock.mockResolvedValue({ s2: 'token', swid: '{swid}' });
+    espnFetchMock.mockResolvedValue(
+      new Response(JSON.stringify({
+        scoringPeriodId: 63,
+        currentMatchupPeriod: 9,
+        settings: {
+          scoringSettings: { scoringType: 'H2H_CATEGORY' },
+        },
+        schedule: [
+          {
+            matchupPeriodId: 9,
+            home: { teamId: 1, totalPoints: 0 },
+            away: { teamId: 7, totalPoints: 0 },
+            winner: 'UNDECIDED',
+          },
+        ],
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    );
+
+    const params = withSeasonContext({ sport: 'baseball', league_id: '30201', season_year: 2026 });
+    const result = await baseballHandlers.get_matchups({} as never, params, 'Bearer x', 'cid');
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const data = result.data as { matchups: Array<{ home: { totalPoints: number | null; scoreAvailable: boolean; categoryScore: null } | null }> };
+    expect(data.matchups[0]?.home).toEqual(expect.objectContaining({
+      totalPoints: null,
+      scoreAvailable: false,
+      categoryScore: null,
+    }));
+  });
+
+  it('keeps point totals for non-category baseball leagues', async () => {
+    getCredentialsMock.mockResolvedValue({ s2: 'token', swid: '{swid}' });
+    espnFetchMock.mockResolvedValue(
+      new Response(JSON.stringify({
+        scoringPeriodId: 3,
+        settings: {
+          scoringSettings: { scoringType: 'H2H_POINTS' },
+        },
+        schedule: [
+          {
+            matchupPeriodId: 3,
+            home: { teamId: 1, totalPoints: 112.4, totalProjectedPointsLive: 145.2 },
+            away: { teamId: 2, totalPoints: 98.1, totalProjectedPoints: 130.5 },
+            winner: 'HOME',
+          },
+        ],
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    );
+
+    const params = withSeasonContext({ sport: 'baseball', league_id: '30201', season_year: 2026 });
+    const result = await baseballHandlers.get_matchups({} as never, params, 'Bearer x', 'cid');
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const data = result.data as { matchups: Array<{ home: { totalPoints: number | null; totalProjectedPoints: number | null; categoryScore: null } | null }> };
+    expect(data.matchups[0]?.home).toEqual(expect.objectContaining({
+      totalPoints: 112.4,
+      totalProjectedPoints: 145.2,
+      categoryScore: null,
+    }));
   });
 });

--- a/workers/espn-client/src/sports/baseball/handlers.ts
+++ b/workers/espn-client/src/sports/baseball/handlers.ts
@@ -11,6 +11,7 @@ import {
   getPositionName,
   getLineupSlotName,
   getProTeamAbbrev,
+  getStatName,
   getInjuryStatus,
   transformEligiblePositions,
   transformStats,
@@ -20,6 +21,44 @@ import { getCurrentSeasonYear, getSeasonContext, normalizeEspnLeagueStatus } fro
 import { deriveStandingsOutcome, deriveStandingsSeasonPhase } from '../../shared/standings';
 
 const GAME_ID = 'flb'; // ESPN's game ID for fantasy baseball
+
+type MatchupSide = NonNullable<NonNullable<EspnLeagueResponse['schedule']>[number]['home']>;
+
+function normalizeMatchupSide(side: MatchupSide | undefined, teamsById: Record<number, string>, scoringType?: string) {
+  if (!side) return null;
+
+  const isCategoryScoring = scoringType === 'H2H_CATEGORY';
+  const scoreByStat = side.cumulativeScore?.scoreByStat;
+  const categoryScoreAvailable = isCategoryScoring && !!side.cumulativeScore;
+  const categories = scoreByStat
+    ? Object.entries(scoreByStat).map(([statId, value]) => ({
+        statId: Number(statId),
+        name: getStatName(Number(statId)),
+        value: value.score ?? null,
+        result: value.result ?? null,
+        rank: value.rank,
+        ineligible: value.ineligible,
+      }))
+    : undefined;
+
+  return {
+    teamId: side.teamId,
+    teamName: side.teamId ? teamsById[side.teamId] : undefined,
+    scoringType,
+    scoreAvailable: isCategoryScoring ? categoryScoreAvailable : typeof side.totalPoints === 'number',
+    totalPoints: isCategoryScoring ? null : side.totalPoints ?? null,
+    totalProjectedPoints: isCategoryScoring
+      ? null
+      : side.totalProjectedPointsLive ?? side.totalProjectedPoints ?? null,
+    pointsByScoringPeriod: isCategoryScoring ? undefined : side.pointsByScoringPeriod,
+    categoryScore: categoryScoreAvailable ? {
+      wins: side.cumulativeScore?.wins ?? 0,
+      losses: side.cumulativeScore?.losses ?? 0,
+      ties: side.cumulativeScore?.ties ?? 0,
+    } : null,
+    categories,
+  };
+}
 
 type HandlerFn = (
   env: Env,
@@ -295,7 +334,7 @@ async function handleGetMatchups(
   try {
     const credentials = await getCredentials(env, authHeader, correlationId);
 
-    let path = `/seasons/${season_year}/segments/0/leagues/${league_id}?view=mMatchupScore&view=mScoreboard&view=mTeam`;
+    let path = `/seasons/${season_year}/segments/0/leagues/${league_id}?view=mMatchupScore&view=mScoreboard&view=mTeam&view=mSettings`;
     if (week) {
       path += `&scoringPeriodId=${week}&matchupPeriodId=${week}`;
     }
@@ -317,6 +356,7 @@ async function handleGetMatchups(
           : team.name || `Team ${team.id}`,
       ])
     );
+    const scoringType = data?.settings?.scoringSettings?.scoringType;
 
     // Transform matchups
     const matchupPeriod = week ?? currentMatchupPeriod ?? data?.scoringPeriodId;
@@ -324,20 +364,8 @@ async function handleGetMatchups(
       .filter((matchup) => matchupPeriod == null || matchup.matchupPeriodId === matchupPeriod)
       .map((matchup) => ({
         matchupPeriodId: matchup.matchupPeriodId,
-        home: matchup.home ? {
-          teamId: matchup.home.teamId,
-          teamName: matchup.home.teamId ? teamsById[matchup.home.teamId] : undefined,
-          totalPoints: matchup.home.totalPoints || 0,
-          totalProjectedPoints: matchup.home.totalProjectedPointsLive || matchup.home.totalProjectedPoints,
-          pointsByScoringPeriod: matchup.home.pointsByScoringPeriod
-        } : null,
-        away: matchup.away ? {
-          teamId: matchup.away.teamId,
-          teamName: matchup.away.teamId ? teamsById[matchup.away.teamId] : undefined,
-          totalPoints: matchup.away.totalPoints || 0,
-          totalProjectedPoints: matchup.away.totalProjectedPointsLive || matchup.away.totalProjectedPoints,
-          pointsByScoringPeriod: matchup.away.pointsByScoringPeriod
-        } : null,
+        home: normalizeMatchupSide(matchup.home, teamsById, scoringType),
+        away: normalizeMatchupSide(matchup.away, teamsById, scoringType),
         winner: matchup.winner,
         playoffTierType: matchup.playoffTierType
       }));
@@ -349,6 +377,7 @@ async function handleGetMatchups(
         seasonYear: season_year,
         currentScoringPeriod: data?.scoringPeriodId,
         matchupPeriod: matchupPeriod ?? null,
+        scoringType,
         matchups
       }
     };
@@ -603,6 +632,10 @@ async function handleGetTransactions(
     const allIds = [...new Set(filtered.flatMap((t) => [
       ...(t.players_added ?? []).map((p) => p.id),
       ...(t.players_dropped ?? []).map((p) => p.id),
+      ...(t.trade_sides ?? []).flatMap((side) => [
+        ...side.acquired.map((p) => p.id),
+        ...side.gave_up.map((p) => p.id),
+      ]),
     ]))];
     if (allIds.length > 0) {
       try {

--- a/workers/espn-client/src/sports/baseball/handlers.ts
+++ b/workers/espn-client/src/sports/baseball/handlers.ts
@@ -2,7 +2,7 @@
 import type { Env, RoutedToolParams, ExecuteResponse, EspnLeagueResponse, EspnPlayerPoolResponse } from '../../types';
 import { getCredentials } from '../../shared/auth';
 import { espnFetch, handleEspnError, requireCredentials } from '../../shared/espn-api';
-import { fetchEspnTransactionsByWeeks, fetchEspnMTransactions2, mergeTradePlayerDetails, getEspnLeagueContext, fetchEspnPlayersByIds, enrichTransactions } from '../../shared/espn-transactions';
+import { collectTransactionPlayerIds, fetchEspnTransactionsByWeeks, fetchEspnMTransactions2, mergeTradePlayerDetails, getEspnLeagueContext, fetchEspnPlayersByIds, enrichTransactions } from '../../shared/espn-transactions';
 import type { NormalizedTransaction } from '../../shared/espn-transactions';
 import { getEspnPlayersIndex } from '../../shared/espn-players-cache';
 import { fetchLeagueOwnershipMap, enrichPlayerWithOwnership } from '../../shared/league-ownership';
@@ -31,6 +31,7 @@ interface NormalizedMatchupSide {
   totalPoints: number | null;
   totalProjectedPoints: number | null;
   pointsByScoringPeriod?: Record<string, number>;
+  // ESPN may provide per-category rows before aggregate W/L/T is available.
   categoryScore: { wins: number; losses: number; ties: number } | null;
   categories: Array<{
     statId: number;
@@ -663,14 +664,7 @@ async function handleGetTransactions(
       .filter((txn) => !type || txn.type === type)
       .slice(0, maxCount);
 
-    const allIds = [...new Set(filtered.flatMap((t) => [
-      ...(t.players_added ?? []).map((p) => p.id),
-      ...(t.players_dropped ?? []).map((p) => p.id),
-      ...(t.trade_sides ?? []).flatMap((side) => [
-        ...side.acquired.map((p) => p.id),
-        ...side.gave_up.map((p) => p.id),
-      ]),
-    ]))];
+    const allIds = [...new Set(filtered.flatMap(collectTransactionPlayerIds))];
     if (allIds.length > 0) {
       try {
         const playerMap = await fetchEspnPlayersByIds(GAME_ID, season_year, allIds);

--- a/workers/espn-client/src/sports/baseball/handlers.ts
+++ b/workers/espn-client/src/sports/baseball/handlers.ts
@@ -51,8 +51,15 @@ function normalizeMatchupSide(
 
   const isCategoryScoring = scoringType === 'H2H_CATEGORY';
   const cumulativeScore = side.cumulativeScore;
+  const categoryWins = cumulativeScore?.wins;
+  const categoryLosses = cumulativeScore?.losses;
+  const categoryTies = cumulativeScore?.ties;
   const scoreByStat = cumulativeScore?.scoreByStat;
-  const categoryScoreAvailable = isCategoryScoring && !!cumulativeScore;
+  const categoryScoreAvailable =
+    isCategoryScoring &&
+    typeof categoryWins === 'number' &&
+    typeof categoryLosses === 'number' &&
+    typeof categoryTies === 'number';
   const categories = isCategoryScoring && scoreByStat
     // Sort by stat ID so the MCP response order is stable across runtimes.
     ? Object.entries(scoreByStat)
@@ -70,16 +77,18 @@ function normalizeMatchupSide(
   return {
     teamId: side.teamId,
     teamName: side.teamId ? teamsById[side.teamId] : undefined,
-    scoreAvailable: isCategoryScoring ? categoryScoreAvailable : typeof side.totalPoints === 'number',
+    scoreAvailable: isCategoryScoring
+      ? categoryScoreAvailable || categories !== null
+      : typeof side.totalPoints === 'number',
     totalPoints: isCategoryScoring ? null : side.totalPoints ?? null,
     totalProjectedPoints: isCategoryScoring
       ? null
       : side.totalProjectedPointsLive ?? side.totalProjectedPoints ?? null,
     pointsByScoringPeriod: isCategoryScoring ? undefined : side.pointsByScoringPeriod,
     categoryScore: categoryScoreAvailable ? {
-      wins: cumulativeScore.wins ?? 0,
-      losses: cumulativeScore.losses ?? 0,
-      ties: cumulativeScore.ties ?? 0,
+      wins: categoryWins,
+      losses: categoryLosses,
+      ties: categoryTies,
     } : null,
     categories,
   };

--- a/workers/espn-client/src/sports/baseball/handlers.ts
+++ b/workers/espn-client/src/sports/baseball/handlers.ts
@@ -24,17 +24,37 @@ const GAME_ID = 'flb'; // ESPN's game ID for fantasy baseball
 
 type MatchupSide = NonNullable<NonNullable<EspnLeagueResponse['schedule']>[number]['home']>;
 
+interface NormalizedMatchupSide {
+  teamId?: number;
+  teamName?: string;
+  scoreAvailable: boolean;
+  totalPoints: number | null;
+  totalProjectedPoints: number | null;
+  pointsByScoringPeriod?: Record<string, number>;
+  categoryScore: { wins: number; losses: number; ties: number } | null;
+  categories: Array<{
+    statId: number;
+    name: string;
+    value: number | null;
+    result: string | null;
+    rank?: number;
+    ineligible?: boolean;
+  }> | null;
+}
+
 function normalizeMatchupSide(
   side: MatchupSide | undefined,
   teamsById: Record<string | number, string>,
   scoringType?: string,
-) {
+): NormalizedMatchupSide | null {
   if (!side) return null;
 
   const isCategoryScoring = scoringType === 'H2H_CATEGORY';
-  const scoreByStat = side.cumulativeScore?.scoreByStat;
-  const categoryScoreAvailable = isCategoryScoring && !!side.cumulativeScore;
+  const cumulativeScore = side.cumulativeScore;
+  const scoreByStat = cumulativeScore?.scoreByStat;
+  const categoryScoreAvailable = isCategoryScoring && !!cumulativeScore;
   const categories = isCategoryScoring && scoreByStat
+    // Sort by stat ID so the MCP response order is stable across runtimes.
     ? Object.entries(scoreByStat)
       .sort(([a], [b]) => Number(a) - Number(b))
       .map(([statId, value]) => ({
@@ -45,7 +65,7 @@ function normalizeMatchupSide(
         rank: value.rank,
         ineligible: value.ineligible,
       }))
-    : undefined;
+    : null;
 
   return {
     teamId: side.teamId,
@@ -57,9 +77,9 @@ function normalizeMatchupSide(
       : side.totalProjectedPointsLive ?? side.totalProjectedPoints ?? null,
     pointsByScoringPeriod: isCategoryScoring ? undefined : side.pointsByScoringPeriod,
     categoryScore: categoryScoreAvailable ? {
-      wins: side.cumulativeScore?.wins ?? 0,
-      losses: side.cumulativeScore?.losses ?? 0,
-      ties: side.cumulativeScore?.ties ?? 0,
+      wins: cumulativeScore.wins ?? 0,
+      losses: cumulativeScore.losses ?? 0,
+      ties: cumulativeScore.ties ?? 0,
     } : null,
     categories,
   };

--- a/workers/espn-client/src/sports/baseball/handlers.ts
+++ b/workers/espn-client/src/sports/baseball/handlers.ts
@@ -24,14 +24,20 @@ const GAME_ID = 'flb'; // ESPN's game ID for fantasy baseball
 
 type MatchupSide = NonNullable<NonNullable<EspnLeagueResponse['schedule']>[number]['home']>;
 
-function normalizeMatchupSide(side: MatchupSide | undefined, teamsById: Record<number, string>, scoringType?: string) {
+function normalizeMatchupSide(
+  side: MatchupSide | undefined,
+  teamsById: Record<string | number, string>,
+  scoringType?: string,
+) {
   if (!side) return null;
 
   const isCategoryScoring = scoringType === 'H2H_CATEGORY';
   const scoreByStat = side.cumulativeScore?.scoreByStat;
   const categoryScoreAvailable = isCategoryScoring && !!side.cumulativeScore;
-  const categories = scoreByStat
-    ? Object.entries(scoreByStat).map(([statId, value]) => ({
+  const categories = isCategoryScoring && scoreByStat
+    ? Object.entries(scoreByStat)
+      .sort(([a], [b]) => Number(a) - Number(b))
+      .map(([statId, value]) => ({
         statId: Number(statId),
         name: getStatName(Number(statId)),
         value: value.score ?? null,
@@ -44,7 +50,6 @@ function normalizeMatchupSide(side: MatchupSide | undefined, teamsById: Record<n
   return {
     teamId: side.teamId,
     teamName: side.teamId ? teamsById[side.teamId] : undefined,
-    scoringType,
     scoreAvailable: isCategoryScoring ? categoryScoreAvailable : typeof side.totalPoints === 'number',
     totalPoints: isCategoryScoring ? null : side.totalPoints ?? null,
     totalProjectedPoints: isCategoryScoring

--- a/workers/espn-client/src/sports/basketball/handlers.ts
+++ b/workers/espn-client/src/sports/basketball/handlers.ts
@@ -2,7 +2,7 @@
 import type { Env, RoutedToolParams, ExecuteResponse, EspnLeagueResponse, EspnPlayerPoolResponse } from '../../types';
 import { getCredentials } from '../../shared/auth';
 import { espnFetch, handleEspnError, requireCredentials } from '../../shared/espn-api';
-import { fetchEspnTransactionsByWeeks, fetchEspnMTransactions2, mergeTradePlayerDetails, getEspnLeagueContext, fetchEspnPlayersByIds, enrichTransactions } from '../../shared/espn-transactions';
+import { collectTransactionPlayerIds, fetchEspnTransactionsByWeeks, fetchEspnMTransactions2, mergeTradePlayerDetails, getEspnLeagueContext, fetchEspnPlayersByIds, enrichTransactions } from '../../shared/espn-transactions';
 import type { NormalizedTransaction } from '../../shared/espn-transactions';
 import { getEspnPlayersIndex } from '../../shared/espn-players-cache';
 import { fetchLeagueOwnershipMap, enrichPlayerWithOwnership } from '../../shared/league-ownership';
@@ -606,14 +606,7 @@ async function handleGetTransactions(
       .filter((txn) => !type || txn.type === type)
       .slice(0, maxCount);
 
-    const allIds = [...new Set(filtered.flatMap((t) => [
-      ...(t.players_added ?? []).map((p) => p.id),
-      ...(t.players_dropped ?? []).map((p) => p.id),
-      ...(t.trade_sides ?? []).flatMap((side) => [
-        ...side.acquired.map((p) => p.id),
-        ...side.gave_up.map((p) => p.id),
-      ]),
-    ]))];
+    const allIds = [...new Set(filtered.flatMap(collectTransactionPlayerIds))];
     if (allIds.length > 0) {
       try {
         const playerMap = await fetchEspnPlayersByIds(GAME_ID, espnYear, allIds);

--- a/workers/espn-client/src/sports/basketball/handlers.ts
+++ b/workers/espn-client/src/sports/basketball/handlers.ts
@@ -609,6 +609,10 @@ async function handleGetTransactions(
     const allIds = [...new Set(filtered.flatMap((t) => [
       ...(t.players_added ?? []).map((p) => p.id),
       ...(t.players_dropped ?? []).map((p) => p.id),
+      ...(t.trade_sides ?? []).flatMap((side) => [
+        ...side.acquired.map((p) => p.id),
+        ...side.gave_up.map((p) => p.id),
+      ]),
     ]))];
     if (allIds.length > 0) {
       try {

--- a/workers/espn-client/src/sports/football/__tests__/transactions.test.ts
+++ b/workers/espn-client/src/sports/football/__tests__/transactions.test.ts
@@ -25,6 +25,21 @@ vi.mock('../../../shared/espn-transactions', () => ({
   mergeTradePlayerDetails: vi.fn((mTxns) => mTxns),
   fetchEspnPlayersByIds: vi.fn(),
   enrichTransactions: vi.fn((txns) => txns),
+  collectTransactionPlayerIds: vi.fn((txn: {
+    players_added?: Array<{ id: string }>;
+    players_dropped?: Array<{ id: string }>;
+    trade_sides?: Array<{
+      acquired: Array<{ id: string }>;
+      gave_up: Array<{ id: string }>;
+    }>;
+  }) => [
+    ...(txn.players_added ?? []).map((p) => p.id),
+    ...(txn.players_dropped ?? []).map((p) => p.id),
+    ...(txn.trade_sides ?? []).flatMap((side) => [
+      ...side.acquired.map((p) => p.id),
+      ...side.gave_up.map((p) => p.id),
+    ]),
+  ]),
 }));
 
 describe('football get_transactions handler', () => {

--- a/workers/espn-client/src/sports/football/__tests__/transactions.test.ts
+++ b/workers/espn-client/src/sports/football/__tests__/transactions.test.ts
@@ -18,29 +18,21 @@ vi.mock('../../../shared/auth', () => ({
   getCredentials: vi.fn(),
 }));
 
-vi.mock('../../../shared/espn-transactions', () => ({
-  getEspnLeagueContext: vi.fn(),
-  fetchEspnTransactionsByWeeks: vi.fn(),
-  fetchEspnMTransactions2: vi.fn(),
-  mergeTradePlayerDetails: vi.fn((mTxns) => mTxns),
-  fetchEspnPlayersByIds: vi.fn(),
-  enrichTransactions: vi.fn((txns) => txns),
-  collectTransactionPlayerIds: vi.fn((txn: {
-    players_added?: Array<{ id: string }>;
-    players_dropped?: Array<{ id: string }>;
-    trade_sides?: Array<{
-      acquired: Array<{ id: string }>;
-      gave_up: Array<{ id: string }>;
-    }>;
-  }) => [
-    ...(txn.players_added ?? []).map((p) => p.id),
-    ...(txn.players_dropped ?? []).map((p) => p.id),
-    ...(txn.trade_sides ?? []).flatMap((side) => [
-      ...side.acquired.map((p) => p.id),
-      ...side.gave_up.map((p) => p.id),
-    ]),
-  ]),
-}));
+vi.mock('../../../shared/espn-transactions', async () => {
+  const actual = await vi.importActual<typeof import('../../../shared/espn-transactions')>(
+    '../../../shared/espn-transactions',
+  );
+
+  return {
+    getEspnLeagueContext: vi.fn(),
+    fetchEspnTransactionsByWeeks: vi.fn(),
+    fetchEspnMTransactions2: vi.fn(),
+    mergeTradePlayerDetails: vi.fn((mTxns) => mTxns),
+    fetchEspnPlayersByIds: vi.fn(),
+    enrichTransactions: vi.fn((txns) => txns),
+    collectTransactionPlayerIds: actual.collectTransactionPlayerIds,
+  };
+});
 
 describe('football get_transactions handler', () => {
   const getCredentialsMock = getCredentials as MockedFunction<typeof getCredentials>;

--- a/workers/espn-client/src/sports/football/handlers.ts
+++ b/workers/espn-client/src/sports/football/handlers.ts
@@ -2,7 +2,7 @@
 import type { Env, RoutedToolParams, ExecuteResponse, EspnLeagueResponse, EspnPlayerPoolResponse } from '../../types';
 import { getCredentials } from '../../shared/auth';
 import { espnFetch, handleEspnError, requireCredentials } from '../../shared/espn-api';
-import { fetchEspnTransactionsByWeeks, fetchEspnMTransactions2, mergeTradePlayerDetails, getEspnLeagueContext, fetchEspnPlayersByIds, enrichTransactions } from '../../shared/espn-transactions';
+import { collectTransactionPlayerIds, fetchEspnTransactionsByWeeks, fetchEspnMTransactions2, mergeTradePlayerDetails, getEspnLeagueContext, fetchEspnPlayersByIds, enrichTransactions } from '../../shared/espn-transactions';
 import type { NormalizedTransaction } from '../../shared/espn-transactions';
 import { getEspnPlayersIndex } from '../../shared/espn-players-cache';
 import { fetchLeagueOwnershipMap, enrichPlayerWithOwnership } from '../../shared/league-ownership';
@@ -602,14 +602,7 @@ async function handleGetTransactions(
       .filter((txn) => !type || txn.type === type)
       .slice(0, maxCount);
 
-    const allIds = [...new Set(filtered.flatMap((t) => [
-      ...(t.players_added ?? []).map((p) => p.id),
-      ...(t.players_dropped ?? []).map((p) => p.id),
-      ...(t.trade_sides ?? []).flatMap((side) => [
-        ...side.acquired.map((p) => p.id),
-        ...side.gave_up.map((p) => p.id),
-      ]),
-    ]))];
+    const allIds = [...new Set(filtered.flatMap(collectTransactionPlayerIds))];
     if (allIds.length > 0) {
       try {
         const playerMap = await fetchEspnPlayersByIds(GAME_ID, season_year, allIds);

--- a/workers/espn-client/src/sports/football/handlers.ts
+++ b/workers/espn-client/src/sports/football/handlers.ts
@@ -605,6 +605,10 @@ async function handleGetTransactions(
     const allIds = [...new Set(filtered.flatMap((t) => [
       ...(t.players_added ?? []).map((p) => p.id),
       ...(t.players_dropped ?? []).map((p) => p.id),
+      ...(t.trade_sides ?? []).flatMap((side) => [
+        ...side.acquired.map((p) => p.id),
+        ...side.gave_up.map((p) => p.id),
+      ]),
     ]))];
     if (allIds.length > 0) {
       try {

--- a/workers/espn-client/src/sports/hockey/handlers.ts
+++ b/workers/espn-client/src/sports/hockey/handlers.ts
@@ -2,7 +2,7 @@
 import type { Env, RoutedToolParams, ExecuteResponse, EspnLeagueResponse, EspnPlayerPoolResponse } from '../../types';
 import { getCredentials } from '../../shared/auth';
 import { espnFetch, handleEspnError, requireCredentials } from '../../shared/espn-api';
-import { fetchEspnTransactionsByWeeks, fetchEspnMTransactions2, mergeTradePlayerDetails, getEspnLeagueContext, fetchEspnPlayersByIds, enrichTransactions } from '../../shared/espn-transactions';
+import { collectTransactionPlayerIds, fetchEspnTransactionsByWeeks, fetchEspnMTransactions2, mergeTradePlayerDetails, getEspnLeagueContext, fetchEspnPlayersByIds, enrichTransactions } from '../../shared/espn-transactions';
 import type { NormalizedTransaction } from '../../shared/espn-transactions';
 import { getEspnPlayersIndex } from '../../shared/espn-players-cache';
 import { fetchLeagueOwnershipMap, enrichPlayerWithOwnership } from '../../shared/league-ownership';
@@ -606,14 +606,7 @@ async function handleGetTransactions(
       .filter((txn) => !type || txn.type === type)
       .slice(0, maxCount);
 
-    const allIds = [...new Set(filtered.flatMap((t) => [
-      ...(t.players_added ?? []).map((p) => p.id),
-      ...(t.players_dropped ?? []).map((p) => p.id),
-      ...(t.trade_sides ?? []).flatMap((side) => [
-        ...side.acquired.map((p) => p.id),
-        ...side.gave_up.map((p) => p.id),
-      ]),
-    ]))];
+    const allIds = [...new Set(filtered.flatMap(collectTransactionPlayerIds))];
     if (allIds.length > 0) {
       try {
         const playerMap = await fetchEspnPlayersByIds(GAME_ID, espnYear, allIds);

--- a/workers/espn-client/src/sports/hockey/handlers.ts
+++ b/workers/espn-client/src/sports/hockey/handlers.ts
@@ -609,6 +609,10 @@ async function handleGetTransactions(
     const allIds = [...new Set(filtered.flatMap((t) => [
       ...(t.players_added ?? []).map((p) => p.id),
       ...(t.players_dropped ?? []).map((p) => p.id),
+      ...(t.trade_sides ?? []).flatMap((side) => [
+        ...side.acquired.map((p) => p.id),
+        ...side.gave_up.map((p) => p.id),
+      ]),
     ]))];
     if (allIds.length > 0) {
       try {

--- a/workers/espn-client/src/types.ts
+++ b/workers/espn-client/src/types.ts
@@ -124,6 +124,17 @@ export interface EspnMatchupTeam {
   totalProjectedPoints?: number;
   totalProjectedPointsLive?: number;
   pointsByScoringPeriod?: Record<string, number>;
+  cumulativeScore?: {
+    wins?: number;
+    losses?: number;
+    ties?: number;
+    scoreByStat?: Record<string, {
+      ineligible?: boolean;
+      rank?: number;
+      result?: string | null;
+      score?: number;
+    }>;
+  };
 }
 
 /** Response from the kona_player_info view (free agents). */


### PR DESCRIPTION
## Summary

- Add directional `trade_sides` to ESPN trade transactions so consumers can see which teams acquired and gave up each player.
- Enrich player details inside trade sides across ESPN sports handlers.
- Preserve baseball H2H category matchup semantics by exposing `categoryScore` and per-category rows instead of fake point totals.

## Why

The demo quality pass found two MCP contract issues:

- `trade-grades` could see that a trade happened, but not enough resolved team/player-side detail to grade it.
- `this-matchup` could show misleading 0-0 point scores for baseball category leagues because ESPN stores category matchup state separately from point totals.

## Validation

- `corepack pnpm --dir workers/espn-client run test`
- `corepack pnpm --dir workers/espn-client run type-check`

## Notes

- This branch intentionally includes only `workers/espn-client` changes.
- It does not include the separate public demo prompt metadata changes in `web/lib/public-chat.ts`.
- It is independent of PR #102, which covers stale default/read-only `get_user_session` behavior.
