### PR TITLE
[codex] Stop returning raw ESPN credentials to browser edit flows

### DIFF
--- a/web/app/api/auth/espn/credentials/route.ts
+++ b/web/app/api/auth/espn/credentials/route.ts
@@ -8,7 +8,7 @@ import { auth } from '@clerk/nextjs/server';
  * Proxies to auth-worker with proper JWT forwarding.
  *
  * Query params:
- * - forEdit=true: Return actual credentials for editing
+ * - forEdit=true: Return replace-only metadata for credential replacement
  */
 export async function GET(request: NextRequest) {
   try {
@@ -23,7 +23,7 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'NEXT_PUBLIC_AUTH_WORKER_URL is not configured' }, { status: 500 });
     }
 
-    // Check if this is a request for editing
+    // Check if this is a request for replace-only credential editing.
     const forEdit = request.nextUrl.searchParams.get('forEdit') === 'true';
     const queryString = forEdit ? '?forEdit=true' : '';
 
@@ -39,6 +39,13 @@ export async function GET(request: NextRequest) {
 
     // auth-worker returns 404 when user has no stored credentials; treat as empty state
     if (workerRes.status === 404) {
+      if (forEdit) {
+        return NextResponse.json({
+          hasCredentials: false,
+          platform: 'espn',
+          replaceOnly: true
+        }, { status: 200 });
+      }
       return NextResponse.json({ hasCredentials: false }, { status: 200 });
     }
 
@@ -50,15 +57,29 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const data = await workerRes.json() as { hasCredentials?: boolean; swid?: string; s2?: string; email?: string; lastUpdated?: string };
-    const hasCredentials = data.hasCredentials ?? (!!data.swid && !!data.s2);
+    const data = await workerRes.json() as {
+      hasCredentials?: boolean;
+      swid?: string;
+      s2?: string;
+      email?: string;
+      lastUpdated?: string;
+      platform?: string;
+      replaceOnly?: boolean;
+      maskedSwid?: string;
+      maskedS2?: string;
+    };
+    const hasCredentials = data.hasCredentials ?? !!(data.maskedSwid || data.maskedS2 || data.swid || data.s2);
 
-    // If editing, return actual credentials
-    if (forEdit && hasCredentials) {
+    // Browser edit flows are replace-only. Never forward raw swid/s2 fields.
+    if (forEdit) {
       return NextResponse.json({
         hasCredentials,
-        swid: data.swid,
-        s2: data.s2
+        platform: 'espn',
+        email: data.email,
+        lastUpdated: data.lastUpdated,
+        replaceOnly: true,
+        maskedSwid: hasCredentials ? data.maskedSwid : undefined,
+        maskedS2: hasCredentials ? data.maskedS2 : undefined
       });
     }
 

--- a/web/app/api/auth/espn/credentials/route.ts
+++ b/web/app/api/auth/espn/credentials/route.ts
@@ -39,13 +39,6 @@ export async function GET(request: NextRequest) {
 
     // auth-worker returns 404 when user has no stored credentials; treat as empty state
     if (workerRes.status === 404) {
-      if (forEdit) {
-        return NextResponse.json({
-          hasCredentials: false,
-          platform: 'espn',
-          replaceOnly: true
-        }, { status: 200 });
-      }
       return NextResponse.json({ hasCredentials: false }, { status: 200 });
     }
 
@@ -68,7 +61,9 @@ export async function GET(request: NextRequest) {
       maskedSwid?: string;
       maskedS2?: string;
     };
-    const hasCredentials = data.hasCredentials ?? !!(data.maskedSwid || data.maskedS2 || data.swid || data.s2);
+    const hasMaskedPair = !!(data.maskedSwid && data.maskedS2);
+    const hasRawPair = !!(data.swid && data.s2);
+    const hasCredentials = data.hasCredentials ?? (hasMaskedPair || hasRawPair);
 
     // Browser edit flows are replace-only. Never forward raw swid/s2 fields.
     if (forEdit) {

--- a/web/app/api/auth/espn/credentials/route.ts
+++ b/web/app/api/auth/espn/credentials/route.ts
@@ -1,6 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@clerk/nextjs/server';
 
+type EspnCredentialsResponse = {
+  hasCredentials?: boolean;
+  swid?: string;
+  s2?: string;
+  email?: string;
+  lastUpdated?: string;
+  platform?: string;
+  replaceOnly?: boolean;
+  maskedSwid?: string;
+  maskedS2?: string;
+};
+
 /**
  * GET /api/auth/espn/credentials
  * -----------------------------------------------------------
@@ -50,23 +62,20 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const data = await workerRes.json() as {
-      hasCredentials?: boolean;
-      swid?: string;
-      s2?: string;
-      email?: string;
-      lastUpdated?: string;
-      platform?: string;
-      replaceOnly?: boolean;
-      maskedSwid?: string;
-      maskedS2?: string;
-    };
-    const hasMaskedPair = !!(data.maskedSwid && data.maskedS2);
-    const hasRawPair = !!(data.swid && data.s2);
-    const hasCredentials = data.hasCredentials ?? (hasMaskedPair || hasRawPair);
-
     // Browser edit flows are replace-only. Never forward raw swid/s2 fields.
     if (forEdit) {
+      const rawData = await workerRes.json().catch(() => null) as unknown;
+      if (!rawData || typeof rawData !== 'object' || Array.isArray(rawData)) {
+        return NextResponse.json(
+          { error: 'Upstream returned an unexpected response shape' },
+          { status: 502 }
+        );
+      }
+
+      const data = rawData as EspnCredentialsResponse;
+      const hasMaskedPair = !!(data.maskedSwid && data.maskedS2);
+      const hasCredentials = data.hasCredentials ?? hasMaskedPair;
+
       return NextResponse.json({
         hasCredentials,
         platform: 'espn',
@@ -77,6 +86,11 @@ export async function GET(request: NextRequest) {
         maskedS2: hasCredentials ? data.maskedS2 : undefined
       });
     }
+
+    const data = await workerRes.json() as EspnCredentialsResponse;
+    const hasMaskedPair = !!(data.maskedSwid && data.maskedS2);
+    const hasRawPair = !!(data.swid && data.s2);
+    const hasCredentials = data.hasCredentials ?? (hasMaskedPair || hasRawPair);
 
     return NextResponse.json({
       hasCredentials,

--- a/web/components/site/StepConnectPlatforms.tsx
+++ b/web/components/site/StepConnectPlatforms.tsx
@@ -44,7 +44,6 @@ export function StepConnectPlatforms({ className }: StepConnectPlatformsProps) {
   const [swid, setSwid] = useState('');
   const [espnS2, setEspnS2] = useState('');
   const [showCredentials, setShowCredentials] = useState(false);
-  const [hasLoadedCreds, setHasLoadedCreds] = useState(false);
   const [isLoadingCreds, setIsLoadingCreds] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [espnError, setEspnError] = useState<string | null>(null);
@@ -139,21 +138,28 @@ export function StepConnectPlatforms({ className }: StepConnectPlatformsProps) {
 
   const handleOpenDialog = async () => {
     setDialogOpen(true);
-    if (hasLoadedCreds || swid || espnS2) {
-      setIsLoadingCreds(false);
-      return;
-    }
+    setSwid('');
+    setEspnS2('');
+    setEspnError(null);
     setIsLoadingCreds(true);
     try {
       const res = await fetch('/api/auth/espn/credentials?forEdit=true');
       if (res.ok) {
-        const data = await res.json() as { swid?: string; s2?: string };
-        if (data.swid) setSwid(data.swid);
-        if (data.s2) setEspnS2(data.s2);
-        if (data.swid || data.s2) setHasLoadedCreds(true);
+        const data = await res.json() as { hasCredentials?: boolean };
+        setHasCredentials(!!data.hasCredentials);
       }
     } catch { /* ignore */ }
     setIsLoadingCreds(false);
+  };
+
+  const handleDialogOpenChange = (open: boolean) => {
+    setDialogOpen(open);
+    if (!open) {
+      setSwid('');
+      setEspnS2('');
+      setShowCredentials(false);
+      setEspnError(null);
+    }
   };
 
   const handleSaveCredentials = async () => {
@@ -174,7 +180,7 @@ export function StepConnectPlatforms({ className }: StepConnectPlatformsProps) {
         throw new Error(data.error || 'Failed to save credentials');
       }
       setHasCredentials(true);
-      setDialogOpen(false);
+      handleDialogOpenChange(false);
     } catch (err) {
       setEspnError(err instanceof Error ? err.message : 'Failed to save');
     }
@@ -302,16 +308,20 @@ export function StepConnectPlatforms({ className }: StepConnectPlatformsProps) {
                       Install Extension
                     </Button>
                   </a>
-                  <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+                  <Dialog open={dialogOpen} onOpenChange={handleDialogOpenChange}>
                     <DialogTrigger asChild>
-                      <Button variant="outline" size="icon" className="h-8 w-8 shrink-0" onClick={handleOpenDialog} title="Add manually">
+                      <Button variant="outline" size="icon" className="h-8 w-8 shrink-0" onClick={handleOpenDialog} title={hasCredentials ? 'Replace manually' : 'Add manually'}>
                         <Wrench className="h-4 w-4" />
                       </Button>
                     </DialogTrigger>
                     <DialogContent>
                       <DialogHeader>
-                        <DialogTitle>ESPN Credentials</DialogTitle>
-                        <DialogDescription>Enter your ESPN authentication cookies.</DialogDescription>
+                        <DialogTitle>{hasCredentials ? 'Replace ESPN credentials' : 'Add ESPN credentials'}</DialogTitle>
+                        <DialogDescription>
+                          {hasCredentials
+                            ? 'Saved credentials are not shown. Enter new ESPN cookies to replace them.'
+                            : 'Enter your ESPN authentication cookies.'}
+                        </DialogDescription>
                       </DialogHeader>
                       <div className="space-y-4 pt-2">
                         {isLoadingCreds ? (
@@ -321,24 +331,36 @@ export function StepConnectPlatforms({ className }: StepConnectPlatformsProps) {
                             {espnError && <div className="p-3 bg-destructive/10 border border-destructive/30 rounded text-sm text-destructive">{espnError}</div>}
                             <div className="space-y-2">
                               <Label htmlFor="swid">SWID</Label>
-                              <Input id="swid" type={showCredentials ? 'text' : 'password'} value={swid} onChange={(e) => setSwid(e.target.value)} />
+                              <Input
+                                id="swid"
+                                type={showCredentials ? 'text' : 'password'}
+                                value={swid}
+                                onChange={(e) => setSwid(e.target.value)}
+                                placeholder={hasCredentials ? 'Enter replacement SWID' : '{xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}'}
+                              />
                             </div>
                             <div className="space-y-2">
                               <Label htmlFor="espn_s2">ESPN_S2</Label>
-                              <Input id="espn_s2" type={showCredentials ? 'text' : 'password'} value={espnS2} onChange={(e) => setEspnS2(e.target.value)} />
+                              <Input
+                                id="espn_s2"
+                                type={showCredentials ? 'text' : 'password'}
+                                value={espnS2}
+                                onChange={(e) => setEspnS2(e.target.value)}
+                                placeholder={hasCredentials ? 'Enter replacement ESPN_S2' : 'espn_s2 cookie value'}
+                              />
                             </div>
                             <div className="flex items-center gap-2">
                               <Button variant="ghost" size="sm" onClick={() => setShowCredentials(!showCredentials)}>
                                 {showCredentials ? <EyeOff className="h-4 w-4 mr-1" /> : <Eye className="h-4 w-4 mr-1" />}
-                                {showCredentials ? 'Hide' : 'Show'}
+                                {showCredentials ? 'Hide entered values' : 'Show entered values'}
                               </Button>
                             </div>
                             <div className="flex gap-2">
                               <Button onClick={handleSaveCredentials} disabled={isSaving}>
                                 {isSaving ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : null}
-                                Save
+                                {hasCredentials ? 'Replace' : 'Save'}
                               </Button>
-                              <Button variant="outline" onClick={() => setDialogOpen(false)}>Cancel</Button>
+                              <Button variant="outline" onClick={() => handleDialogOpenChange(false)}>Cancel</Button>
                             </div>
                           </>
                         )}

--- a/web/components/site/StepConnectPlatforms.tsx
+++ b/web/components/site/StepConnectPlatforms.tsx
@@ -144,12 +144,17 @@ export function StepConnectPlatforms({ className }: StepConnectPlatformsProps) {
     setIsLoadingCreds(true);
     try {
       const res = await fetch('/api/auth/espn/credentials?forEdit=true');
-      if (res.ok) {
-        const data = await res.json() as { hasCredentials?: boolean };
-        setHasCredentials(!!data.hasCredentials);
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({})) as { error?: string; message?: string };
+        throw new Error(data.error || data.message || 'Failed to load credential status');
       }
-    } catch { /* ignore */ }
-    setIsLoadingCreds(false);
+      const data = await res.json() as { hasCredentials?: boolean };
+      setHasCredentials(!!data.hasCredentials);
+    } catch (err) {
+      setEspnError(err instanceof Error ? err.message : 'Failed to load credential status');
+    } finally {
+      setIsLoadingCreds(false);
+    }
   };
 
   const handleDialogOpenChange = (open: boolean) => {

--- a/web/lib/server/__tests__/espn-credentials-route.test.ts
+++ b/web/lib/server/__tests__/espn-credentials-route.test.ts
@@ -108,6 +108,45 @@ describe('GET /api/auth/espn/credentials?forEdit=true', () => {
     expect(body).not.toHaveProperty('swid');
     expect(body).not.toHaveProperty('s2');
   });
+
+  it('does not infer edit credentials from hostile upstream raw-only fields', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({
+      email: 'user@example.com',
+      lastUpdated: '2026-06-08T16:30:00.000Z',
+      swid: '{11111111-2222-3333-4444-555555555555}',
+      s2: 'raw-espn-s2-secret-value-that-should-not-return-to-browser',
+    })));
+
+    const response = await GET(credentialsRequest('?forEdit=true'));
+    const body = await response.json() as Record<string, unknown>;
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      hasCredentials: false,
+      platform: 'espn',
+      email: 'user@example.com',
+      lastUpdated: '2026-06-08T16:30:00.000Z',
+      replaceOnly: true,
+    });
+    expect(body).not.toHaveProperty('swid');
+    expect(body).not.toHaveProperty('s2');
+    expect(JSON.stringify(body)).not.toContain('raw-espn-s2-secret-value');
+  });
+
+  it('returns bad gateway for malformed upstream edit metadata', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('{not-json', {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })));
+
+    const response = await GET(credentialsRequest('?forEdit=true'));
+    const body = await response.json() as Record<string, unknown>;
+
+    expect(response.status).toBe(502);
+    expect(body).toEqual({
+      error: 'Upstream returned an unexpected response shape',
+    });
+  });
 });
 
 describe('GET /api/auth/espn/credentials', () => {

--- a/web/lib/server/__tests__/espn-credentials-route.test.ts
+++ b/web/lib/server/__tests__/espn-credentials-route.test.ts
@@ -91,8 +91,10 @@ describe('GET /api/auth/espn/credentials?forEdit=true', () => {
 
   it('returns replace-only empty state for missing credentials', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({
-      error: 'Credentials not found',
-    }, 404)));
+      hasCredentials: false,
+      platform: 'espn',
+      replaceOnly: true,
+    })));
 
     const response = await GET(credentialsRequest('?forEdit=true'));
     const body = await response.json() as Record<string, unknown>;
