### PR TITLE
[codex] Point public demo reader to v6 cache

### DIFF
--- a/web/lib/public-chat.ts
+++ b/web/lib/public-chat.ts
@@ -30,7 +30,7 @@ export interface PublicChatPreset {
   rail?: PublicChatPresetRail;
 }
 
-export const PUBLIC_DEMO_PROMPT_VERSION = "v5";
+export const PUBLIC_DEMO_PROMPT_VERSION = "v6";
 export const PUBLIC_DEMO_CONTEXT_VERSION = "v2";
 
 export const PUBLIC_CHAT_SIMPLE_PRESETS: readonly PublicChatPreset[] = [

--- a/web/lib/server/__tests__/public-chat-cache-route.test.ts
+++ b/web/lib/server/__tests__/public-chat-cache-route.test.ts
@@ -168,13 +168,13 @@ describe("sanitizePublicDemoRefreshFailure", () => {
 describe("GET /api/public-chat/cache", () => {
   it("does not expose raw tool traces or raw source metadata", async () => {
     mocks.getCachedPublicDemoAnswer.mockResolvedValue({
-      cacheKey: "public-demo-answer:wire-watch:baseball:v5:v2",
+      cacheKey: "public-demo-answer:wire-watch:baseball:v6:v2",
       presetId: "wire-watch",
       sport: "baseball",
       provider: "gemini",
       providerModel: "gemini-2.5-flash",
       contextVersion: "v2",
-      promptVersion: "v5",
+      promptVersion: "v6",
       answerText: "Add the useful player and drop the risky player.",
       generatedAt: "2026-06-06T12:00:00.000Z",
       expiresAt: "2026-06-06T18:00:00.000Z",


### PR DESCRIPTION
## Summary

- Point the public homepage demo cache reader at prompt namespace `v6`.

## Why

The `flaim-demo` runner now writes the improved Antigravity prompt outputs under `DEMO_PROMPT_VERSION = "v6"`, and all 12 baseball rows have been seeded and verified green. The app reader needs to use the same namespace.

## Validation

- `corepack pnpm --dir web exec vitest run -c vitest.config.ts lib/server/__tests__/public-chat-cache-route.test.ts`
- `corepack pnpm --dir web exec tsc --noEmit`
