### PR TITLE
[codex] Sanitize auth-worker public error responses

### DIFF
--- a/workers/auth-worker/src/__tests__/public-error-sanitization.test.ts
+++ b/workers/auth-worker/src/__tests__/public-error-sanitization.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import app from '../index-hono';
+
+const RAW_SUPABASE_ERROR = 'raw Supabase password=secret failed';
+const RAW_THROWN_ERROR = 'raw OAuth secret stack failed';
+
+const { mockHasCredentials, mockMetadataDiscovery } = vi.hoisted(() => ({
+  mockHasCredentials: vi.fn(),
+  mockMetadataDiscovery: vi.fn(),
+}));
+
+vi.mock('../supabase-storage', () => {
+  return {
+    EspnSupabaseStorage: {
+      fromEnvironment: vi.fn().mockReturnValue({
+        hasCredentials: mockHasCredentials,
+      }),
+    },
+  };
+});
+
+vi.mock('../oauth-handlers', () => ({
+  handleMetadataDiscovery: mockMetadataDiscovery,
+  handleClientRegistration: vi.fn(),
+  handleAuthorize: vi.fn(),
+  handleCreateCode: vi.fn(),
+  handleToken: vi.fn(),
+  handleRevoke: vi.fn(),
+  handleCheckStatus: vi.fn(),
+  handleRevokeAll: vi.fn(),
+  handleRevokeSingle: vi.fn(),
+  validateOAuthToken: vi.fn().mockResolvedValue(null),
+}));
+
+const baseEnv = {
+  SUPABASE_URL: 'https://example.supabase.co',
+  SUPABASE_SERVICE_KEY: 'test-service-key',
+  NODE_ENV: 'test',
+  ENVIRONMENT: 'test',
+  TOKEN_RATE_LIMITER: { limit: async () => ({ success: true }) },
+  CREDENTIALS_RATE_LIMITER: { limit: async () => ({ success: true }) },
+};
+
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+function makeRequest(path: string): Request {
+  return new Request(`https://api.flaim.app${path}`);
+}
+
+describe('public error sanitization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('sanitizes Supabase health check failures while logging details', async () => {
+    mockHasCredentials.mockRejectedValue(new Error(RAW_SUPABASE_ERROR));
+
+    const response = await app.fetch(makeRequest('/auth/health'), baseEnv);
+    const text = await response.text();
+    const body = JSON.parse(text) as Record<string, unknown>;
+
+    expect(response.status).toBe(503);
+    expect(body.status).toBe('degraded');
+    expect(body.supabase_status).toBe('error');
+    expect(body.supabase_error).toBe('supabase_connectivity_check_failed');
+    expect(text).not.toContain(RAW_SUPABASE_ERROR);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[auth-worker] Supabase health check failed:',
+      expect.any(Error)
+    );
+  });
+
+  it('sanitizes global 500 responses while logging details', async () => {
+    mockMetadataDiscovery.mockImplementation(() => {
+      throw new Error(RAW_THROWN_ERROR);
+    });
+
+    const response = await app.fetch(makeRequest('/.well-known/oauth-authorization-server'), baseEnv);
+    const text = await response.text();
+    const body = JSON.parse(text) as Record<string, unknown>;
+
+    expect(response.status).toBe(500);
+    expect(body).toEqual({
+      error: 'server_error',
+      error_description: 'Internal server error',
+    });
+    expect(text).not.toContain(RAW_THROWN_ERROR);
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Auth worker error:', expect.any(Error));
+  });
+});

--- a/workers/auth-worker/src/index-hono.ts
+++ b/workers/auth-worker/src/index-hono.ts
@@ -597,8 +597,9 @@ api.get('/health', async (c) => {
       healthData.status = 'degraded';
     }
   } catch (error) {
+    console.error('[auth-worker] Supabase health check failed:', error);
     healthData.supabase_status = 'error';
-    healthData.supabase_error = error instanceof Error ? error.message : 'Unknown Supabase error';
+    healthData.supabase_error = 'supabase_connectivity_check_failed';
     healthData.status = 'degraded';
   }
 
@@ -1793,8 +1794,8 @@ api.onError((err, c) => {
   console.error('Auth worker error:', err);
   const corsHeaders = getCorsHeaders(c.req.raw);
   return new Response(JSON.stringify({
-    error: 'Internal server error',
-    details: err instanceof Error ? err.message : 'Unknown error'
+    error: 'server_error',
+    error_description: 'Internal server error'
   }), {
     status: 500,
     headers: { 'Content-Type': 'application/json', ...corsHeaders }


### PR DESCRIPTION
## Summary

- Sanitize public auth-worker health and generic 500 error responses so public surfaces do not leak internal metadata.
- Preserve the existing internal behavior covered by the worker test suite.

## Validation

- `corepack pnpm --dir workers/auth-worker exec vitest run src/__tests__/public-error-sanitization.test.ts` passed
- `corepack pnpm --dir workers/auth-worker run test` passed: 18 files, 327 tests
- `corepack pnpm --dir workers/auth-worker run type-check` passed
- `git diff --check` passed
- Note: local pnpm emitted Node engine warning because project wants Node 24.x and shell is Node v26.0.0

## Linear

https://linear.app/flaim/issue/FLA-141/sanitize-public-auth-worker-health-and-500-error-responses