@@ -105,5 +107,50 @@ describe('GET /api/auth/espn/credentials?forEdit=true', () => {
     });
     expect(body).not.toHaveProperty('swid');
     expect(body).not.toHaveProperty('s2');
+  });
+});
+
+describe('GET /api/auth/espn/credentials', () => {
+  it('sanitizes raw ESPN credentials from upstream status metadata', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({
+      email: 'user@example.com',
+      lastUpdated: '2026-06-08T16:30:00.000Z',
+      swid: '{11111111-2222-3333-4444-555555555555}',
+      s2: 'raw-espn-s2-secret-value-that-should-not-return-to-browser',
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await GET(credentialsRequest());
+    const body = await response.json() as Record<string, unknown>;
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      hasCredentials: true,
+      email: 'user@example.com',
+      lastUpdated: '2026-06-08T16:30:00.000Z',
+    });
+    expect(body).not.toHaveProperty('swid');
+    expect(body).not.toHaveProperty('s2');
+    expect(JSON.stringify(body)).not.toContain('raw-espn-s2-secret-value');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://auth.example/credentials/espn',
+      {
+        headers: {
+          Authorization: 'Bearer test-clerk-token',
+        },
+      },
+    );
+  });
+
+  it('does not infer credentials from incomplete upstream status metadata', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({
+      maskedSwid: '{********-****-****-****-************}',
+    })));
+
+    const response = await GET(credentialsRequest());
+    const body = await response.json() as Record<string, unknown>;
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ hasCredentials: false });
   });
 });

