### PR TITLE
Fix Resend welcome template variables

### DIFF
--- a/web/lib/server/__tests__/resend-welcome-automation.test.ts
+++ b/web/lib/server/__tests__/resend-welcome-automation.test.ts
@@ -105,6 +105,27 @@ describe("sendWelcomeAutomationEvent", () => {
     }));
   });
 
+  it("removes markup from the greeting name before sending it to Resend", async () => {
+    const send = vi.fn(async () => ({
+      data: { event: WELCOME_AUTOMATION_EVENT_NAME, object: "event" },
+      error: null,
+    }));
+
+    await sendWelcomeAutomationEvent(
+      { ...clerkUser, first_name: " <b>Gerry</b>\n<svg/onload=alert(1)> " },
+      {
+        client: { events: { send } },
+        enabled: true,
+      },
+    );
+
+    expect(send).toHaveBeenCalledWith(expect.objectContaining({
+      payload: expect.objectContaining({
+        given_name: "Gerry",
+      }),
+    }));
+  });
+
   it("skips explicitly unverified Clerk primary emails", async () => {
     const send = vi.fn();
 

--- a/web/lib/server/resend-welcome-automation.ts
+++ b/web/lib/server/resend-welcome-automation.ts
@@ -10,6 +10,7 @@ import {
 } from "@/lib/server/resend-contact-sync";
 
 export const WELCOME_AUTOMATION_EVENT_NAME = "flaim.user_created";
+const WELCOME_GIVEN_NAME_MAX_LENGTH = 80;
 
 export interface WelcomeAutomationEventResult {
   email?: string;
@@ -46,6 +47,22 @@ function cleanString(value: string | null | undefined) {
   return cleaned || null;
 }
 
+function getWelcomeGivenName(value: string | null | undefined) {
+  const cleaned = cleanString(value);
+  if (!cleaned) return "there";
+
+  const safeName = cleaned
+    .replace(/<[^>]*>/g, "")
+    .replace(/[<>]/g, "")
+    .replace(/[\u0000-\u001f\u007f]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, WELCOME_GIVEN_NAME_MAX_LENGTH)
+    .trim();
+
+  return safeName || "there";
+}
+
 export function isWelcomeAutomationEnabled(options: SendWelcomeAutomationEventOptions = {}) {
   return options.enabled ?? process.env.RESEND_WELCOME_AUTOMATION_ENABLED === "true";
 }
@@ -73,10 +90,9 @@ export async function sendWelcomeAutomationEvent(
 
   const event = cleanString(options.eventName) ?? WELCOME_AUTOMATION_EVENT_NAME;
   const email = emailResult.email;
-  const firstName = cleanString(user.first_name);
   const payload: Record<string, string> = {
     clerk_user_id: user.id,
-    given_name: firstName ?? "there",
+    given_name: getWelcomeGivenName(user.first_name),
     source: "clerk.user_created",
   };
 

--- a/web/scripts/setup-resend-welcome-automation.mjs
+++ b/web/scripts/setup-resend-welcome-automation.mjs
@@ -90,7 +90,7 @@ function buildWelcomeHtml() {
               <td style="background:#ffffff;border:1px solid #e5e7eb;border-radius:8px;padding:28px;">
                 <p style="margin:0 0 10px 0;font-size:12px;line-height:18px;font-weight:700;color:#6b7280;">WELCOME</p>
                 <h1 style="margin:0 0 18px 0;font-size:24px;line-height:32px;font-weight:700;color:#030712;">Connect your first league</h1>
-                <p style="margin:0 0 16px 0;font-size:15px;line-height:24px;color:#030712;">Hi {{GIVEN_NAME}},</p>
+                <p style="margin:0 0 16px 0;font-size:15px;line-height:24px;color:#030712;">Hi {{{GIVEN_NAME}}},</p>
                 <p style="margin:0 0 16px 0;font-size:15px;line-height:24px;color:#030712;">Flaim lets you ask fantasy questions using your real league data, including your roster, standings, matchups, and transactions. Once connected, you can ask about waiver adds, trade ideas, roster decisions, and league trends.</p>
                 <div style="margin:8px 0 20px;padding:16px;border-radius:8px;border:1px solid #e5e7eb;background:#f9fafb;">
                   <p style="margin:0 0 12px 0;font-size:14px;line-height:22px;font-weight:700;color:#030712;">Finish your setup</p>
@@ -136,11 +136,10 @@ function buildWelcomeHtml() {
 }
 
 function buildWelcomeText() {
-  // Custom text values use double braces for escaping. Resend's built-in
-  // unsubscribe URL is inserted as a trusted URL, so it uses triple braces.
+  // Resend template variables use triple braces.
   return `Welcome to Flaim
 
-Hi {{GIVEN_NAME}},
+Hi {{{GIVEN_NAME}}},
 
 Flaim lets you ask fantasy questions using your real league data, including your roster, standings, matchups, and transactions. Once connected, you can ask about waiver adds, trade ideas, roster decisions, and league trends.
 


### PR DESCRIPTION
## Summary
- use Resend's required triple-brace variable syntax in the welcome automation template
- keep the template variable key aligned with the existing automation mapping to event.given_name
- strip markup/control characters from Clerk first names before sending them into the raw Resend template variable

## Verification
- corepack pnpm --dir web exec node --check scripts/setup-resend-welcome-automation.mjs
- corepack pnpm --dir web exec vitest run lib/server/__tests__/resend-welcome-automation.test.ts
- production setup rerun succeeded after this fix
- live Resend test event generated and delivered the welcome email