### PR TITLE
Add live product setup signals

### DIFF
--- a/workers/auth-worker/src/__tests__/oauth-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/oauth-handlers.test.ts
@@ -59,6 +59,10 @@ function expectRedirectLocation(response: Response): URL {
   return new URL(location!);
 }
 
+function emittedSetupSignal(spy: ReturnType<typeof vi.spyOn>): boolean {
+  return spy.mock.calls.some((call) => String(call[0]).includes('"schema_version":1'));
+}
+
 describe('oauth-handlers', () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -77,6 +81,16 @@ describe('oauth-handlers', () => {
     expect(body1.client_id).toMatch(/^mcp_/);
     expect(body2.client_id).toMatch(/^mcp_/);
     expect(body1.client_id).not.toBe(body2.client_id);
+  });
+
+  it('does not emit setup signal for non-POST DCR probes', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const req = new Request('https://api.flaim.app/auth/register', { method: 'GET' });
+
+    const res = await handleClientRegistration(req, env, corsHeaders);
+
+    expect(res.status).toBe(405);
+    expect(emittedSetupSignal(logSpy)).toBe(false);
   });
 
   it('keeps non-Perplexity public DCR clients public without a client_secret when auth method is none', async () => {
@@ -221,6 +235,16 @@ describe('oauth-handlers', () => {
     const body = await res.json() as { error?: string; error_description?: string };
     expect(body.error).toBe('invalid_request');
     expect(body.error_description).toBe('redirect_uri is required');
+  });
+
+  it('does not emit setup signal for no-param /authorize probes', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const req = new Request('https://api.flaim.app/authorize');
+
+    const res = await handleAuthorize(req, env);
+
+    expect(res.status).toBe(400);
+    expect(emittedSetupSignal(logSpy)).toBe(false);
   });
 
   it('returns invalid_grant when token exchange fails', async () => {

--- a/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-connect-handlers.test.ts
@@ -49,6 +49,10 @@ function yahooRefreshDiagnostics(spy: { mock: { calls: unknown[][] } }): Array<R
     .filter((entry): entry is Record<string, unknown> => entry?.component === 'yahoo-connect');
 }
 
+function yahooSetupSignals(spy: { mock: { calls: unknown[][] } }): Array<Record<string, unknown>> {
+  return yahooRefreshDiagnostics(spy).filter((entry) => entry.schema_version === 1);
+}
+
 function expectNoRawYahooTokenFields(value: unknown): void {
   if (Array.isArray(value)) {
     for (const item of value) {
@@ -188,6 +192,18 @@ describe('yahoo-connect-handlers', () => {
   // ===========================================================================
 
   describe('handleYahooCallback', () => {
+    it('does not emit setup signal for empty callback probes', async () => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+      const request = new Request('https://api.flaim.app/connect/yahoo/callback');
+
+      const response = await handleYahooCallback(request, env, corsHeaders);
+
+      expect(response.status).toBe(302);
+      const location = response.headers.get('Location')!;
+      expect(location).toContain('error=missing_code');
+      expect(yahooSetupSignals(logSpy)).toEqual([]);
+    });
+
     it('returns error redirect for missing code', async () => {
       const request = new Request('https://api.flaim.app/connect/yahoo/callback?state=user_123:abc123');
 

--- a/workers/auth-worker/src/extension-handlers.ts
+++ b/workers/auth-worker/src/extension-handlers.ts
@@ -6,6 +6,7 @@
  */
 
 import { EspnSupabaseStorage } from './supabase-storage';
+import { logSetupSignal, type SetupSignalEvent } from '@flaim/worker-shared';
 
 // =============================================================================
 // TYPES
@@ -56,12 +57,37 @@ function jsonResponse(body: Record<string, unknown>, status: number, corsHeaders
   });
 }
 
+function logExtensionFailure(
+  request: Request,
+  env: ExtensionEnv,
+  fields: Omit<SetupSignalEvent, 'service' | 'component' | 'event'>
+): void {
+  const url = new URL(request.url);
+  logSetupSignal({
+    service: 'auth-worker',
+    component: 'espn-extension',
+    event: 'onboarding_failed',
+    outcome: 'failure',
+    request_path: url.pathname,
+    method: request.method,
+    has_auth_header: request.headers.has('Authorization'),
+    correlation_id: request.headers.get('X-Correlation-ID') || undefined,
+    cf_ray: request.headers.get('CF-Ray') || undefined,
+    environment: env.ENVIRONMENT || env.NODE_ENV,
+    platform: 'espn',
+    auth_type: 'clerk',
+    ...fields,
+  } as SetupSignalEvent & Record<string, unknown>);
+}
+
 function parseSyncCredentialsBody(
   rawBody: unknown,
   corsHeaders: Record<string, string>
-): { body?: ExtensionSyncBody; response?: Response } {
+): { body?: ExtensionSyncBody; response?: Response; errorCode?: string; status?: number } {
   if (!rawBody || typeof rawBody !== 'object') {
     return {
+      errorCode: 'invalid_request_body',
+      status: 400,
       response: jsonResponse({
         error: 'invalid_request',
         error_description: 'Invalid request body',
@@ -72,6 +98,8 @@ function parseSyncCredentialsBody(
   const bodyRecord = rawBody as { swid?: unknown; s2?: unknown };
   if (typeof bodyRecord.swid !== 'string' || typeof bodyRecord.s2 !== 'string' || !bodyRecord.swid || !bodyRecord.s2) {
     return {
+      errorCode: 'missing_espn_credentials',
+      status: 400,
       response: jsonResponse({
         error: 'invalid_request',
         error_description: 'swid and s2 are required',
@@ -81,6 +109,8 @@ function parseSyncCredentialsBody(
 
   if (!isValidSwid(bodyRecord.swid)) {
     return {
+      errorCode: 'invalid_swid',
+      status: 400,
       response: jsonResponse({
         error: 'invalid_request',
         error_description: 'Invalid SWID format (expected UUID in curly braces)',
@@ -90,6 +120,8 @@ function parseSyncCredentialsBody(
 
   if (!isValidS2(bodyRecord.s2)) {
     return {
+      errorCode: 'invalid_espn_s2',
+      status: 400,
       response: jsonResponse({
         error: 'invalid_request',
         error_description: 'Invalid espn_s2 format (too short)',
@@ -123,6 +155,12 @@ export async function handleSyncCredentials(
     const rawBody = await request.json().catch(() => null);
     const parsedBody = parseSyncCredentialsBody(rawBody, corsHeaders);
     if (parsedBody.response) {
+      logExtensionFailure(request, env, {
+        stage: 'credential_payload_validation',
+        failure_kind: 'validation',
+        error_code: parsedBody.errorCode || 'invalid_request',
+        http_status: parsedBody.status || 400,
+      });
       return parsedBody.response;
     }
     const body = parsedBody.body!;
@@ -132,6 +170,12 @@ export async function handleSyncCredentials(
     const success = await credStorage.setCredentials(userId, body.swid, body.s2);
 
     if (!success) {
+      logExtensionFailure(request, env, {
+        stage: 'credential_storage',
+        failure_kind: 'storage',
+        error_code: 'credential_storage_failed',
+        http_status: 500,
+      });
       return jsonResponse({
         error: 'server_error',
         error_description: 'Failed to store credentials',
@@ -145,6 +189,12 @@ export async function handleSyncCredentials(
       message: 'Credentials synced successfully',
     }, 200, corsHeaders);
   } catch (error) {
+    logExtensionFailure(request, env, {
+      stage: 'credential_sync',
+      failure_kind: 'exception',
+      error_code: 'server_error',
+      http_status: 500,
+    });
     console.error('[extension] Failed to sync credentials:', error);
     return jsonResponse({
       error: 'server_error',

--- a/workers/auth-worker/src/extension-handlers.ts
+++ b/workers/auth-worker/src/extension-handlers.ts
@@ -60,14 +60,13 @@ function jsonResponse(body: Record<string, unknown>, status: number, corsHeaders
 function logExtensionFailure(
   request: Request,
   env: ExtensionEnv,
-  fields: Omit<SetupSignalEvent, 'service' | 'component' | 'event'>
+  fields: Omit<SetupSignalEvent, 'service' | 'component' | 'event' | 'outcome'>
 ): void {
   const url = new URL(request.url);
   logSetupSignal({
     service: 'auth-worker',
     component: 'espn-extension',
     event: 'onboarding_failed',
-    outcome: 'failure',
     request_path: url.pathname,
     method: request.method,
     has_auth_header: request.headers.has('Authorization'),
@@ -77,6 +76,7 @@ function logExtensionFailure(
     platform: 'espn',
     auth_type: 'clerk',
     ...fields,
+    outcome: 'failure',
   } as SetupSignalEvent & Record<string, unknown>);
 }
 

--- a/workers/auth-worker/src/index-hono.ts
+++ b/workers/auth-worker/src/index-hono.ts
@@ -320,13 +320,13 @@ function logAuthWorkerFailure(
   request: Request,
   env: Env,
   event: string,
-  fields: Omit<SetupSignalEvent, 'service' | 'event'>
+  fields: Omit<SetupSignalEvent, 'service' | 'event' | 'outcome'>
 ): void {
   logSetupSignal({
     ...baseAuthWorkerSignal(request, env),
     event,
-    outcome: 'failure',
     ...fields,
+    outcome: 'failure',
   } as SetupSignalEvent & Record<string, unknown>);
 }
 
@@ -741,6 +741,7 @@ api.get('/internal/introspect', async (c) => {
   const { userId, error: authError, status: authStatus, scope, authType } = await getInternalUserId(c.req.raw, c.env, expectedResource, { allowStaticApiKey: true });
 
   if (!userId) {
+    // 403/500 internal-service auth failures are already logged by getInternalUserId.
     if (authStatus !== 403 && authStatus !== 500) {
       logAuthWorkerFailure(c.req.raw, c.env, 'auth_trust_path_failed', {
         component: 'auth-introspection',

--- a/workers/auth-worker/src/index-hono.ts
+++ b/workers/auth-worker/src/index-hono.ts
@@ -59,6 +59,7 @@ import {
   YahooConnectEnv,
 } from './yahoo-connect-handlers';
 import { YahooStorage } from './yahoo-storage';
+import { logSetupSignal, type SetupSignalEvent } from '@flaim/worker-shared';
 import {
   handleSleeperDiscover,
   handleSleeperStatus,
@@ -302,6 +303,33 @@ function debugLog(env: Env, message: string): void {
   }
 }
 
+function baseAuthWorkerSignal(request: Request, env: Env): Partial<SetupSignalEvent> {
+  const url = new URL(request.url);
+  return {
+    service: 'auth-worker',
+    request_path: url.pathname,
+    method: request.method,
+    has_auth_header: request.headers.has('Authorization'),
+    correlation_id: request.headers.get('X-Correlation-ID') || undefined,
+    cf_ray: request.headers.get('CF-Ray') || undefined,
+    environment: env.ENVIRONMENT || env.NODE_ENV,
+  };
+}
+
+function logAuthWorkerFailure(
+  request: Request,
+  env: Env,
+  event: string,
+  fields: Omit<SetupSignalEvent, 'service' | 'event'>
+): void {
+  logSetupSignal({
+    ...baseAuthWorkerSignal(request, env),
+    event,
+    outcome: 'failure',
+    ...fields,
+  } as SetupSignalEvent & Record<string, unknown>);
+}
+
 // =============================================================================
 // AUTH HELPERS
 // =============================================================================
@@ -378,6 +406,14 @@ async function getVerifiedUserId(
     for (const staticKey of staticKeys) {
       if (!staticKey.key) continue;
       if (!staticKey.userId) {
+        logAuthWorkerFailure(request, env, 'auth_trust_path_failed', {
+          component: 'static-api-key',
+          stage: 'static_key_config',
+          failure_kind: 'configuration',
+          error_code: 'static_key_user_id_missing',
+          http_status: 500,
+          auth_type: staticKey.authType,
+        });
         console.error(`[auth-worker] ${staticKey.label} set but corresponding user ID missing — skipping static API key auth`);
         continue;
       }
@@ -458,6 +494,13 @@ async function getInternalUserId(
 ): Promise<AuthResult> {
   const internalError = await requireInternalService(request, env);
   if (internalError) {
+    logAuthWorkerFailure(request, env, 'auth_trust_path_failed', {
+      component: 'internal-service-auth',
+      stage: 'internal_service_validation',
+      failure_kind: internalError.status === 500 ? 'configuration' : 'auth',
+      error_code: internalError.status === 500 ? 'internal_service_auth_not_configured' : 'invalid_internal_service_token',
+      http_status: internalError.status,
+    });
     return { userId: null, error: internalError.error, status: internalError.status };
   }
 
@@ -698,6 +741,16 @@ api.get('/internal/introspect', async (c) => {
   const { userId, error: authError, status: authStatus, scope, authType } = await getInternalUserId(c.req.raw, c.env, expectedResource, { allowStaticApiKey: true });
 
   if (!userId) {
+    if (authStatus !== 403 && authStatus !== 500) {
+      logAuthWorkerFailure(c.req.raw, c.env, 'auth_trust_path_failed', {
+        component: 'auth-introspection',
+        stage: 'token_introspection',
+        failure_kind: 'auth',
+        error_code: 'invalid_token',
+        http_status: authStatus ?? 401,
+        auth_type: authType,
+      });
+    }
     return c.json({ valid: false, error: authError || 'Invalid token' }, authStatus ?? 401);
   }
 
@@ -712,6 +765,14 @@ api.get('/internal/introspect', async (c) => {
 api.post('/oauth/code', async (c) => {
   const { userId, error: authError } = await getClerkUserId(c.req.raw, c.env);
   if (!userId) {
+    logAuthWorkerFailure(c.req.raw, c.env, 'oauth_code_failed', {
+      component: 'oauth-provider',
+      stage: 'clerk_auth',
+      failure_kind: 'auth',
+      error_code: 'clerk_auth_required',
+      http_status: 401,
+      auth_type: 'clerk',
+    });
     return c.json({
       error: 'unauthorized',
       error_description: authError || 'Authentication required',
@@ -764,6 +825,15 @@ api.post('/oauth/revoke', async (c) => {
 api.post('/extension/sync', async (c) => {
   const { userId, error: authError } = await getClerkUserId(c.req.raw, c.env);
   if (!userId) {
+    logAuthWorkerFailure(c.req.raw, c.env, 'onboarding_failed', {
+      component: 'espn-extension',
+      stage: 'clerk_auth',
+      failure_kind: 'auth',
+      error_code: 'clerk_auth_required',
+      http_status: 401,
+      platform: 'espn',
+      auth_type: 'clerk',
+    });
     return c.json({
       error: 'unauthorized',
       error_description: authError || 'Authentication required',
@@ -800,6 +870,15 @@ api.get('/extension/connection', async (c) => {
 api.post('/extension/discover', async (c) => {
   const { userId, error: authError } = await getClerkUserId(c.req.raw, c.env);
   if (!userId) {
+    logAuthWorkerFailure(c.req.raw, c.env, 'onboarding_failed', {
+      component: 'espn-extension',
+      stage: 'clerk_auth',
+      failure_kind: 'auth',
+      error_code: 'clerk_auth_required',
+      http_status: 401,
+      platform: 'espn',
+      auth_type: 'clerk',
+    });
     return c.json({
       error: 'unauthorized',
       error_description: authError || 'Authentication required',
@@ -812,6 +891,15 @@ api.post('/extension/discover', async (c) => {
   // Get stored credentials
   const credentials = await storage.getCredentials(userId);
   if (!credentials) {
+    logAuthWorkerFailure(c.req.raw, c.env, 'onboarding_failed', {
+      component: 'espn-extension',
+      stage: 'credential_lookup',
+      failure_kind: 'missing_credentials',
+      error_code: 'credentials_not_found',
+      http_status: 400,
+      platform: 'espn',
+      auth_type: 'clerk',
+    });
     return new Response(JSON.stringify({
       error: 'credentials_not_found',
       error_description: 'ESPN credentials not found. Please sync credentials first.',
@@ -892,6 +980,15 @@ api.post('/extension/discover', async (c) => {
     const isAuthError = errorMessage.includes('authentication') ||
       errorMessage.includes('expired') ||
       errorMessage.includes('invalid');
+    logAuthWorkerFailure(c.req.raw, c.env, 'onboarding_failed', {
+      component: 'espn-extension',
+      stage: 'league_discovery',
+      failure_kind: isAuthError ? 'auth' : 'upstream',
+      error_code: isAuthError ? 'espn_auth_failed' : 'discovery_failed',
+      http_status: isAuthError ? 401 : 500,
+      platform: 'espn',
+      auth_type: 'clerk',
+    });
 
     return c.json({
       error: isAuthError ? 'espn_auth_failed' : 'discovery_failed',
@@ -1279,6 +1376,15 @@ async function handleCredentialsEspn(c: Context<{ Bindings: Env }>, method: stri
   debugLog(env, `🔐 [auth-worker] /credentials/espn - Verified user: ${clerkUserId ? maskUserId(clerkUserId) : 'null'}, authType: ${authType || 'none'}, authError: ${authError || 'none'}`);
 
   if (!clerkUserId) {
+    logAuthWorkerFailure(c.req.raw, env, 'onboarding_failed', {
+      component: 'espn-credentials',
+      stage: 'clerk_auth',
+      failure_kind: 'auth',
+      error_code: 'clerk_auth_required',
+      http_status: 401,
+      platform: 'espn',
+      auth_type: 'clerk',
+    });
     return c.json({
       error: 'Authentication required',
       message: authError || 'Missing or invalid Authorization token'
@@ -1292,6 +1398,15 @@ async function handleCredentialsEspn(c: Context<{ Bindings: Env }>, method: stri
     const validation = validateEspnCredentials(body);
 
     if (!validation.valid) {
+      logAuthWorkerFailure(c.req.raw, env, 'onboarding_failed', {
+        component: 'espn-credentials',
+        stage: 'credential_payload_validation',
+        failure_kind: 'validation',
+        error_code: 'invalid_espn_credentials_payload',
+        http_status: 400,
+        platform: 'espn',
+        auth_type: 'clerk',
+      });
       return c.json({
         error: 'Invalid credentials',
         message: validation.error
@@ -1301,6 +1416,15 @@ async function handleCredentialsEspn(c: Context<{ Bindings: Env }>, method: stri
     const success = await storage.setCredentials(clerkUserId, body.swid!, body.s2!, body.email);
 
     if (!success) {
+      logAuthWorkerFailure(c.req.raw, env, 'onboarding_failed', {
+        component: 'espn-credentials',
+        stage: 'credential_storage',
+        failure_kind: 'storage',
+        error_code: 'credential_storage_failed',
+        http_status: 500,
+        platform: 'espn',
+        auth_type: 'clerk',
+      });
       return c.json({ error: 'Failed to store credentials' }, 500);
     }
 

--- a/workers/auth-worker/src/oauth-handlers.ts
+++ b/workers/auth-worker/src/oauth-handlers.ts
@@ -189,13 +189,13 @@ function logOAuthFailure(
   request: Request,
   env: OAuthEnv,
   event: string,
-  fields: Omit<SetupSignalEvent, 'service' | 'component' | 'event'>
+  fields: Omit<SetupSignalEvent, 'service' | 'component' | 'event' | 'outcome'>
 ): void {
   logSetupSignal({
     ...baseOAuthSignal(request, env),
     event,
-    outcome: 'failure',
     ...fields,
+    outcome: 'failure',
   } as SetupSignalEvent & Record<string, unknown>);
 }
 

--- a/workers/auth-worker/src/oauth-handlers.ts
+++ b/workers/auth-worker/src/oauth-handlers.ts
@@ -19,7 +19,7 @@
 
 import { OAuthStorage } from './oauth-storage';
 import { getFrontendUrl } from './preview-url';
-import { isValidRedirectUri } from '@flaim/worker-shared';
+import { isValidRedirectUri, logSetupSignal, type SetupSignalEvent } from '@flaim/worker-shared';
 import {
   createConfidentialClientRegistration,
   getClientIdFromBoundToken,
@@ -171,6 +171,54 @@ function invalidClientResponse(
   });
 }
 
+function baseOAuthSignal(request: Request, env: OAuthEnv): Partial<SetupSignalEvent> {
+  const url = new URL(request.url);
+  return {
+    service: 'auth-worker',
+    component: 'oauth-provider',
+    request_path: url.pathname,
+    method: request.method,
+    has_auth_header: request.headers.has('Authorization'),
+    correlation_id: request.headers.get('X-Correlation-ID') || undefined,
+    cf_ray: request.headers.get('CF-Ray') || undefined,
+    environment: env.ENVIRONMENT || env.NODE_ENV,
+  };
+}
+
+function logOAuthFailure(
+  request: Request,
+  env: OAuthEnv,
+  event: string,
+  fields: Omit<SetupSignalEvent, 'service' | 'component' | 'event'>
+): void {
+  logSetupSignal({
+    ...baseOAuthSignal(request, env),
+    event,
+    outcome: 'failure',
+    ...fields,
+  } as SetupSignalEvent & Record<string, unknown>);
+}
+
+function hasAuthorizeAttemptEvidence(params: AuthorizeParams): boolean {
+  return Boolean(
+    params.client_id ||
+    params.redirect_uri ||
+    params.code_challenge ||
+    params.state ||
+    params.scope ||
+    params.resource
+  );
+}
+
+function hasStrongAuthorizeAttemptEvidence(params: AuthorizeParams): boolean {
+  return Boolean(
+    params.client_id ||
+    params.code_challenge ||
+    params.state ||
+    params.resource
+  );
+}
+
 async function validateTokenEndpointClient(
   body: TokenRequest,
   requiredClientId: string | undefined,
@@ -298,6 +346,12 @@ export async function handleClientRegistration(
   try {
     body = await request.json() as ClientRegistrationRequest;
   } catch {
+    logOAuthFailure(request, env, 'oauth_registration_failed', {
+      stage: 'request_parse',
+      failure_kind: 'validation',
+      error_code: 'invalid_json',
+      http_status: 400,
+    });
     return new Response(JSON.stringify({
       error: 'invalid_request',
       error_description: 'Invalid JSON body'
@@ -311,6 +365,12 @@ export async function handleClientRegistration(
   const redirectUris = body.redirect_uris || [];
   for (const uri of redirectUris) {
     if (!isValidRedirectUri(uri)) {
+      logOAuthFailure(request, env, 'oauth_registration_failed', {
+        stage: 'redirect_uri_validation',
+        failure_kind: 'validation',
+        error_code: 'invalid_redirect_uri',
+        http_status: 400,
+      });
       return new Response(JSON.stringify({
         error: 'invalid_redirect_uri',
         error_description: `Invalid redirect URI: ${uri}`
@@ -325,6 +385,12 @@ export async function handleClientRegistration(
     body.token_endpoint_auth_method
     && !['none', 'client_secret_post'].includes(body.token_endpoint_auth_method)
   ) {
+    logOAuthFailure(request, env, 'oauth_registration_failed', {
+      stage: 'client_metadata_validation',
+      failure_kind: 'validation',
+      error_code: 'invalid_client_metadata',
+      http_status: 400,
+    });
     return new Response(JSON.stringify({
       error: 'invalid_client_metadata',
       error_description: 'Only none and client_secret_post token endpoint auth methods are supported',
@@ -405,6 +471,14 @@ export async function handleAuthorize(request: Request, env: OAuthEnv): Promise<
 
   // Validate required parameters
   if (params.response_type !== 'code') {
+    if (params.response_type || hasAuthorizeAttemptEvidence(params)) {
+      logOAuthFailure(request, env, 'oauth_authorize_failed', {
+        stage: 'parameter_validation',
+        failure_kind: 'validation',
+        error_code: 'unsupported_response_type',
+        http_status: params.redirect_uri && isValidRedirectUri(params.redirect_uri) ? 302 : 400,
+      });
+    }
     if (params.redirect_uri && isValidRedirectUri(params.redirect_uri)) {
       return Response.redirect(
         buildErrorRedirect(params.redirect_uri, 'unsupported_response_type', 'Only code response type is supported', params.state),
@@ -418,6 +492,14 @@ export async function handleAuthorize(request: Request, env: OAuthEnv): Promise<
   }
 
   if (!params.redirect_uri) {
+    if (hasStrongAuthorizeAttemptEvidence(params)) {
+      logOAuthFailure(request, env, 'oauth_authorize_failed', {
+        stage: 'parameter_validation',
+        failure_kind: 'validation',
+        error_code: 'missing_redirect_uri',
+        http_status: 400,
+      });
+    }
     return new Response(JSON.stringify({
       error: 'invalid_request',
       error_description: 'redirect_uri is required',
@@ -425,6 +507,14 @@ export async function handleAuthorize(request: Request, env: OAuthEnv): Promise<
   }
 
   if (!isValidRedirectUri(params.redirect_uri)) {
+    if (params.response_type === 'code' || hasStrongAuthorizeAttemptEvidence(params)) {
+      logOAuthFailure(request, env, 'oauth_authorize_failed', {
+        stage: 'redirect_uri_validation',
+        failure_kind: 'validation',
+        error_code: 'invalid_redirect_uri',
+        http_status: 400,
+      });
+    }
     return new Response(JSON.stringify({
       error: 'invalid_request',
       error_description: 'redirect_uri is not in the allowed list',
@@ -433,6 +523,14 @@ export async function handleAuthorize(request: Request, env: OAuthEnv): Promise<
 
   // PKCE is required (OAuth 2.1)
   if (!params.code_challenge) {
+    if (hasStrongAuthorizeAttemptEvidence(params)) {
+      logOAuthFailure(request, env, 'oauth_authorize_failed', {
+        stage: 'pkce_validation',
+        failure_kind: 'validation',
+        error_code: 'missing_code_challenge',
+        http_status: 302,
+      });
+    }
     return Response.redirect(
       buildErrorRedirect(params.redirect_uri, 'invalid_request', 'code_challenge is required (PKCE)', params.state),
       302
@@ -441,6 +539,12 @@ export async function handleAuthorize(request: Request, env: OAuthEnv): Promise<
 
   // Only S256 PKCE is supported
   if (params.code_challenge_method && params.code_challenge_method !== 'S256') {
+    logOAuthFailure(request, env, 'oauth_authorize_failed', {
+      stage: 'pkce_validation',
+      failure_kind: 'validation',
+      error_code: 'unsupported_code_challenge_method',
+      http_status: 302,
+    });
     return Response.redirect(
       buildErrorRedirect(params.redirect_uri, 'invalid_request', 'Only S256 PKCE is supported', params.state),
       302
@@ -458,6 +562,12 @@ export async function handleAuthorize(request: Request, env: OAuthEnv): Promise<
         expiresInSeconds: 600,
       });
     } catch (error) {
+      logOAuthFailure(request, env, 'oauth_authorize_failed', {
+        stage: 'state_storage',
+        failure_kind: 'storage',
+        error_code: 'state_storage_failed',
+        http_status: 302,
+      });
       console.error('[oauth] Failed to store state:', error);
       return Response.redirect(
         buildErrorRedirect(params.redirect_uri, 'server_error', 'Failed to initialize authorization state', params.state),
@@ -522,6 +632,13 @@ export async function handleCreateCode(
     };
 
     if (!body.redirect_uri) {
+      logOAuthFailure(request, env, 'oauth_code_failed', {
+        stage: 'parameter_validation',
+        failure_kind: 'validation',
+        error_code: 'missing_redirect_uri',
+        http_status: 400,
+        auth_type: 'clerk',
+      });
       return new Response(JSON.stringify({
         error: 'invalid_request',
         error_description: 'redirect_uri is required',
@@ -529,6 +646,13 @@ export async function handleCreateCode(
     }
 
     if (!isValidRedirectUri(body.redirect_uri)) {
+      logOAuthFailure(request, env, 'oauth_code_failed', {
+        stage: 'redirect_uri_validation',
+        failure_kind: 'validation',
+        error_code: 'invalid_redirect_uri',
+        http_status: 400,
+        auth_type: 'clerk',
+      });
       return new Response(JSON.stringify({
         error: 'invalid_request',
         error_description: 'redirect_uri is not in the allowed list',
@@ -544,8 +668,15 @@ export async function handleCreateCode(
         body.client_id
       );
       if (!validState) {
+        logOAuthFailure(request, env, 'oauth_code_failed', {
+          stage: 'state_validation',
+          failure_kind: 'validation',
+          error_code: 'invalid_state',
+          http_status: 400,
+          auth_type: 'clerk',
+        });
         console.log(
-          `[oauth] Invalid state during /oauth/code: state=${maskState(body.state)}, redirect_uri=${body.redirect_uri}, client_id=${body.client_id ? maskClientId(body.client_id) : 'none'}`
+          `[oauth] Invalid state during /oauth/code: state=${maskState(body.state)}, redirect_uri_allowed=${isValidRedirectUri(body.redirect_uri)}, client_id=${body.client_id ? maskClientId(body.client_id) : 'none'}`
         );
         return new Response(JSON.stringify({
           error: 'invalid_request',
@@ -557,6 +688,13 @@ export async function handleCreateCode(
     // Only S256 PKCE is supported
     const codeChallengeMethod = body.code_challenge_method || 'S256';
     if (codeChallengeMethod !== 'S256') {
+      logOAuthFailure(request, env, 'oauth_code_failed', {
+        stage: 'pkce_validation',
+        failure_kind: 'validation',
+        error_code: 'unsupported_code_challenge_method',
+        http_status: 400,
+        auth_type: 'clerk',
+      });
       return new Response(JSON.stringify({
         error: 'invalid_request',
         error_description: 'Only S256 PKCE is supported',
@@ -586,6 +724,13 @@ export async function handleCreateCode(
       headers: { 'Content-Type': 'application/json', ...corsHeaders },
     });
   } catch (error) {
+    logOAuthFailure(request, env, 'oauth_code_failed', {
+      stage: 'code_creation',
+      failure_kind: 'storage',
+      error_code: 'server_error',
+      http_status: 500,
+      auth_type: 'clerk',
+    });
     console.error('[oauth] Failed to create authorization code:', error);
     return new Response(JSON.stringify({
       error: 'server_error',
@@ -636,6 +781,13 @@ export async function handleToken(
     // Handle authorization_code grant
     if (body.grant_type === 'authorization_code') {
       if (!body.code) {
+        logOAuthFailure(request, env, 'oauth_token_failed', {
+          stage: 'token_exchange',
+          failure_kind: 'validation',
+          error_code: 'missing_code',
+          http_status: 400,
+          auth_type: 'oauth',
+        });
         return new Response(JSON.stringify({
           error: 'invalid_request',
           error_description: 'code is required',
@@ -643,6 +795,13 @@ export async function handleToken(
       }
 
       if (!body.redirect_uri) {
+        logOAuthFailure(request, env, 'oauth_token_failed', {
+          stage: 'token_exchange',
+          failure_kind: 'validation',
+          error_code: 'missing_redirect_uri',
+          http_status: 400,
+          auth_type: 'oauth',
+        });
         return new Response(JSON.stringify({
           error: 'invalid_request',
           error_description: 'redirect_uri is required',
@@ -658,6 +817,13 @@ export async function handleToken(
         corsHeaders
       );
       if (clientAuth.errorResponse) {
+        logOAuthFailure(request, env, 'oauth_token_failed', {
+          stage: 'client_auth',
+          failure_kind: 'auth',
+          error_code: 'invalid_client',
+          http_status: 401,
+          auth_type: 'oauth',
+        });
         return clientAuth.errorResponse;
       }
 
@@ -669,6 +835,13 @@ export async function handleToken(
       );
 
       if (!token) {
+        logOAuthFailure(request, env, 'oauth_token_failed', {
+          stage: 'token_exchange',
+          failure_kind: 'auth',
+          error_code: 'invalid_grant',
+          http_status: 400,
+          auth_type: 'oauth',
+        });
         return new Response(JSON.stringify({
           error: 'invalid_grant',
           error_description: 'Invalid authorization code or PKCE verification failed',
@@ -703,6 +876,13 @@ export async function handleToken(
     // Handle refresh_token grant
     if (body.grant_type === 'refresh_token') {
       if (!body.refresh_token) {
+        logOAuthFailure(request, env, 'oauth_token_failed', {
+          stage: 'token_refresh',
+          failure_kind: 'validation',
+          error_code: 'missing_refresh_token',
+          http_status: 400,
+          auth_type: 'oauth',
+        });
         return new Response(JSON.stringify({
           error: 'invalid_request',
           error_description: 'refresh_token is required',
@@ -718,12 +898,26 @@ export async function handleToken(
         corsHeaders
       );
       if (clientAuth.errorResponse) {
+        logOAuthFailure(request, env, 'oauth_token_failed', {
+          stage: 'client_auth',
+          failure_kind: 'auth',
+          error_code: 'invalid_client',
+          http_status: 401,
+          auth_type: 'oauth',
+        });
         return clientAuth.errorResponse;
       }
 
       const token = await storage.refreshAccessToken(body.refresh_token, clientAuth.clientId);
 
       if (!token) {
+        logOAuthFailure(request, env, 'oauth_token_failed', {
+          stage: 'token_refresh',
+          failure_kind: 'auth',
+          error_code: 'invalid_grant',
+          http_status: 400,
+          auth_type: 'oauth',
+        });
         return new Response(JSON.stringify({
           error: 'invalid_grant',
           error_description: 'Invalid or expired refresh token',
@@ -755,12 +949,26 @@ export async function handleToken(
     }
 
     // Unsupported grant type
+    logOAuthFailure(request, env, 'oauth_token_failed', {
+      stage: 'grant_type_validation',
+      failure_kind: 'validation',
+      error_code: 'unsupported_grant_type',
+      http_status: 400,
+      auth_type: 'oauth',
+    });
     return new Response(JSON.stringify({
       error: 'unsupported_grant_type',
       error_description: 'Only authorization_code and refresh_token grants are supported',
     }), { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } });
 
   } catch (error) {
+    logOAuthFailure(request, env, 'oauth_token_failed', {
+      stage: 'token_endpoint',
+      failure_kind: 'exception',
+      error_code: 'server_error',
+      http_status: 500,
+      auth_type: 'oauth',
+    });
     console.error('[oauth] Token endpoint error:', error);
     return new Response(JSON.stringify({
       error: 'server_error',

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -32,7 +32,9 @@ import {
   isYahooRateLimitStatus,
   isYahooTransientHttpStatus,
   parseRetryAfterSeconds,
+  logSetupSignal,
   YahooAuthWorkerErrorCode,
+  type SetupSignalEvent,
   type YahooPublicCredentialHealth,
   type YahooPublicRefreshState,
 } from '@flaim/worker-shared';
@@ -322,6 +324,29 @@ function logYahooRefreshDiagnostic(event: string, fields: YahooRefreshDiagnostic
   if (fields.recoverySucceeded !== undefined) payload.recovery_succeeded = fields.recoverySucceeded;
 
   console.log(JSON.stringify(payload));
+}
+
+function logYahooSetupFailure(
+  env: YahooConnectEnv,
+  event: string,
+  fields: Omit<SetupSignalEvent, 'service' | 'component' | 'event' | 'platform'>,
+  request?: Request
+): void {
+  const url = request ? new URL(request.url) : undefined;
+  logSetupSignal({
+    service: 'auth-worker',
+    component: 'yahoo-connect',
+    event,
+    outcome: 'failure',
+    platform: 'yahoo',
+    request_path: url?.pathname,
+    method: request?.method,
+    has_auth_header: request?.headers.has('Authorization'),
+    correlation_id: fields.correlation_id || request?.headers.get('X-Correlation-ID') || undefined,
+    cf_ray: request?.headers.get('CF-Ray') || undefined,
+    environment: env.ENVIRONMENT || env.NODE_ENV,
+    ...fields,
+  } as SetupSignalEvent & Record<string, unknown>);
 }
 
 type UsableYahooTokenResponse =
@@ -1325,6 +1350,13 @@ export async function handleYahooAuthorize(
       },
     });
   } catch (error) {
+    logYahooSetupFailure(env, 'onboarding_failed', {
+      stage: 'authorization_start',
+      failure_kind: 'storage',
+      error_code: 'authorization_failed',
+      http_status: 500,
+      auth_type: 'clerk',
+    }, request);
     console.error('[yahoo-connect] Authorization error:', error);
     return new Response(
       JSON.stringify({
@@ -1378,11 +1410,27 @@ export async function handleYahooCallback(
 
   // Validate required parameters
   if (!code) {
+    if (state) {
+      logYahooSetupFailure(env, 'oauth_callback_failed', {
+        stage: 'callback_validation',
+        failure_kind: 'validation',
+        error_code: 'missing_code',
+        http_status: 302,
+        auth_type: 'clerk',
+      }, request);
+    }
     console.log('[yahoo-connect] Callback missing code parameter');
     return errorRedirect('missing_code', 'Authorization code not provided');
   }
 
   if (!state) {
+    logYahooSetupFailure(env, 'oauth_callback_failed', {
+      stage: 'callback_validation',
+      failure_kind: 'validation',
+      error_code: 'missing_state',
+      http_status: 302,
+      auth_type: 'clerk',
+    }, request);
     console.log('[yahoo-connect] Callback missing state parameter');
     return errorRedirect('missing_state', 'State parameter not provided');
   }
@@ -1393,6 +1441,13 @@ export async function handleYahooCallback(
     // Validate and consume state (single-use)
     const stateData = await storage.consumePlatformOAuthState(state);
     if (!stateData) {
+      logYahooSetupFailure(env, 'oauth_callback_failed', {
+        stage: 'state_validation',
+        failure_kind: 'validation',
+        error_code: 'invalid_state',
+        http_status: 302,
+        auth_type: 'clerk',
+      }, request);
       console.log('[yahoo-connect] Invalid or expired state');
       return errorRedirect('invalid_state', 'Invalid or expired state parameter');
     }
@@ -1422,6 +1477,16 @@ export async function handleYahooCallback(
       tokenResponse = await exchangeCodeForTokens(requestBody, env, exchangeController.signal);
     } catch (error) {
       clearTimeout(exchangeTimer);
+      logYahooSetupFailure(env, 'oauth_callback_failed', {
+        stage: 'token_exchange',
+        failure_kind: isAbortError(error) ? 'timeout' : 'fetch_error',
+        error_code: YahooAuthWorkerErrorCode.TOKEN_EXCHANGE_UNAVAILABLE,
+        http_status: 302,
+        retryable: true,
+        retry_after: YAHOO_DEFAULT_TRANSIENT_RETRY_AFTER_SECONDS,
+        retry_after_source: 'fallback_default',
+        auth_type: 'clerk',
+      }, request);
       logYahooRefreshDiagnostic('token_exchange_request_exception', {
         userId: clerkUserId,
         authType: 'clerk',
@@ -1445,6 +1510,18 @@ export async function handleYahooCallback(
 
     if (tokenResponse.error) {
       const failureKind = classifyYahooTokenFailure(tokenResponse);
+      const isTransient = isTransientYahooTokenFailure(tokenResponse);
+      logYahooSetupFailure(env, 'oauth_callback_failed', {
+        stage: 'token_exchange',
+        failure_kind: failureKind,
+        error_code: isTransient ? YahooAuthWorkerErrorCode.TOKEN_EXCHANGE_UNAVAILABLE : 'token_exchange_failed',
+        http_status: 302,
+        upstream_status: tokenResponse.status,
+        retryable: isTransient,
+        retry_after: tokenResponse.retry_after,
+        retry_after_source: tokenResponse.retry_after_source,
+        auth_type: 'clerk',
+      }, request);
       logYahooRefreshDiagnostic('token_exchange_response_error', {
         userId: clerkUserId,
         authType: 'clerk',
@@ -1456,7 +1533,6 @@ export async function handleYahooCallback(
         ...requestDiagnosticFields,
       });
       console.error(`[yahoo-connect] Token exchange failed: ${tokenResponse.error}`);
-      const isTransient = isTransientYahooTokenFailure(tokenResponse);
       return errorRedirect(
         isTransient ? YahooAuthWorkerErrorCode.TOKEN_EXCHANGE_UNAVAILABLE : 'token_exchange_failed',
         isTransient
@@ -1466,6 +1542,14 @@ export async function handleYahooCallback(
     }
 
     if (!hasUsableTokenFields(tokenResponse)) {
+      logYahooSetupFailure(env, 'oauth_callback_failed', {
+        stage: 'token_exchange',
+        failure_kind: 'invalid_response',
+        error_code: 'token_exchange_failed',
+        http_status: 302,
+        upstream_status: tokenResponse.status,
+        auth_type: 'clerk',
+      }, request);
       console.error('[yahoo-connect] Token exchange returned unusable token fields');
       return errorRedirect('token_exchange_failed', 'Yahoo did not return usable token fields');
     }
@@ -1473,6 +1557,14 @@ export async function handleYahooCallback(
     // hasUsableTokenFields validates the access-token shape; reconnect must
     // also return a refresh token for future lazy refreshes.
     if (!tokenResponse.refresh_token) {
+      logYahooSetupFailure(env, 'oauth_callback_failed', {
+        stage: 'token_exchange',
+        failure_kind: 'invalid_response',
+        error_code: 'missing_refresh_token',
+        http_status: 302,
+        upstream_status: tokenResponse.status,
+        auth_type: 'clerk',
+      }, request);
       console.error('[yahoo-connect] Yahoo did not return a refresh token');
       return errorRedirect('token_exchange_failed', 'Yahoo did not provide a refresh token');
     }
@@ -1514,6 +1606,13 @@ export async function handleYahooCallback(
       headers: { Location: successUrl.toString(), ...corsHeaders },
     });
   } catch (error) {
+    logYahooSetupFailure(env, 'oauth_callback_failed', {
+      stage: 'callback',
+      failure_kind: 'exception',
+      error_code: 'callback_error',
+      http_status: 302,
+      auth_type: 'clerk',
+    }, request);
     console.error('[yahoo-connect] Callback error:', error);
     return errorRedirect('callback_error', 'An error occurred during authorization');
   }
@@ -1549,6 +1648,18 @@ export async function handleYahooCredentials(
           }
         );
       }
+      logYahooSetupFailure(env, 'platform_auth_failed', {
+        stage: 'credential_refresh',
+        failure_kind: result.retryable ? 'retryable_auth' : 'auth',
+        error_code: result.error,
+        http_status: result.error === YahooAuthWorkerErrorCode.REFRESH_TEMPORARILY_UNAVAILABLE ? 503 : 401,
+        upstream_status: result.upstreamStatus,
+        retryable: result.retryable,
+        retry_after: result.retryAfter,
+        retry_after_source: result.retryAfterSource,
+        correlation_id: correlationId,
+        auth_type: authType,
+      });
       return yahooRefreshFailureResponse(result, corsHeaders);
     }
 
@@ -1567,6 +1678,14 @@ export async function handleYahooCredentials(
       }
     );
   } catch (error) {
+    logYahooSetupFailure(env, 'platform_auth_failed', {
+      stage: 'credentials_lookup',
+      failure_kind: 'exception',
+      error_code: 'server_error',
+      http_status: 500,
+      correlation_id: correlationId,
+      auth_type: authType,
+    });
     console.error('[yahoo-connect] Credentials error:', error);
     return new Response(
       JSON.stringify({
@@ -1882,6 +2001,14 @@ export async function handleYahooDiscover(
     const credentials = await storage.getYahooCredentials(userId);
 
     if (!credentials) {
+      logYahooSetupFailure(env, 'onboarding_failed', {
+        stage: 'credential_lookup',
+        failure_kind: 'missing_credentials',
+        error_code: 'not_connected',
+        http_status: 404,
+        correlation_id: correlationId,
+        auth_type: 'clerk',
+      });
       return new Response(
         JSON.stringify({
           error: 'not_connected',
@@ -1900,6 +2027,18 @@ export async function handleYahooDiscover(
       console.log(`[yahoo-connect] Refreshing token before discovery for user ${maskUserId(userId)}`);
       const tokenResult = await getValidYahooAccessToken(storage, userId, env, credentials, correlationId, 'clerk');
       if ('error' in tokenResult) {
+        logYahooSetupFailure(env, 'onboarding_failed', {
+          stage: 'credential_refresh',
+          failure_kind: tokenResult.retryable ? 'retryable_auth' : 'auth',
+          error_code: tokenResult.error,
+          http_status: tokenResult.error === YahooAuthWorkerErrorCode.REFRESH_TEMPORARILY_UNAVAILABLE ? 503 : 401,
+          upstream_status: tokenResult.upstreamStatus,
+          retryable: tokenResult.retryable,
+          retry_after: tokenResult.retryAfter,
+          retry_after_source: tokenResult.retryAfterSource,
+          correlation_id: correlationId,
+          auth_type: 'clerk',
+        });
         return yahooRefreshFailureResponse(tokenResult, corsHeaders);
       }
       accessToken = tokenResult.accessToken;
@@ -1915,8 +2054,21 @@ export async function handleYahooDiscover(
     });
 
     if (!apiResponse.ok) {
-      const errorText = await apiResponse.text();
-      console.error(`[yahoo-connect] Yahoo API error: ${apiResponse.status} - ${errorText}`);
+      const classification = classifyYahooApiFailure(apiResponse);
+      logYahooSetupFailure(env, 'onboarding_failed', {
+        stage: 'league_discovery',
+        failure_kind: classification.kind,
+        error_code: classification.retryable
+          ? YahooAuthWorkerErrorCode.YAHOO_API_TEMPORARILY_UNAVAILABLE
+          : YahooAuthWorkerErrorCode.YAHOO_API_ERROR,
+        http_status: classification.status,
+        upstream_status: classification.upstreamStatus,
+        retryable: classification.retryable,
+        retry_after: classification.retryAfter,
+        correlation_id: correlationId,
+        auth_type: 'clerk',
+      });
+      console.error(`[yahoo-connect] Yahoo API error during discovery: ${apiResponse.status}`);
       return yahooApiFailureResponse(
         { status: apiResponse.status, headers: apiResponse.headers },
         corsHeaders
@@ -1954,6 +2106,14 @@ export async function handleYahooDiscover(
       }
     );
   } catch (error) {
+    logYahooSetupFailure(env, 'onboarding_failed', {
+      stage: 'league_discovery',
+      failure_kind: 'exception',
+      error_code: 'server_error',
+      http_status: 500,
+      correlation_id: correlationId,
+      auth_type: 'clerk',
+    });
     console.error('[yahoo-connect] Discovery error:', error);
     return new Response(
       JSON.stringify({

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -329,7 +329,7 @@ function logYahooRefreshDiagnostic(event: string, fields: YahooRefreshDiagnostic
 function logYahooSetupFailure(
   env: YahooConnectEnv,
   event: string,
-  fields: Omit<SetupSignalEvent, 'service' | 'component' | 'event' | 'platform'>,
+  fields: Omit<SetupSignalEvent, 'service' | 'component' | 'event' | 'outcome' | 'platform'>,
   request?: Request
 ): void {
   const url = request ? new URL(request.url) : undefined;
@@ -337,7 +337,6 @@ function logYahooSetupFailure(
     service: 'auth-worker',
     component: 'yahoo-connect',
     event,
-    outcome: 'failure',
     platform: 'yahoo',
     request_path: url?.pathname,
     method: request?.method,
@@ -346,6 +345,7 @@ function logYahooSetupFailure(
     cf_ray: request?.headers.get('CF-Ray') || undefined,
     environment: env.ENVIRONMENT || env.NODE_ENV,
     ...fields,
+    outcome: 'failure',
   } as SetupSignalEvent & Record<string, unknown>);
 }
 

--- a/workers/fantasy-mcp/src/index.ts
+++ b/workers/fantasy-mcp/src/index.ts
@@ -25,13 +25,12 @@ const app = new Hono<{ Bindings: Env }>();
 function logFantasySetupFailure(
   c: Context<{ Bindings: Env }>,
   event: string,
-  fields: Omit<SetupSignalEvent, 'service' | 'event'>
+  fields: Omit<SetupSignalEvent, 'service' | 'event' | 'outcome'>
 ): void {
   const url = new URL(c.req.raw.url);
   logSetupSignal({
     service: 'fantasy-mcp',
     event,
-    outcome: 'failure',
     request_path: url.pathname,
     method: c.req.method,
     has_auth_header: c.req.raw.headers.has('Authorization'),
@@ -39,6 +38,7 @@ function logFantasySetupFailure(
     cf_ray: c.req.raw.headers.get('CF-Ray') || undefined,
     environment: c.env.ENVIRONMENT || c.env.NODE_ENV,
     ...fields,
+    outcome: 'failure',
   } as SetupSignalEvent & Record<string, unknown>);
 }
 

--- a/workers/fantasy-mcp/src/index.ts
+++ b/workers/fantasy-mcp/src/index.ts
@@ -8,7 +8,9 @@ import {
   EVAL_TRACE_HEADER,
   getCorrelationId,
   getEvalContext,
+  logSetupSignal,
   withInternalServiceToken,
+  type SetupSignalEvent,
 } from '@flaim/worker-shared';
 import type { Env } from './types';
 import { createFantasyMcpServer } from './mcp/server';
@@ -19,6 +21,26 @@ import { buildMcpAuthErrorResponse } from './auth-response';
 import { USER_SESSION_WIDGET_HTML } from './widgets/user-session-widget';
 
 const app = new Hono<{ Bindings: Env }>();
+
+function logFantasySetupFailure(
+  c: Context<{ Bindings: Env }>,
+  event: string,
+  fields: Omit<SetupSignalEvent, 'service' | 'event'>
+): void {
+  const url = new URL(c.req.raw.url);
+  logSetupSignal({
+    service: 'fantasy-mcp',
+    event,
+    outcome: 'failure',
+    request_path: url.pathname,
+    method: c.req.method,
+    has_auth_header: c.req.raw.headers.has('Authorization'),
+    correlation_id: c.req.raw.headers.get(CORRELATION_ID_HEADER) || undefined,
+    cf_ray: c.req.raw.headers.get('CF-Ray') || undefined,
+    environment: c.env.ENVIRONMENT || c.env.NODE_ENV,
+    ...fields,
+  } as SetupSignalEvent & Record<string, unknown>);
+}
 
 // CORS middleware
 app.use('*', async (c, next) => {
@@ -161,6 +183,28 @@ function buildMethodNotAllowedResponse(allow: string): Response {
   );
 }
 
+async function isAuthenticatedMcpToolAttemptRequest(request: Request): Promise<boolean> {
+  if (request.method !== 'POST') {
+    return false;
+  }
+
+  const contentType = request.headers.get('Content-Type') || '';
+  if (!contentType.includes('application/json')) {
+    return false;
+  }
+
+  try {
+    const payload = await request.clone().json() as { method?: unknown; params?: unknown };
+    if (payload?.method !== 'tools/call') {
+      return false;
+    }
+    const params = payload.params;
+    return Boolean(params && typeof params === 'object' && 'name' in params);
+  } catch {
+    return false;
+  }
+}
+
 async function handleMcpRequest(c: Context<{ Bindings: Env }>): Promise<Response> {
   const correlationId = getCorrelationId(c.req.raw);
   const { evalRunId, evalTraceId } = getEvalContext(c.req.raw);
@@ -178,6 +222,16 @@ async function handleMcpRequest(c: Context<{ Bindings: Env }>): Promise<Response
   const authHeader = c.req.header('Authorization');
   const allowPublicHandshake = !authHeader && await isPublicMcpHandshakeRequest(c.req.raw);
   if (!authHeader && !allowPublicHandshake) {
+    if (await isAuthenticatedMcpToolAttemptRequest(c.req.raw)) {
+      logFantasySetupFailure(c, 'auth_trust_path_failed', {
+        component: 'mcp-auth',
+        stage: 'authorization_header',
+        failure_kind: 'auth',
+        error_code: 'missing_authorization',
+        http_status: 401,
+        correlation_id: correlationId,
+      });
+    }
     return buildMcpAuthErrorResponse(c.req.raw);
   }
 
@@ -199,6 +253,15 @@ async function handleMcpRequest(c: Context<{ Bindings: Env }>): Promise<Response
         })
       );
       if (!introspectRes.ok) {
+        logFantasySetupFailure(c, 'auth_trust_path_failed', {
+          component: 'mcp-auth',
+          stage: 'token_introspection',
+          failure_kind: 'auth',
+          error_code: 'introspection_failed',
+          http_status: 401,
+          upstream_status: introspectRes.status,
+          correlation_id: correlationId,
+        });
         return buildMcpAuthErrorResponse(c.req.raw);
       }
       const tokenInfo = await introspectRes.json() as {
@@ -208,10 +271,28 @@ async function handleMcpRequest(c: Context<{ Bindings: Env }>): Promise<Response
         authType?: 'clerk' | 'oauth' | 'eval-api-key' | 'demo-api-key';
       };
       if (!tokenInfo.valid) {
+        logFantasySetupFailure(c, 'auth_trust_path_failed', {
+          component: 'mcp-auth',
+          stage: 'token_introspection',
+          failure_kind: 'auth',
+          error_code: 'invalid_token',
+          http_status: 401,
+          auth_type: tokenInfo.authType,
+          correlation_id: correlationId,
+        });
         return buildMcpAuthErrorResponse(c.req.raw);
       }
       tokenScope = typeof tokenInfo.scope === 'string' ? tokenInfo.scope.trim() : undefined;
       if (!tokenScope) {
+        logFantasySetupFailure(c, 'auth_trust_path_failed', {
+          component: 'mcp-auth',
+          stage: 'scope_validation',
+          failure_kind: 'auth',
+          error_code: 'missing_scope',
+          http_status: 401,
+          auth_type: tokenInfo.authType,
+          correlation_id: correlationId,
+        });
         return buildMcpAuthErrorResponse(c.req.raw);
       }
 
@@ -256,6 +337,14 @@ async function handleMcpRequest(c: Context<{ Bindings: Env }>): Promise<Response
         }
       }
     } catch {
+      logFantasySetupFailure(c, 'auth_trust_path_failed', {
+        component: 'mcp-auth',
+        stage: 'token_introspection',
+        failure_kind: 'fetch_error',
+        error_code: 'introspection_exception',
+        http_status: 401,
+        correlation_id: correlationId,
+      });
       return buildMcpAuthErrorResponse(c.req.raw);
     }
   }

--- a/workers/fantasy-mcp/src/index.ts
+++ b/workers/fantasy-mcp/src/index.ts
@@ -193,7 +193,13 @@ async function isAuthenticatedMcpToolAttemptRequest(request: Request): Promise<b
     return false;
   }
 
+  const contentLength = Number(request.headers.get('Content-Length'));
+  if (Number.isFinite(contentLength) && contentLength > 65536) {
+    return false;
+  }
+
   try {
+    // Clone so this logging heuristic never consumes the MCP handler body.
     const payload = await request.clone().json() as { method?: unknown; params?: unknown };
     if (payload?.method !== 'tools/call') {
       return false;

--- a/workers/fantasy-mcp/src/mcp/tools.ts
+++ b/workers/fantasy-mcp/src/mcp/tools.ts
@@ -6,9 +6,11 @@ import { routeToClient, type RouteResult } from '../router';
 import {
   getDefaultSeasonYear,
   getSeasonLabel,
+  logSetupSignal,
   withCorrelationId,
   withEvalHeaders,
   withInternalServiceToken,
+  type SetupSignalEvent,
 } from '@flaim/worker-shared';
 import { logEvalEvent } from '../logging';
 
@@ -78,6 +80,36 @@ function getActiveThresholdYear(): number {
   return new Date().getFullYear() - 2;
 }
 
+function logMcpSetupFailure(
+  env: Env,
+  event: string,
+  fields: Omit<SetupSignalEvent, 'service' | 'event'>
+): void {
+  logSetupSignal({
+    service: 'fantasy-mcp',
+    event,
+    outcome: 'failure',
+    environment: env.ENVIRONMENT || env.NODE_ENV,
+    ...fields,
+  } as SetupSignalEvent & Record<string, unknown>);
+}
+
+function logSessionDiscoveryFailure(
+  env: Env,
+  platform: Platform,
+  stage: string,
+  correlationId: string | undefined,
+  fields: Omit<SetupSignalEvent, 'service' | 'component' | 'event' | 'platform' | 'stage' | 'correlation_id'>
+): void {
+  logMcpSetupFailure(env, 'session_discovery_failed', {
+    component: 'session-discovery',
+    platform,
+    stage,
+    correlation_id: correlationId,
+    ...fields,
+  });
+}
+
 // =============================================================================
 // HELPER: Fetch user leagues from auth-worker
 // =============================================================================
@@ -141,6 +173,11 @@ async function fetchUserLeagues(
     clearTimeout(timeoutId);
 
     if (!response.ok) {
+      logSessionDiscoveryFailure(env, 'espn', 'league_fetch', correlationId, {
+        failure_kind: response.status === 401 || response.status === 403 ? 'auth' : 'upstream',
+        error_code: response.status === 401 || response.status === 403 ? 'auth_worker_auth_failed' : 'auth_worker_fetch_failed',
+        http_status: response.status,
+      });
       console.error(`[fantasy-mcp] ${cid} leagues fetch failed: ${response.status}`);
       const text = await response.text().catch(() => 'no body');
       return {
@@ -159,11 +196,16 @@ async function fetchUserLeagues(
     return { leagues };
   } catch (error) {
     clearTimeout(timeoutId);
+    const isTimeout = (error as Error).name === 'AbortError';
+    logSessionDiscoveryFailure(env, 'espn', 'league_fetch', correlationId, {
+      failure_kind: isTimeout ? 'timeout' : 'fetch_error',
+      error_code: isTimeout ? 'auth_worker_timeout' : 'auth_worker_fetch_exception',
+    });
     console.error(`[fantasy-mcp] ${cid} failed to fetch leagues:`, error);
     return {
       leagues: [],
       error:
-        (error as Error).name === 'AbortError'
+        isTimeout
           ? 'Fetch timed out after 5 seconds'
           : `Fetch failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
     };
@@ -202,6 +244,11 @@ async function fetchYahooLeagues(
     clearTimeout(timeoutId);
 
     if (!response.ok) {
+      logSessionDiscoveryFailure(env, 'yahoo', 'league_fetch', correlationId, {
+        failure_kind: response.status === 401 || response.status === 403 ? 'auth' : 'upstream',
+        error_code: response.status === 401 || response.status === 403 ? 'auth_worker_auth_failed' : 'auth_worker_fetch_failed',
+        http_status: response.status,
+      });
       console.error(`[fantasy-mcp] ${cid} Yahoo leagues fetch failed: ${response.status}`);
       return { leagues: [], error: `Yahoo leagues fetch failed: ${response.status}` };
     }
@@ -232,6 +279,10 @@ async function fetchYahooLeagues(
   } catch (error) {
     clearTimeout(timeoutId);
     const isTimeout = (error as Error).name === 'AbortError';
+    logSessionDiscoveryFailure(env, 'yahoo', 'league_fetch', correlationId, {
+      failure_kind: isTimeout ? 'timeout' : 'fetch_error',
+      error_code: isTimeout ? 'auth_worker_timeout' : 'auth_worker_fetch_exception',
+    });
     const errorMsg = isTimeout ? 'Yahoo leagues fetch timed out' : `Yahoo leagues fetch failed: ${(error as Error).message}`;
     console.error(`[fantasy-mcp] ${cid} failed to fetch Yahoo leagues: ${errorMsg}`);
     return { leagues: [], error: errorMsg };
@@ -270,6 +321,11 @@ async function fetchSleeperLeagues(
     clearTimeout(timeoutId);
 
     if (!response.ok) {
+      logSessionDiscoveryFailure(env, 'sleeper', 'league_fetch', correlationId, {
+        failure_kind: response.status === 401 || response.status === 403 ? 'auth' : 'upstream',
+        error_code: response.status === 401 || response.status === 403 ? 'auth_worker_auth_failed' : 'auth_worker_fetch_failed',
+        http_status: response.status,
+      });
       console.error(`[fantasy-mcp] ${cid} Sleeper leagues fetch failed: ${response.status}`);
       return { leagues: [], error: `Sleeper leagues fetch failed: ${response.status}` };
     }
@@ -300,6 +356,10 @@ async function fetchSleeperLeagues(
   } catch (error) {
     clearTimeout(timeoutId);
     const isTimeout = (error as Error).name === 'AbortError';
+    logSessionDiscoveryFailure(env, 'sleeper', 'league_fetch', correlationId, {
+      failure_kind: isTimeout ? 'timeout' : 'fetch_error',
+      error_code: isTimeout ? 'auth_worker_timeout' : 'auth_worker_fetch_exception',
+    });
     const errorMsg = isTimeout ? 'Sleeper leagues fetch timed out' : `Sleeper leagues fetch failed: ${(error as Error).message}`;
     console.error(`[fantasy-mcp] ${cid} failed to fetch Sleeper leagues: ${errorMsg}`);
     return { leagues: [], error: errorMsg };
@@ -530,6 +590,18 @@ export function getUnifiedTools(): UnifiedTool[] {
 
           const hasLeagues = leagues.length > 0;
           const hasRawLeagues = allLeagues.length > 0;
+          if (!hasLeagues && hasRawLeagues) {
+            logMcpSetupFailure(env, 'session_discovery_failed', {
+              component: 'session-discovery',
+              stage: 'current_season_filter',
+              failure_kind: 'stale_data',
+              error_code: 'current_season_not_found',
+              correlation_id: correlationId,
+              league_count: allLeagues.length,
+              current_season_found: false,
+              past_seasons_found: true,
+            });
+          }
           const sportCounts = leagues.reduce(
             (acc, l) => {
               const sport = l.sport?.toLowerCase() || 'unknown';
@@ -824,7 +896,7 @@ export function getUnifiedTools(): UnifiedTool[] {
           season_year: args.season_year as number,
         };
 
-        return withToolLogging(correlationId, 'get_league_info', `${params.platform} ${params.sport} league=${params.league_id}`, async () => {
+        return withToolLogging(correlationId, 'get_league_info', `${params.platform} ${params.sport} league=provided`, async () => {
           const result = await routeToClient(env, 'get_league_info', params, authHeader, correlationId, evalRunId, evalTraceId);
           return routeResultToMcp(result);
         }, evalRunId, evalTraceId);
@@ -859,7 +931,7 @@ export function getUnifiedTools(): UnifiedTool[] {
           season_year: args.season_year as number,
         };
 
-        return withToolLogging(correlationId, 'get_standings', `${params.platform} ${params.sport} league=${params.league_id}`, async () => {
+        return withToolLogging(correlationId, 'get_standings', `${params.platform} ${params.sport} league=provided`, async () => {
           const result = await routeToClient(env, 'get_standings', params, authHeader, correlationId, evalRunId, evalTraceId);
           return routeResultToMcp(result);
         }, evalRunId, evalTraceId);
@@ -896,7 +968,7 @@ export function getUnifiedTools(): UnifiedTool[] {
           week: args.week as number | undefined,
         };
 
-        return withToolLogging(correlationId, 'get_matchups', `${params.platform} ${params.sport} league=${params.league_id} week=${params.week || 'current'}`, async () => {
+        return withToolLogging(correlationId, 'get_matchups', `${params.platform} ${params.sport} league=provided week=${params.week || 'current'}`, async () => {
           const result = await routeToClient(env, 'get_matchups', params, authHeader, correlationId, evalRunId, evalTraceId);
           return routeResultToMcp(result);
         }, evalRunId, evalTraceId);
@@ -935,7 +1007,7 @@ export function getUnifiedTools(): UnifiedTool[] {
           week: args.week as number | undefined,
         };
 
-        return withToolLogging(correlationId, 'get_roster', `${params.platform} ${params.sport} league=${params.league_id} team=${params.team_id || 'self'}`, async () => {
+        return withToolLogging(correlationId, 'get_roster', `${params.platform} ${params.sport} league=provided team=${params.team_id ? 'provided' : 'self'}`, async () => {
           const result = await routeToClient(env, 'get_roster', params, authHeader, correlationId, evalRunId, evalTraceId);
           return routeResultToMcp(result);
         }, evalRunId, evalTraceId);
@@ -980,7 +1052,7 @@ export function getUnifiedTools(): UnifiedTool[] {
           count: args.count as number | undefined,
         };
 
-        return withToolLogging(correlationId, 'get_free_agents', `${params.platform} ${params.sport} league=${params.league_id} pos=${params.position || 'ALL'}`, async () => {
+        return withToolLogging(correlationId, 'get_free_agents', `${params.platform} ${params.sport} league=provided pos=${params.position || 'ALL'}`, async () => {
           const result = await routeToClient(env, 'get_free_agents', params, authHeader, correlationId, evalRunId, evalTraceId);
           return routeResultToMcp(result);
         }, evalRunId, evalTraceId);
@@ -1030,7 +1102,7 @@ export function getUnifiedTools(): UnifiedTool[] {
           count: args.count as number | undefined,
         };
 
-        return withToolLogging(correlationId, 'get_players', `${params.platform} ${params.sport} q=${params.query} pos=${params.position || 'ALL'}`, async () => {
+        return withToolLogging(correlationId, 'get_players', `${params.platform} ${params.sport} q=provided pos=${params.position || 'ALL'}`, async () => {
           const result = await routeToClient(env, 'get_players', params, authHeader, correlationId, evalRunId, evalTraceId);
           return routeResultToMcp(result);
         }, evalRunId, evalTraceId);
@@ -1078,7 +1150,7 @@ export function getUnifiedTools(): UnifiedTool[] {
           count: Number.isFinite(requestedCount) ? Math.max(1, Math.min(100, requestedCount)) : 25,
         };
 
-        return withToolLogging(correlationId, 'get_transactions', `${params.platform} ${params.sport} league=${params.league_id} week=${params.week || 'recent'}`, async () => {
+        return withToolLogging(correlationId, 'get_transactions', `${params.platform} ${params.sport} league=provided week=${params.week || 'recent'}`, async () => {
           const result = await routeToClient(env, 'get_transactions', params, authHeader, correlationId, evalRunId, evalTraceId);
           return routeResultToMcp(result);
         }, evalRunId, evalTraceId);

--- a/workers/fantasy-mcp/src/mcp/tools.ts
+++ b/workers/fantasy-mcp/src/mcp/tools.ts
@@ -196,7 +196,7 @@ async function fetchUserLeagues(
     return { leagues };
   } catch (error) {
     clearTimeout(timeoutId);
-    const isTimeout = (error as Error).name === 'AbortError';
+    const isTimeout = error instanceof Error && error.name === 'AbortError';
     logSessionDiscoveryFailure(env, 'espn', 'league_fetch', correlationId, {
       failure_kind: isTimeout ? 'timeout' : 'fetch_error',
       error_code: isTimeout ? 'auth_worker_timeout' : 'auth_worker_fetch_exception',
@@ -278,7 +278,7 @@ async function fetchYahooLeagues(
     return { leagues };
   } catch (error) {
     clearTimeout(timeoutId);
-    const isTimeout = (error as Error).name === 'AbortError';
+    const isTimeout = error instanceof Error && error.name === 'AbortError';
     logSessionDiscoveryFailure(env, 'yahoo', 'league_fetch', correlationId, {
       failure_kind: isTimeout ? 'timeout' : 'fetch_error',
       error_code: isTimeout ? 'auth_worker_timeout' : 'auth_worker_fetch_exception',
@@ -355,7 +355,7 @@ async function fetchSleeperLeagues(
     return { leagues };
   } catch (error) {
     clearTimeout(timeoutId);
-    const isTimeout = (error as Error).name === 'AbortError';
+    const isTimeout = error instanceof Error && error.name === 'AbortError';
     logSessionDiscoveryFailure(env, 'sleeper', 'league_fetch', correlationId, {
       failure_kind: isTimeout ? 'timeout' : 'fetch_error',
       error_code: isTimeout ? 'auth_worker_timeout' : 'auth_worker_fetch_exception',

--- a/workers/fantasy-mcp/src/mcp/tools.ts
+++ b/workers/fantasy-mcp/src/mcp/tools.ts
@@ -83,14 +83,14 @@ function getActiveThresholdYear(): number {
 function logMcpSetupFailure(
   env: Env,
   event: string,
-  fields: Omit<SetupSignalEvent, 'service' | 'event'>
+  fields: Omit<SetupSignalEvent, 'service' | 'event' | 'outcome'>
 ): void {
   logSetupSignal({
     service: 'fantasy-mcp',
     event,
-    outcome: 'failure',
     environment: env.ENVIRONMENT || env.NODE_ENV,
     ...fields,
+    outcome: 'failure',
   } as SetupSignalEvent & Record<string, unknown>);
 }
 
@@ -99,7 +99,7 @@ function logSessionDiscoveryFailure(
   platform: Platform,
   stage: string,
   correlationId: string | undefined,
-  fields: Omit<SetupSignalEvent, 'service' | 'component' | 'event' | 'platform' | 'stage' | 'correlation_id'>
+  fields: Omit<SetupSignalEvent, 'service' | 'component' | 'event' | 'outcome' | 'platform' | 'stage' | 'correlation_id'>
 ): void {
   logMcpSetupFailure(env, 'session_discovery_failed', {
     component: 'session-discovery',

--- a/workers/fantasy-mcp/src/router.ts
+++ b/workers/fantasy-mcp/src/router.ts
@@ -1,10 +1,12 @@
 // workers/fantasy-mcp/src/router.ts
 import type { Env, Platform, ToolParams } from './types';
 import {
+  logSetupSignal,
   parseRetryAfterSeconds,
   withCorrelationId,
   withEvalHeaders,
   withInternalServiceToken,
+  type SetupSignalEvent,
 } from '@flaim/worker-shared';
 
 export interface RouteResult {
@@ -17,6 +19,26 @@ export interface RouteResult {
   retryable?: boolean;
   retry_after?: number;
   retry_after_source?: string;
+}
+
+function logPlatformToolFailure(
+  env: Env,
+  params: ToolParams,
+  correlationId: string | undefined,
+  fields: Omit<SetupSignalEvent, 'service' | 'component' | 'event' | 'platform' | 'sport' | 'season_year' | 'correlation_id'>
+): void {
+  logSetupSignal({
+    service: 'fantasy-mcp',
+    component: 'platform-router',
+    event: 'platform_tool_failed',
+    outcome: 'failure',
+    platform: params.platform,
+    sport: params.sport,
+    season_year: params.season_year,
+    correlation_id: correlationId,
+    environment: env.ENVIRONMENT || env.NODE_ENV,
+    ...fields,
+  } as SetupSignalEvent & Record<string, unknown>);
 }
 
 /**
@@ -36,6 +58,11 @@ export async function routeToClient(
   // Select the service binding based on platform
   const client = selectClient(env, platform);
   if (!client) {
+    logPlatformToolFailure(env, params, correlationId, {
+      stage: 'service_binding',
+      failure_kind: 'configuration',
+      error_code: 'PLATFORM_NOT_SUPPORTED',
+    });
     return {
       success: false,
       error: `Platform "${platform}" is not yet supported`,
@@ -82,6 +109,16 @@ export async function routeToClient(
         retry_after_source?: string;
       };
       const retryAfter = parseRetryAfterSeconds(response.headers.get('Retry-After')) ?? errorData.retry_after;
+      logPlatformToolFailure(env, params, correlationId, {
+        stage: 'platform_worker_response',
+        failure_kind: errorData.retryable ? 'retryable_upstream' : 'upstream',
+        error_code: errorData.code || 'PLATFORM_ERROR',
+        http_status: response.status,
+        upstream_status: errorData.upstream_status,
+        retryable: errorData.retryable,
+        retry_after: retryAfter,
+        retry_after_source: errorData.retry_after_source,
+      });
       return {
         success: false,
         error: errorData.error || `Platform worker returned ${response.status}`,
@@ -98,12 +135,22 @@ export async function routeToClient(
   } catch (error) {
     clearTimeout(timeoutId);
     if (error instanceof Error && error.name === 'AbortError') {
+      logPlatformToolFailure(env, params, correlationId, {
+        stage: 'platform_worker_fetch',
+        failure_kind: 'timeout',
+        error_code: 'ROUTING_ERROR',
+      });
       return {
         success: false,
         error: `Platform worker "${platform}" timed out after 25s`,
         code: 'ROUTING_ERROR',
       };
     }
+    logPlatformToolFailure(env, params, correlationId, {
+      stage: 'platform_worker_fetch',
+      failure_kind: 'fetch_error',
+      error_code: 'ROUTING_ERROR',
+    });
     return {
       success: false,
       error: error instanceof Error ? error.message : 'Failed to reach platform worker',

--- a/workers/fantasy-mcp/src/router.ts
+++ b/workers/fantasy-mcp/src/router.ts
@@ -25,19 +25,19 @@ function logPlatformToolFailure(
   env: Env,
   params: ToolParams,
   correlationId: string | undefined,
-  fields: Omit<SetupSignalEvent, 'service' | 'component' | 'event' | 'platform' | 'sport' | 'season_year' | 'correlation_id'>
+  fields: Omit<SetupSignalEvent, 'service' | 'component' | 'event' | 'outcome' | 'platform' | 'sport' | 'season_year' | 'correlation_id'>
 ): void {
   logSetupSignal({
     service: 'fantasy-mcp',
     component: 'platform-router',
     event: 'platform_tool_failed',
-    outcome: 'failure',
     platform: params.platform,
     sport: params.sport,
     season_year: params.season_year,
     correlation_id: correlationId,
     environment: env.ENVIRONMENT || env.NODE_ENV,
     ...fields,
+    outcome: 'failure',
   } as SetupSignalEvent & Record<string, unknown>);
 }
 

--- a/workers/fantasy-mcp/tests/integration/index.integration.test.ts
+++ b/workers/fantasy-mcp/tests/integration/index.integration.test.ts
@@ -112,6 +112,10 @@ function mockExecutionContext(): ExecutionContext {
   } as unknown as ExecutionContext;
 }
 
+function emittedSetupSignal(spy: { mock: { calls: unknown[][] } }): boolean {
+  return spy.mock.calls.some((call) => String(call[0]).includes('"schema_version":1'));
+}
+
 function buildEnv(authFetch: (request: Request) => Promise<Response>): Env {
   return {
     INTERNAL_SERVICE_TOKEN: 'internal-secret',
@@ -138,6 +142,33 @@ describe('fantasy-mcp gateway integration', () => {
 
     // Auth should not be called — 405 fires before auth/introspection
     expect(authFetch).not.toHaveBeenCalled();
+  });
+
+  it('does not emit setup signal for unauthenticated non-MCP POST probes', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const authFetch = vi.fn(async () => new Response('unexpected', { status: 500 }));
+    const env = buildEnv(authFetch);
+
+    try {
+      const response = await app.fetch(
+        new Request('https://api.flaim.app/mcp', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+          },
+          body: JSON.stringify({ probe: true }),
+        }),
+        env,
+        mockExecutionContext()
+      );
+
+      expect(response.status).toBe(401);
+      expect(authFetch).not.toHaveBeenCalled();
+      expect(emittedSetupSignal(logSpy)).toBe(false);
+    } finally {
+      logSpy.mockRestore();
+    }
   });
 
   it('serves oauth metadata aliases under /mcp/.well-known', async () => {

--- a/workers/fantasy-mcp/tests/integration/index.integration.test.ts
+++ b/workers/fantasy-mcp/tests/integration/index.integration.test.ts
@@ -171,6 +171,41 @@ describe('fantasy-mcp gateway integration', () => {
     }
   });
 
+  it('does not emit setup signal for oversized unauthenticated tool-call probes', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const authFetch = vi.fn(async () => new Response('unexpected', { status: 500 }));
+    const env = buildEnv(authFetch);
+    const body = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 'oversized-probe',
+      method: 'tools/call',
+      params: { name: 'get_user_session', arguments: {} },
+      padding: 'x'.repeat(65536),
+    });
+
+    try {
+      const response = await app.fetch(
+        new Request('https://api.flaim.app/mcp', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Content-Length': String(body.length),
+            Accept: 'application/json',
+          },
+          body,
+        }),
+        env,
+        mockExecutionContext()
+      );
+
+      expect(response.status).toBe(401);
+      expect(authFetch).not.toHaveBeenCalled();
+      expect(emittedSetupSignal(logSpy)).toBe(false);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
   it('serves oauth metadata aliases under /mcp/.well-known', async () => {
     const authFetch = vi.fn(async (request: Request) => {
       if (new URL(request.url).pathname === '/.well-known/oauth-authorization-server') {

--- a/workers/shared/src/__tests__/logging.test.ts
+++ b/workers/shared/src/__tests__/logging.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { logSetupSignal } from '../logging';
+
+describe('logSetupSignal', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('logs the setup signal schema with allowlisted fields', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    logSetupSignal({
+      service: 'auth-worker',
+      component: 'oauth-provider',
+      event: 'oauth_token_failed',
+      stage: 'token_exchange',
+      outcome: 'failure',
+      failure_kind: 'validation',
+      error_code: 'invalid_grant',
+      http_status: 400,
+      retryable: false,
+      auth_type: 'oauth',
+      has_auth_header: true,
+      correlation_id: 'cid_123',
+      cf_ray: 'ray_123',
+      request_path: '/auth/token',
+      method: 'POST',
+      duration_ms: 12,
+      environment: 'prod',
+    });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(String(spy.mock.calls[0][0])) as Record<string, unknown>;
+    expect(payload).toMatchObject({
+      schema_version: 1,
+      service: 'auth-worker',
+      component: 'oauth-provider',
+      event: 'oauth_token_failed',
+      stage: 'token_exchange',
+      outcome: 'failure',
+      error_code: 'invalid_grant',
+      http_status: 400,
+      retryable: false,
+      correlation_id: 'cid_123',
+      request_path: '/auth/token',
+      method: 'POST',
+      environment: 'prod',
+    });
+  });
+
+  it('drops forbidden or unknown input keys even when accidentally supplied', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    logSetupSignal({
+      service: 'auth-worker',
+      component: 'oauth-provider',
+      event: 'oauth_token_failed',
+      outcome: 'failure',
+      Authorization: 'Bearer clerk.jwt.secret',
+      authorization: 'Bearer oauth.access.token',
+      client_secret: 'client-secret',
+      code_verifier: 'verifier',
+      state: 'oauth-state',
+      refresh_token: 'refresh-token',
+      access_token: 'access-token',
+      email: 'person@example.com',
+      user_id: 'user_123',
+      redirect_uri: 'https://client.example/callback?code=secret',
+      league_id: 'raw-league-id',
+      team_id: 'raw-team-id',
+      request_body: { swid: '{00000000-0000-0000-0000-000000000000}' },
+    } as Parameters<typeof logSetupSignal>[0]);
+
+    const payloadText = String(spy.mock.calls[0][0]);
+    const payload = JSON.parse(payloadText) as Record<string, unknown>;
+    expect(payload.Authorization).toBeUndefined();
+    expect(payload.authorization).toBeUndefined();
+    expect(payload.client_secret).toBeUndefined();
+    expect(payload.refresh_token).toBeUndefined();
+    expect(payload.email).toBeUndefined();
+    expect(payload.user_id).toBeUndefined();
+    expect(payload.redirect_uri).toBeUndefined();
+    expect(payload.league_id).toBeUndefined();
+    expect(payload.team_id).toBeUndefined();
+    expect(payload.request_body).toBeUndefined();
+    expect(payloadText).not.toContain('clerk.jwt.secret');
+    expect(payloadText).not.toContain('refresh-token');
+    expect(payloadText).not.toContain('person@example.com');
+    expect(payloadText).not.toContain('raw-league-id');
+  });
+
+  it('does not throw if console logging fails', () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {
+      throw new Error('console unavailable');
+    });
+
+    expect(() => logSetupSignal({
+      service: 'auth-worker',
+      component: 'oauth-provider',
+      event: 'oauth_token_failed',
+      outcome: 'failure',
+    })).not.toThrow();
+  });
+});

--- a/workers/shared/src/index.ts
+++ b/workers/shared/src/index.ts
@@ -82,8 +82,8 @@ export { ErrorCode, YahooAuthWorkerErrorCode, extractErrorCode } from './errors.
 export type { ErrorCodeValue, YahooAuthWorkerErrorCodeValue, ExecuteResponse } from './errors.js';
 
 // Logging
-export { logEvalEvent } from './logging.js';
-export type { TraceLogEvent } from './logging.js';
+export { logEvalEvent, logSetupSignal } from './logging.js';
+export type { SetupSignalEvent, TraceLogEvent } from './logging.js';
 
 // Tracing utilities
 export {

--- a/workers/shared/src/logging.ts
+++ b/workers/shared/src/logging.ts
@@ -30,3 +30,124 @@ export function logEvalEvent(event: TraceLogEvent): void {
   }
   console.log(JSON.stringify(event));
 }
+
+export interface SetupSignalEvent {
+  schema_version?: 1;
+  service: string;
+  component: string;
+  event: string;
+  stage?: string;
+  outcome?: string;
+  failure_kind?: string;
+  error_code?: string;
+  http_status?: number;
+  upstream_status?: number;
+  retryable?: boolean;
+  retry_after?: number;
+  retry_after_source?: string;
+  platform?: string;
+  sport?: string;
+  season_year?: number;
+  league_count?: number;
+  current_season_found?: boolean;
+  past_seasons_found?: boolean;
+  auth_type?: string;
+  has_auth_header?: boolean;
+  correlation_id?: string;
+  cf_ray?: string;
+  request_path?: string;
+  method?: string;
+  duration_ms?: number;
+  environment?: string;
+}
+
+const SETUP_SIGNAL_SCHEMA_VERSION = 1;
+
+const SETUP_SIGNAL_STRING_FIELDS = [
+  'service',
+  'component',
+  'event',
+  'stage',
+  'outcome',
+  'failure_kind',
+  'error_code',
+  'retry_after_source',
+  'platform',
+  'sport',
+  'auth_type',
+  'correlation_id',
+  'cf_ray',
+  'request_path',
+  'method',
+  'environment',
+] as const;
+
+const SETUP_SIGNAL_NUMBER_FIELDS = [
+  'http_status',
+  'upstream_status',
+  'retry_after',
+  'season_year',
+  'league_count',
+  'duration_ms',
+] as const;
+
+const SETUP_SIGNAL_BOOLEAN_FIELDS = [
+  'retryable',
+  'current_season_found',
+  'past_seasons_found',
+  'has_auth_header',
+] as const;
+
+function boundedString(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  return value.length > 512 ? `${value.slice(0, 512)}...` : value;
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function booleanValue(value: unknown): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+/**
+ * Logs compact live-product setup/trust-path signals for production triage.
+ *
+ * This helper is intentionally allowlist-only and no-throw. Unknown keys are
+ * dropped so accidental secret-bearing fields never reach structured logs.
+ */
+export function logSetupSignal(event: SetupSignalEvent & Record<string, unknown>): void {
+  try {
+    const payload: Record<string, string | number | boolean> = {
+      schema_version: SETUP_SIGNAL_SCHEMA_VERSION,
+    };
+
+    for (const field of SETUP_SIGNAL_STRING_FIELDS) {
+      const value = boundedString(event[field]);
+      if (value !== undefined) {
+        payload[field] = value;
+      }
+    }
+
+    for (const field of SETUP_SIGNAL_NUMBER_FIELDS) {
+      const value = finiteNumber(event[field]);
+      if (value !== undefined) {
+        payload[field] = value;
+      }
+    }
+
+    for (const field of SETUP_SIGNAL_BOOLEAN_FIELDS) {
+      const value = booleanValue(event[field]);
+      if (value !== undefined) {
+        payload[field] = value;
+      }
+    }
+
+    console.log(JSON.stringify(payload));
+  } catch {
+    // Logging must never affect request behavior.
+  }
+}

--- a/workers/shared/src/logging.ts
+++ b/workers/shared/src/logging.ts
@@ -40,6 +40,10 @@ export interface SetupSignalEvent {
   outcome?: string;
   failure_kind?: string;
   error_code?: string;
+  /**
+   * Transport response status for the failed path; redirect-to-error outcomes
+   * can legitimately carry a 3xx status.
+   */
   http_status?: number;
   upstream_status?: number;
   retryable?: boolean;


### PR DESCRIPTION
## Summary
- add a shared no-throw setup-signal logger with allowlisted fields
- emit failure-only live-product signals for auth, onboarding, session discovery, and platform routing failures
- tighten noisy scanner/probe cases and keep credential/token/fantasy payload data out of logs

## Verification
- corepack pnpm --dir workers/shared run test
- corepack pnpm --dir workers/shared run type-check
- corepack pnpm --dir workers/auth-worker run test
- corepack pnpm --dir workers/auth-worker run type-check
- corepack pnpm --dir workers/fantasy-mcp run test
- corepack pnpm --dir workers/fantasy-mcp run type-check
- git diff --check

Linear: FLA-56