--- a/web/lib/server/__tests__/espn-credentials-route.test.ts
+++ b/web/lib/server/__tests__/espn-credentials-route.test.ts
@@ -1,0 +1,109 @@
+import { NextRequest } from 'next/server';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  auth: vi.fn(),
+}));
+
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: mocks.auth,
+}));
+
+import { GET } from '../../../app/api/auth/espn/credentials/route';
+
+const ORIGINAL_AUTH_WORKER_URL = process.env.NEXT_PUBLIC_AUTH_WORKER_URL;
+
+function mockSignedInUser() {
+  const getToken = vi.fn(async () => 'test-clerk-token');
+  mocks.auth.mockResolvedValue({
+    userId: 'user_123',
+    getToken,
+  });
+  return { getToken };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function credentialsRequest(search = '') {
+  return new NextRequest(`https://flaim.app/api/auth/espn/credentials${search}`);
+}
+
+beforeEach(() => {
+  process.env.NEXT_PUBLIC_AUTH_WORKER_URL = 'https://auth.example';
+  mockSignedInUser();
+});
+
+afterEach(() => {
+  if (ORIGINAL_AUTH_WORKER_URL === undefined) {
+    delete process.env.NEXT_PUBLIC_AUTH_WORKER_URL;
+  } else {
+    process.env.NEXT_PUBLIC_AUTH_WORKER_URL = ORIGINAL_AUTH_WORKER_URL;
+  }
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('GET /api/auth/espn/credentials?forEdit=true', () => {
+  it('sanitizes raw ESPN credentials from upstream replace metadata', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({
+      hasCredentials: true,
+      platform: 'espn',
+      email: 'user@example.com',
+      lastUpdated: '2026-06-08T16:30:00.000Z',
+      replaceOnly: true,
+      maskedSwid: '{********-****-****-****-************}',
+      maskedS2: '************',
+      swid: '{11111111-2222-3333-4444-555555555555}',
+      s2: 'raw-espn-s2-secret-value-that-should-not-return-to-browser',
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await GET(credentialsRequest('?forEdit=true'));
+    const body = await response.json() as Record<string, unknown>;
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      hasCredentials: true,
+      platform: 'espn',
+      email: 'user@example.com',
+      lastUpdated: '2026-06-08T16:30:00.000Z',
+      replaceOnly: true,
+      maskedSwid: '{********-****-****-****-************}',
+      maskedS2: '************',
+    });
+    expect(body).not.toHaveProperty('swid');
+    expect(body).not.toHaveProperty('s2');
+    expect(JSON.stringify(body)).not.toContain('raw-espn-s2-secret-value');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://auth.example/credentials/espn?forEdit=true',
+      {
+        headers: {
+          Authorization: 'Bearer test-clerk-token',
+        },
+      },
+    );
+  });
+
+  it('returns replace-only empty state for missing credentials', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({
+      error: 'Credentials not found',
+    }, 404)));
+
+    const response = await GET(credentialsRequest('?forEdit=true'));
+    const body = await response.json() as Record<string, unknown>;
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      hasCredentials: false,
+      platform: 'espn',
+      replaceOnly: true,
+    });
+    expect(body).not.toHaveProperty('swid');
+    expect(body).not.toHaveProperty('s2');
+  });
+});

