### PR TITLE
Route API robots.txt to fantasy worker

### DIFF
--- a/workers/fantasy-mcp/wrangler.jsonc
+++ b/workers/fantasy-mcp/wrangler.jsonc
@@ -31,6 +31,10 @@
           "zone_name": "flaim.app"
         },
         {
+          "pattern": "api.flaim.app/robots.txt",
+          "zone_name": "flaim.app"
+        },
+        {
           "pattern": "api.flaim.app/favicon.ico",
           "zone_name": "flaim.app"
         },


### PR DESCRIPTION
## Summary
- route api.flaim.app/robots.txt to the fantasy-mcp worker in production
- enables the robots handler added in the SEO crawler policy PR to respond on the API hostname

## Verification
- corepack pnpm --dir workers/fantasy-mcp run type-check
- corepack pnpm --dir workers/fantasy-mcp exec vitest run src/__tests__/types.test.ts