--- a/web/lib/use-espn-credentials.ts
+++ b/web/lib/use-espn-credentials.ts
@@ -183,6 +183,8 @@ export function useEspnCredentials(): EspnCredentialsState {
 
     setIsLoadingCreds(true);
     setCredsError(null);
+    setSwid('');
+    setEspnS2('');
 
     let errored = false;
     try {
@@ -191,17 +193,18 @@ export function useEspnCredentials(): EspnCredentialsState {
       });
       if (controller.signal.aborted || !shouldApply()) return;
       if (res.ok) {
-        const data = await res.json() as { hasCredentials?: boolean; swid?: string; s2?: string };
+        const data = await res.json() as { hasCredentials?: boolean; lastUpdated?: string };
         if (!shouldApply()) return;
-        if (data.swid) setSwid(data.swid);
-        if (data.s2) setEspnS2(data.s2);
+        const connected = !!data.hasCredentials;
+        setHasCredentials(connected);
+        setLastUpdated(connected ? data.lastUpdated || null : null);
       }
     } catch (err) {
       if (isAbortError(err)) return;
       if (!shouldApply()) return;
       errored = true;
-      console.error('Failed to fetch credentials for editing:', err);
-      setCredsError(err instanceof Error ? err.message : 'Failed to load credentials');
+      console.error('Failed to fetch credential replacement metadata:', err);
+      setCredsError(err instanceof Error ? err.message : 'Failed to load credential status');
     } finally {
       if (!controller.signal.aborted && shouldApply()) {
         setIsLoadingCreds(false);

--- a/web/lib/use-espn-credentials.ts
+++ b/web/lib/use-espn-credentials.ts
@@ -198,6 +198,9 @@ export function useEspnCredentials(): EspnCredentialsState {
         const connected = !!data.hasCredentials;
         setHasCredentials(connected);
         setLastUpdated(connected ? data.lastUpdated || null : null);
+      } else {
+        const data = await res.json().catch(() => ({})) as { error?: string; message?: string };
+        throw new Error(data.error || data.message || 'Failed to load credential status');
       }
     } catch (err) {
       if (isAbortError(err)) return;

--- a/workers/auth-worker/src/__tests__/espn-credentials-route.test.ts
+++ b/workers/auth-worker/src/__tests__/espn-credentials-route.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockStorage = vi.hoisted(() => ({
+  getCredentials: vi.fn(),
+  getCredentialMetadata: vi.fn(),
+  getSetupStatus: vi.fn(),
+  deleteCredentials: vi.fn(),
+  setCredentials: vi.fn(),
+}));
+
+vi.mock('../supabase-storage', () => {
+  return {
+    EspnSupabaseStorage: {
+      fromEnvironment: vi.fn().mockReturnValue(mockStorage),
+    },
+  };
+});
+
+vi.mock('../oauth-storage', () => {
+  return {
+    OAuthStorage: {
+      fromEnvironment: vi.fn().mockReturnValue({}),
+    },
+  };
+});
+
+vi.mock('../yahoo-storage', () => {
+  return {
+    YahooStorage: {
+      fromEnvironment: vi.fn().mockReturnValue({}),
+    },
+  };
+});
+
+vi.mock('../oauth-handlers', () => ({
+  handleMetadataDiscovery: vi.fn(),
+  handleClientRegistration: vi.fn(),
+  handleAuthorize: vi.fn(),
+  handleCreateCode: vi.fn(),
+  handleToken: vi.fn(),
+  handleRevoke: vi.fn(),
+  handleCheckStatus: vi.fn(),
+  handleRevokeAll: vi.fn(),
+  handleRevokeSingle: vi.fn(),
+  validateOAuthToken: vi.fn().mockResolvedValue(null),
+  OAuthEnv: {},
+}));
+
+vi.mock('../yahoo-connect-handlers', () => ({
+  handleYahooAuthorize: vi.fn(),
+  handleYahooCallback: vi.fn(),
+  handleYahooCredentials: vi.fn(),
+  handleYahooCredentialHealth: vi.fn(),
+  handleYahooDisconnect: vi.fn(),
+  handleYahooDiscover: vi.fn(),
+  handleYahooStatus: vi.fn(),
+  YahooConnectEnv: {},
+}));
+
+import app from '../index-hono';
+
+const ISSUER = 'https://flaim-test.clerk.accounts.dev';
+const KEY_ID = 'espn-credentials-route-test-key';
+const RAW_SWID = '{11111111-2222-3333-4444-555555555555}';
+const RAW_S2 = 'raw-espn-s2-secret-value-that-should-not-return-to-browser';
+
+const baseEnv = {
+  SUPABASE_URL: 'https://example.supabase.co',
+  SUPABASE_SERVICE_KEY: 'test-key',
+  NODE_ENV: 'test',
+  ENVIRONMENT: 'test',
+  CLERK_ISSUER: ISSUER,
+  TOKEN_RATE_LIMITER: { limit: async () => ({ success: true }) },
+  CREDENTIALS_RATE_LIMITER: { limit: async () => ({ success: true }) },
+};
+
+type TestJwk = JsonWebKey & { kid: string; alg: string; use: string };
+
+let privateKey: CryptoKey;
+let publicJwk: TestJwk;
+
+function base64Url(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+function base64UrlJson(value: unknown): string {
+  return base64Url(new TextEncoder().encode(JSON.stringify(value)));
+}
+
+async function signedClerkToken(sub = 'user_public_route_test'): Promise<string> {
+  const header = base64UrlJson({ alg: 'RS256', kid: KEY_ID, typ: 'JWT' });
+  const payload = base64UrlJson({
+    sub,
+    iss: ISSUER,
+    exp: Math.floor(Date.now() / 1000) + 3600,
+  });
+  const data = `${header}.${payload}`;
+  const signature = await crypto.subtle.sign(
+    'RSASSA-PKCS1-v1_5',
+    privateKey,
+    new TextEncoder().encode(data),
+  );
+  return `${data}.${base64Url(new Uint8Array(signature))}`;
+}
+
+function makeRequest(path: string, token: string): Request {
+  return new Request(`https://api.flaim.app${path}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+}
+
+beforeAll(async () => {
+  const keyPair = await crypto.subtle.generateKey(
+    {
+      name: 'RSASSA-PKCS1-v1_5',
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: 'SHA-256',
+    },
+    true,
+    ['sign', 'verify'],
+  ) as CryptoKeyPair;
+  privateKey = keyPair.privateKey;
+  const exported = await crypto.subtle.exportKey('jwk', keyPair.publicKey) as JsonWebKey;
+  publicJwk = {
+    ...exported,
+    kid: KEY_ID,
+    alg: 'RS256',
+    use: 'sig',
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal('fetch', vi.fn(async () => {
+    return new Response(JSON.stringify({ keys: [publicJwk] }), {
+      headers: { 'content-type': 'application/json' },
+    });
+  }));
+  mockStorage.getCredentials.mockResolvedValue({ swid: RAW_SWID, s2: RAW_S2 });
+  mockStorage.getCredentialMetadata.mockResolvedValue({
+    hasCredentials: true,
+    email: 'user@example.com',
+    lastUpdated: '2026-06-08T16:30:00.000Z',
+  });
+  mockStorage.getSetupStatus.mockResolvedValue({
+    hasCredentials: true,
+    hasLeagues: false,
+    hasDefaultTeam: false,
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('GET /auth/credentials/espn?forEdit=true', () => {
+  it('returns replace-only metadata without raw ESPN credentials', async () => {
+    const token = await signedClerkToken();
+    const res = await app.fetch(makeRequest('/auth/credentials/espn?forEdit=true', token), baseEnv);
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body).toEqual({
+      hasCredentials: true,
+      platform: 'espn',
+      email: 'user@example.com',
+      lastUpdated: '2026-06-08T16:30:00.000Z',
+      replaceOnly: true,
+      maskedSwid: '{********-****-****-****-************}',
+      maskedS2: '************',
+    });
+    expect(body).not.toHaveProperty('swid');
+    expect(body).not.toHaveProperty('s2');
+    expect(JSON.stringify(body)).not.toContain(RAW_SWID);
+    expect(JSON.stringify(body)).not.toContain(RAW_S2);
+    expect(mockStorage.getCredentialMetadata).toHaveBeenCalledWith('user_public_route_test');
+    expect(mockStorage.getCredentials).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty replace-only state when credentials are absent', async () => {
+    mockStorage.getCredentialMetadata.mockResolvedValueOnce({ hasCredentials: false });
+
+    const token = await signedClerkToken();
+    const res = await app.fetch(makeRequest('/auth/credentials/espn?forEdit=true', token), baseEnv);
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(body).toEqual({
+      hasCredentials: false,
+      platform: 'espn',
+      replaceOnly: true,
+    });
+    expect(body).not.toHaveProperty('swid');
+    expect(body).not.toHaveProperty('s2');
+    expect(mockStorage.getCredentials).not.toHaveBeenCalled();
+  });
+});

--- a/workers/auth-worker/src/__tests__/eval-api-key.test.ts
+++ b/workers/auth-worker/src/__tests__/eval-api-key.test.ts
@@ -178,9 +178,9 @@ describe('eval API key auth', () => {
       })
     );
     expect(res.status).toBe(200);
-    const body = await res.json() as { success: boolean; credentials: unknown };
+    const body = await res.json() as { success: boolean; credentials: { swid: string; s2: string } };
     expect(body.success).toBe(true);
-    expect(body.credentials).toBeTruthy();
+    expect(body.credentials).toEqual({ swid: 'test-swid', s2: 'test-s2' });
   });
 
   it('GET /auth/internal/leagues with valid API key returns leagues', async () => {

--- a/workers/auth-worker/src/index-hono.ts
+++ b/workers/auth-worker/src/index-hono.ts
@@ -119,6 +119,8 @@ type JwtPayload = { sub?: string; iss?: string; exp?: number; [k: string]: unkno
 const EVAL_RUN_HEADER = 'X-Flaim-Eval-Run';
 const EVAL_TRACE_HEADER = 'X-Flaim-Eval-Trace';
 const INTERNAL_SERVICE_TOKEN_HEADER = 'X-Flaim-Internal-Token';
+const MASKED_ESPN_SWID = '{********-****-****-****-************}';
+const MASKED_ESPN_S2 = '************';
 
 const ALLOWED_ORIGINS = [
   'https://flaim-*.vercel.app',
@@ -1317,24 +1319,28 @@ async function handleCredentialsEspn(c: Context<{ Bindings: Env }>, method: stri
       }, 403);
     }
 
-    // Check if this is an edit request
+    // Browser edit flows are replace-only: expose metadata and masks, never raw cookies.
     const forEdit = url.searchParams.get('forEdit') === 'true';
 
     if (forEdit) {
-      const credentials = await storage.getCredentials(clerkUserId);
+      const metadata = await storage.getCredentialMetadata(clerkUserId);
 
-      if (!credentials) {
+      if (!metadata?.hasCredentials) {
         return c.json({
           hasCredentials: false,
-          message: 'No ESPN credentials found'
-        }, 404);
+          platform: 'espn',
+          replaceOnly: true
+        });
       }
 
       return c.json({
         hasCredentials: true,
         platform: 'espn',
-        swid: credentials.swid,
-        s2: credentials.s2
+        email: metadata.email,
+        lastUpdated: metadata.lastUpdated,
+        replaceOnly: true,
+        maskedSwid: MASKED_ESPN_SWID,
+        maskedS2: MASKED_ESPN_S2
       });
     }
 


### PR DESCRIPTION
## Summary
- Public ESPN edit GETs now return replace-only metadata/masks.
- Web proxy strips raw fields defensively before returning edit data to the browser.
- Browser inputs open blank for replacement instead of pre-filling stored values.
- Internal raw route remains token-protected.

## Validation
- `corepack pnpm --dir workers/auth-worker run test` passed: 19 files, 329 tests
- `corepack pnpm --dir workers/auth-worker run type-check` passed
- `corepack pnpm --dir web exec tsc --noEmit` passed
- `corepack pnpm --dir web run test -- lib/server/__tests__/espn-credentials-route.test.ts` passed: 10 files, 76 tests
- `git diff --check origin/main...HEAD` passed

## Notes
- Existing local Node engine warning: local shell Node v26 while repo declares Node 24.x; CI uses Node 24 and this is already tracked under FLA-58.

Linear: https://linear.app/flaim/issue/FLA-142/stop-returning-raw-espn-credentials-to-browser-edit-flows