### PR TITLE
Manual league archive — ESPN + Sleeper (Phase 1a, FLA-124)

### DIFF
--- a/web/app/(site)/leagues/page.tsx
+++ b/web/app/(site)/leagues/page.tsx
@@ -265,6 +265,46 @@ function sleeperToUnified(
   });
 }
 
+// Resolve the recurring-league archive key for a group: ESPN keys on the stable
+// leagueId; Sleeper keys on its recurring id (falling back to the season league id).
+function getArchiveRecurringId(group: UnifiedLeagueGroup): string {
+  if (group.platform === 'sleeper') {
+    const withRecurring = group.seasons.find((s) => s.recurringLeagueId);
+    return withRecurring?.recurringLeagueId || group.leagueId;
+  }
+  return group.leagueId;
+}
+
+// Archive icon-button shared by the active and old league sections. ESPN + Sleeper
+// only — Yahoo is gated to Phase 1b (D9), so callers only render this for those two.
+function ArchiveButton({
+  group,
+  archivingLeagueKey,
+  onArchive,
+}: {
+  group: UnifiedLeagueGroup;
+  archivingLeagueKey: string | null;
+  onArchive: (group: UnifiedLeagueGroup) => void;
+}) {
+  const isArchiving = archivingLeagueKey === `${group.platform}:${getArchiveRecurringId(group)}`;
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      className="h-8 w-8 text-muted-foreground hover:text-foreground"
+      onClick={() => onArchive(group)}
+      disabled={isArchiving}
+      title="Archive (hide from your AI)"
+    >
+      {isArchiving ? (
+        <Loader2 className="h-4 w-4 animate-spin" />
+      ) : (
+        <Archive className="h-4 w-4" />
+      )}
+    </Button>
+  );
+}
+
 function LeaguesPageContent() {
   const { isLoaded, isSignedIn, userId } = useAuth();
   const {
@@ -1128,18 +1168,11 @@ function LeaguesPageContent() {
     }
   };
 
-  // Resolve the recurring-league archive key for a group: ESPN keys on the stable
-  // leagueId; Sleeper keys on its recurring id (falling back to the season league id).
-  const getArchiveRecurringId = (group: UnifiedLeagueGroup): string => {
-    if (group.platform === 'sleeper') {
-      const withRecurring = group.seasons.find((s) => s.recurringLeagueId);
-      return withRecurring?.recurringLeagueId || group.leagueId;
-    }
-    return group.leagueId;
-  };
-
-  // Archive a league group (ESPN + Sleeper only — Yahoo is gated to Phase 1b, D9).
-  const handleArchiveLeague = async (group: UnifiedLeagueGroup) => {
+  // Archive/unarchive a league group (ESPN + Sleeper only — Yahoo is gated to Phase 1b,
+  // D9). Both directions share the flow: resolve key → set loading → fetch → refresh the
+  // affected platform so the `archived` flag re-buckets the group. POST archives (hides
+  // from the AI); DELETE unarchives (restores to the visible/AI surfaces).
+  const performArchiveAction = async (group: UnifiedLeagueGroup, action: 'archive' | 'unarchive') => {
     const recurringLeagueId = getArchiveRecurringId(group);
     const actionKey = `${group.platform}:${recurringLeagueId}`;
     const shouldApply = createAccountGuard();
@@ -1149,47 +1182,13 @@ function LeaguesPageContent() {
 
     try {
       const res = await fetch('/api/leagues/archive', {
-        method: 'POST',
+        method: action === 'archive' ? 'POST' : 'DELETE',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ platform: group.platform, sport: group.sport, recurringLeagueId }),
       });
       if (!res.ok) {
         const data = await res.json() as { error?: string };
-        throw new Error(data.error || 'Failed to archive league');
-      }
-      // Refresh the affected platform so the `archived` flag re-buckets the group.
-      if (group.platform === 'espn') {
-        await loadLeagues({ showSpinner: false, shouldApply });
-      } else {
-        await loadSleeperLeagues(shouldApply);
-      }
-    } catch (err) {
-      if (shouldApply()) {
-        setLeagueError(err instanceof Error ? err.message : 'Failed to archive league');
-      }
-    } finally {
-      if (shouldApply()) setArchivingLeagueKey(null);
-    }
-  };
-
-  // Unarchive a league group, restoring it to the visible/AI surfaces.
-  const handleUnarchiveLeague = async (group: UnifiedLeagueGroup) => {
-    const recurringLeagueId = getArchiveRecurringId(group);
-    const actionKey = `${group.platform}:${recurringLeagueId}`;
-    const shouldApply = createAccountGuard();
-    setArchivingLeagueKey(actionKey);
-    setLeagueError(null);
-    setLeagueNotice(null);
-
-    try {
-      const res = await fetch('/api/leagues/archive', {
-        method: 'DELETE',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ platform: group.platform, sport: group.sport, recurringLeagueId }),
-      });
-      if (!res.ok) {
-        const data = await res.json() as { error?: string };
-        throw new Error(data.error || 'Failed to unarchive league');
+        throw new Error(data.error || `Failed to ${action} league`);
       }
       if (group.platform === 'espn') {
         await loadLeagues({ showSpinner: false, shouldApply });
@@ -1198,7 +1197,7 @@ function LeaguesPageContent() {
       }
     } catch (err) {
       if (shouldApply()) {
-        setLeagueError(err instanceof Error ? err.message : 'Failed to unarchive league');
+        setLeagueError(err instanceof Error ? err.message : `Failed to ${action} league`);
       }
     } finally {
       if (shouldApply()) setArchivingLeagueKey(null);
@@ -1593,25 +1592,13 @@ function LeaguesPageContent() {
                               </div>
                               <div className="flex items-center gap-1 shrink-0">
                                 {/* Archive: ESPN + Sleeper only (Yahoo gated to Phase 1b, D9). */}
-                                {(group.platform === 'espn' || group.platform === 'sleeper') && (() => {
-                                  const isArchiving = archivingLeagueKey === `${group.platform}:${getArchiveRecurringId(group)}`;
-                                  return (
-                                    <Button
-                                      variant="ghost"
-                                      size="icon"
-                                      className="h-8 w-8 text-muted-foreground hover:text-foreground"
-                                      onClick={() => handleArchiveLeague(group)}
-                                      disabled={isArchiving}
-                                      title="Archive (hide from your AI)"
-                                    >
-                                      {isArchiving ? (
-                                        <Loader2 className="h-4 w-4 animate-spin" />
-                                      ) : (
-                                        <Archive className="h-4 w-4" />
-                                      )}
-                                    </Button>
-                                  );
-                                })()}
+                                {(group.platform === 'espn' || group.platform === 'sleeper') && (
+                                  <ArchiveButton
+                                    group={group}
+                                    archivingLeagueKey={archivingLeagueKey}
+                                    onArchive={(g) => performArchiveAction(g, 'archive')}
+                                  />
+                                )}
                                 <Button
                                   variant="ghost"
                                   size="icon"
@@ -1721,25 +1708,13 @@ function LeaguesPageContent() {
                                     </div>
                                     <div className="flex items-center gap-1 shrink-0">
                                       {/* Archive: ESPN + Sleeper only (Yahoo gated to Phase 1b, D9). */}
-                                      {(group.platform === 'espn' || group.platform === 'sleeper') && (() => {
-                                        const isArchiving = archivingLeagueKey === `${group.platform}:${getArchiveRecurringId(group)}`;
-                                        return (
-                                          <Button
-                                            variant="ghost"
-                                            size="icon"
-                                            className="h-8 w-8 text-muted-foreground hover:text-foreground"
-                                            onClick={() => handleArchiveLeague(group)}
-                                            disabled={isArchiving}
-                                            title="Archive (hide from your AI)"
-                                          >
-                                            {isArchiving ? (
-                                              <Loader2 className="h-4 w-4 animate-spin" />
-                                            ) : (
-                                              <Archive className="h-4 w-4" />
-                                            )}
-                                          </Button>
-                                        );
-                                      })()}
+                                      {(group.platform === 'espn' || group.platform === 'sleeper') && (
+                                        <ArchiveButton
+                                          group={group}
+                                          archivingLeagueKey={archivingLeagueKey}
+                                          onArchive={(g) => performArchiveAction(g, 'archive')}
+                                        />
+                                      )}
                                       <Button
                                         variant="ghost"
                                         size="icon"
@@ -1824,7 +1799,7 @@ function LeaguesPageContent() {
                                         variant="ghost"
                                         size="icon"
                                         className="h-8 w-8 text-muted-foreground hover:text-foreground"
-                                        onClick={() => handleUnarchiveLeague(group)}
+                                        onClick={() => performArchiveAction(group, 'unarchive')}
                                         disabled={isArchiving}
                                         title="Unarchive (show to your AI again)"
                                       >

--- a/web/app/(site)/leagues/page.tsx
+++ b/web/app/(site)/leagues/page.tsx
@@ -276,7 +276,7 @@ function getArchiveRecurringId(group: UnifiedLeagueGroup): string {
 }
 
 // Archive icon-button shared by the active and old league sections. ESPN + Sleeper
-// only — Yahoo is gated to Phase 1b (D9), so callers only render this for those two.
+// only — Yahoo archive is deferred to a later phase, so callers only render this for those two.
 function ArchiveButton({
   group,
   archivingLeagueKey,
@@ -1168,8 +1168,8 @@ function LeaguesPageContent() {
     }
   };
 
-  // Archive/unarchive a league group (ESPN + Sleeper only — Yahoo is gated to Phase 1b,
-  // D9). Both directions share the flow: resolve key → set loading → fetch → refresh the
+  // Archive/unarchive a league group (ESPN + Sleeper only — Yahoo archive is deferred to a
+  // later phase). Both directions share the flow: resolve key → set loading → fetch → refresh the
   // affected platform so the `archived` flag re-buckets the group. POST archives (hides
   // from the AI); DELETE unarchives (restores to the visible/AI surfaces).
   const performArchiveAction = async (group: UnifiedLeagueGroup, action: 'archive' | 'unarchive') => {
@@ -1591,7 +1591,7 @@ function LeaguesPageContent() {
                                 </div>
                               </div>
                               <div className="flex items-center gap-1 shrink-0">
-                                {/* Archive: ESPN + Sleeper only (Yahoo gated to Phase 1b, D9). */}
+                                {/* Archive: ESPN + Sleeper only (Yahoo deferred to a later phase). */}
                                 {(group.platform === 'espn' || group.platform === 'sleeper') && (
                                   <ArchiveButton
                                     group={group}
@@ -1707,7 +1707,7 @@ function LeaguesPageContent() {
                                       </div>
                                     </div>
                                     <div className="flex items-center gap-1 shrink-0">
-                                      {/* Archive: ESPN + Sleeper only (Yahoo gated to Phase 1b, D9). */}
+                                      {/* Archive: ESPN + Sleeper only (Yahoo deferred to a later phase). */}
                                       {(group.platform === 'espn' || group.platform === 'sleeper') && (
                                         <ArchiveButton
                                           group={group}

--- a/web/app/(site)/leagues/page.tsx
+++ b/web/app/(site)/leagues/page.tsx
@@ -18,6 +18,8 @@ import {
   BookOpen,
   Info,
   RefreshCw,
+  Archive,
+  ArchiveRestore,
 } from 'lucide-react';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { useEspnCredentials } from '@/lib/use-espn-credentials';
@@ -47,6 +49,7 @@ interface League {
   teamId?: string;
   teamName?: string;
   seasonYear?: number;
+  archived?: boolean;
 }
 
 interface YahooLeague {
@@ -68,6 +71,7 @@ interface SleeperLeague {
   leagueName: string;
   rosterId: number | null;
   recurringLeagueId?: string;
+  archived?: boolean;
 }
 
 interface LeagueDefault {
@@ -103,6 +107,8 @@ interface UnifiedLeague {
   // Sleeper-specific
   sleeperId?: string;    // DB UUID for deletion (Sleeper only)
   recurringLeagueId?: string;
+  // Archive state (annotated by the public /leagues* endpoints, ESPN + Sleeper)
+  archived?: boolean;
 }
 
 interface UnifiedLeagueGroup {
@@ -113,6 +119,7 @@ interface UnifiedLeagueGroup {
   leagueName: string;
   teamId?: string;
   seasons: UnifiedLeague[];
+  archived: boolean;     // true when this recurring league is archived (hidden from the AI)
 }
 
 const SPORT_OPTIONS: { value: Sport; label: string; emoji: string }[] = [
@@ -203,6 +210,7 @@ function espnToUnified(leagues: League[], preferences: UserPreferencesState): Un
       isDefault,
       leagueId: l.leagueId,
       teamId: l.teamId,
+      archived: l.archived ?? false,
     };
   });
 }
@@ -252,6 +260,7 @@ function sleeperToUnified(
       isDefault,
       sleeperId: sl.id,
       recurringLeagueId: sl.recurringLeagueId,
+      archived: sl.archived ?? false,
     };
   });
 }
@@ -316,6 +325,9 @@ function LeaguesPageContent() {
   const displayPreferences = isAccountStateCurrent ? preferences : EMPTY_USER_PREFERENCES;
   const defaultSport = displayPreferences.defaultSport;
   const [showOldLeagues, setShowOldLeagues] = useState(false);
+  const [showArchivedLeagues, setShowArchivedLeagues] = useState(false);
+  // Keyed by `${platform}:${recurringLeagueId}` while an archive/unarchive request is in flight.
+  const [archivingLeagueKey, setArchivingLeagueKey] = useState<string | null>(null);
 
   const clearYahooConnectionState = useCallback(() => {
     setIsYahooConnected(false);
@@ -399,9 +411,13 @@ function LeaguesPageContent() {
           leagueName: league.leagueName,
           teamId: league.teamId,
           seasons: [],
+          archived: false,
         });
       }
-      grouped.get(groupKey)!.seasons.push(league);
+      const group = grouped.get(groupKey)!;
+      group.seasons.push(league);
+      // Seasons of a recurring league share an archive state; any flagged season archives the group.
+      if (league.archived) group.archived = true;
     }
 
     // Sort seasons desc within each group
@@ -412,17 +428,24 @@ function LeaguesPageContent() {
       group.teamId = group.seasons.find((s) => s.teamId)?.teamId;
     }
 
-    // Separate active vs old leagues
+    // Separate archived, then active vs old. Archived leagues are pulled out of
+    // both the active and old buckets into their own section (hidden from the AI).
     const activeLeagues: UnifiedLeagueGroup[] = [];
     const oldLeagueGroups: UnifiedLeagueGroup[] = [];
+    const archivedLeagueGroups: UnifiedLeagueGroup[] = [];
 
     for (const group of grouped.values()) {
-      if (isOldLeague(group.sport as Sport, group.seasons)) {
+      if (group.archived) {
+        archivedLeagueGroups.push(group);
+      } else if (isOldLeague(group.sport as Sport, group.seasons)) {
         oldLeagueGroups.push(group);
       } else {
         activeLeagues.push(group);
       }
     }
+
+    // Sort archived by most recent season desc for a stable list order.
+    archivedLeagueGroups.sort((a, b) => (b.seasons[0]?.seasonYear ?? 0) - (a.seasons[0]?.seasonYear ?? 0));
 
     // Group active leagues by sport
     const bySportActive = new Map<string, UnifiedLeagueGroup[]>();
@@ -448,7 +471,7 @@ function LeaguesPageContent() {
       return sportOrder.indexOf(a[0]) - sportOrder.indexOf(b[0]);
     });
 
-    return { active: sortedActive, old: oldLeagueGroups };
+    return { active: sortedActive, old: oldLeagueGroups, archived: archivedLeagueGroups };
   }, [displayLeagues, displayYahooLeagues, displaySleeperLeagues, displayPreferences]);
 
   const loadLeagues = useCallback(async (options?: { showSpinner?: boolean; shouldApply?: () => boolean }) => {
@@ -1105,12 +1128,92 @@ function LeaguesPageContent() {
     }
   };
 
+  // Resolve the recurring-league archive key for a group: ESPN keys on the stable
+  // leagueId; Sleeper keys on its recurring id (falling back to the season league id).
+  const getArchiveRecurringId = (group: UnifiedLeagueGroup): string => {
+    if (group.platform === 'sleeper') {
+      const withRecurring = group.seasons.find((s) => s.recurringLeagueId);
+      return withRecurring?.recurringLeagueId || group.leagueId;
+    }
+    return group.leagueId;
+  };
+
+  // Archive a league group (ESPN + Sleeper only — Yahoo is gated to Phase 1b, D9).
+  const handleArchiveLeague = async (group: UnifiedLeagueGroup) => {
+    const recurringLeagueId = getArchiveRecurringId(group);
+    const actionKey = `${group.platform}:${recurringLeagueId}`;
+    const shouldApply = createAccountGuard();
+    setArchivingLeagueKey(actionKey);
+    setLeagueError(null);
+    setLeagueNotice(null);
+
+    try {
+      const res = await fetch('/api/leagues/archive', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ platform: group.platform, sport: group.sport, recurringLeagueId }),
+      });
+      if (!res.ok) {
+        const data = await res.json() as { error?: string };
+        throw new Error(data.error || 'Failed to archive league');
+      }
+      // Refresh the affected platform so the `archived` flag re-buckets the group.
+      if (group.platform === 'espn') {
+        await loadLeagues({ showSpinner: false, shouldApply });
+      } else {
+        await loadSleeperLeagues(shouldApply);
+      }
+    } catch (err) {
+      if (shouldApply()) {
+        setLeagueError(err instanceof Error ? err.message : 'Failed to archive league');
+      }
+    } finally {
+      if (shouldApply()) setArchivingLeagueKey(null);
+    }
+  };
+
+  // Unarchive a league group, restoring it to the visible/AI surfaces.
+  const handleUnarchiveLeague = async (group: UnifiedLeagueGroup) => {
+    const recurringLeagueId = getArchiveRecurringId(group);
+    const actionKey = `${group.platform}:${recurringLeagueId}`;
+    const shouldApply = createAccountGuard();
+    setArchivingLeagueKey(actionKey);
+    setLeagueError(null);
+    setLeagueNotice(null);
+
+    try {
+      const res = await fetch('/api/leagues/archive', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ platform: group.platform, sport: group.sport, recurringLeagueId }),
+      });
+      if (!res.ok) {
+        const data = await res.json() as { error?: string };
+        throw new Error(data.error || 'Failed to unarchive league');
+      }
+      if (group.platform === 'espn') {
+        await loadLeagues({ showSpinner: false, shouldApply });
+      } else {
+        await loadSleeperLeagues(shouldApply);
+      }
+    } catch (err) {
+      if (shouldApply()) {
+        setLeagueError(err instanceof Error ? err.message : 'Failed to unarchive league');
+      }
+    } finally {
+      if (shouldApply()) setArchivingLeagueKey(null);
+    }
+  };
+
   const getSportEmoji = (sport: string) => {
     const option = SPORT_OPTIONS.find((s) => s.value === sport);
     return option?.emoji || '\u{1F3C6}';
   };
 
-  const hasAnyLeagueGroups = leaguesBySport.active.length > 0 || leaguesBySport.old.length > 0;
+  const hasAnyLeagueGroups =
+    leaguesBySport.active.length > 0 ||
+    leaguesBySport.old.length > 0 ||
+    leaguesBySport.archived.length > 0;
   const displayLeagueError = isAccountStateCurrent ? leagueError : null;
   const displayLeagueNotice = isAccountStateCurrent ? leagueNotice : null;
   const displayEspnConnected = isAccountStateCurrent && hasCredentials;
@@ -1372,6 +1475,11 @@ function LeaguesPageContent() {
               </div>
             ) : (
               <div className="space-y-6">
+                {leaguesBySport.active.length > 0 && (
+                  <p className="text-sm text-muted-foreground">
+                    Used in your AI conversations.
+                  </p>
+                )}
                 {leaguesBySport.active.map(([sport, sportLeagues]) => (
                   <div key={sport} className="space-y-3">
                     {/* Sport Header with Default Star */}
@@ -1484,6 +1592,26 @@ function LeaguesPageContent() {
                                 </div>
                               </div>
                               <div className="flex items-center gap-1 shrink-0">
+                                {/* Archive: ESPN + Sleeper only (Yahoo gated to Phase 1b, D9). */}
+                                {(group.platform === 'espn' || group.platform === 'sleeper') && (() => {
+                                  const isArchiving = archivingLeagueKey === `${group.platform}:${getArchiveRecurringId(group)}`;
+                                  return (
+                                    <Button
+                                      variant="ghost"
+                                      size="icon"
+                                      className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                                      onClick={() => handleArchiveLeague(group)}
+                                      disabled={isArchiving}
+                                      title="Archive (hide from your AI)"
+                                    >
+                                      {isArchiving ? (
+                                        <Loader2 className="h-4 w-4 animate-spin" />
+                                      ) : (
+                                        <Archive className="h-4 w-4" />
+                                      )}
+                                    </Button>
+                                  );
+                                })()}
                                 <Button
                                   variant="ghost"
                                   size="icon"
@@ -1591,36 +1719,142 @@ function LeaguesPageContent() {
                                         {` • Last active: ${mostRecentYear}`}
                                       </div>
                                     </div>
-                                    <Button
-                                      variant="ghost"
-                                      size="icon"
-                                      className="h-8 w-8 text-muted-foreground hover:text-destructive shrink-0"
-                                      onClick={() => {
-                                        if (group.platform === 'espn') {
-                                          handleDeleteLeague(group.leagueId, group.sport);
-                                        } else if (group.platform === 'sleeper') {
-                                          handleDeleteSleeperLeagueGroup(group.seasons, group.leagueId);
-                                        } else {
-                                          handleDeleteYahooLeagueGroup(group.seasons);
+                                    <div className="flex items-center gap-1 shrink-0">
+                                      {/* Archive: ESPN + Sleeper only (Yahoo gated to Phase 1b, D9). */}
+                                      {(group.platform === 'espn' || group.platform === 'sleeper') && (() => {
+                                        const isArchiving = archivingLeagueKey === `${group.platform}:${getArchiveRecurringId(group)}`;
+                                        return (
+                                          <Button
+                                            variant="ghost"
+                                            size="icon"
+                                            className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                                            onClick={() => handleArchiveLeague(group)}
+                                            disabled={isArchiving}
+                                            title="Archive (hide from your AI)"
+                                          >
+                                            {isArchiving ? (
+                                              <Loader2 className="h-4 w-4 animate-spin" />
+                                            ) : (
+                                              <Archive className="h-4 w-4" />
+                                            )}
+                                          </Button>
+                                        );
+                                      })()}
+                                      <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        className="h-8 w-8 text-muted-foreground hover:text-destructive"
+                                        onClick={() => {
+                                          if (group.platform === 'espn') {
+                                            handleDeleteLeague(group.leagueId, group.sport);
+                                          } else if (group.platform === 'sleeper') {
+                                            handleDeleteSleeperLeagueGroup(group.seasons, group.leagueId);
+                                          } else {
+                                            handleDeleteYahooLeagueGroup(group.seasons);
+                                          }
+                                        }}
+                                        disabled={
+                                          isDeleting
+                                          || (group.platform === 'sleeper' && deletingSleeperKey === `sleeper:${group.leagueId}`)
+                                          || (group.platform === 'yahoo' && deletingLeagueKey === `yahoo:${group.seasons[0]?.yahooId}`)
                                         }
-                                      }}
-                                      disabled={
-                                        isDeleting
-                                        || (group.platform === 'sleeper' && deletingSleeperKey === `sleeper:${group.leagueId}`)
-                                        || (group.platform === 'yahoo' && deletingLeagueKey === `yahoo:${group.seasons[0]?.yahooId}`)
-                                      }
-                                      title="Delete league"
-                                    >
-                                      {(
-                                        isDeleting
-                                        || (group.platform === 'sleeper' && deletingSleeperKey === `sleeper:${group.leagueId}`)
-                                        || (group.platform === 'yahoo' && deletingLeagueKey === `yahoo:${group.seasons[0]?.yahooId}`)
-                                      ) ? (
-                                        <Loader2 className="h-4 w-4 animate-spin" />
-                                      ) : (
-                                        <Trash2 className="h-4 w-4" />
-                                      )}
-                                    </Button>
+                                        title="Delete league"
+                                      >
+                                        {(
+                                          isDeleting
+                                          || (group.platform === 'sleeper' && deletingSleeperKey === `sleeper:${group.leagueId}`)
+                                          || (group.platform === 'yahoo' && deletingLeagueKey === `yahoo:${group.seasons[0]?.yahooId}`)
+                                        ) ? (
+                                          <Loader2 className="h-4 w-4 animate-spin" />
+                                        ) : (
+                                          <Trash2 className="h-4 w-4" />
+                                        )}
+                                      </Button>
+                                    </div>
+                                  </div>
+                                </div>
+                              );
+                            })}
+                          </div>
+                        )}
+                      </div>
+                    )}
+
+                    {/* Archived Leagues Section */}
+                    {leaguesBySport.archived.length > 0 && (
+                      <div className="space-y-3 pt-3 border-t">
+                        <button
+                          type="button"
+                          className="flex items-center gap-2 font-medium text-muted-foreground hover:text-foreground transition-colors w-full"
+                          onClick={() => setShowArchivedLeagues(!showArchivedLeagues)}
+                        >
+                          <Archive className="h-4 w-4" />
+                          <span className="text-base">Archived ({leaguesBySport.archived.length})</span>
+                          <ChevronDown className={`h-4 w-4 ml-auto transition-transform ${showArchivedLeagues ? 'rotate-180' : ''}`} />
+                        </button>
+
+                        {showArchivedLeagues && (
+                          <div className="space-y-3">
+                            <p className="text-sm text-muted-foreground">
+                              Hidden from your AI entirely. Unarchive to bring it back.
+                            </p>
+                            {leaguesBySport.archived.map((group) => {
+                              const baseKey = `${group.leagueId}-${group.sport}`;
+                              const isDeleting =
+                                (group.platform === 'espn' && deletingLeagueKey === baseKey)
+                                || (group.platform === 'sleeper' && deletingSleeperKey === `sleeper:${group.leagueId}`);
+                              const isArchiving = archivingLeagueKey === `${group.platform}:${getArchiveRecurringId(group)}`;
+                              const mostRecentYear = group.seasons[0]?.seasonYear;
+
+                              return (
+                                <div key={group.key} className="rounded-lg border bg-muted/30">
+                                  {/* Archived League Header */}
+                                  <div className="flex items-center justify-between gap-3 p-3">
+                                    <div className="min-w-0">
+                                      <div className="font-medium break-words text-muted-foreground">
+                                        {group.leagueName || `League ${group.leagueId}`}
+                                      </div>
+                                      <div className="text-xs text-muted-foreground/70 break-words">
+                                        {group.platform === 'espn' ? 'ESPN' : 'Sleeper'}
+                                        {mostRecentYear ? ` • Last active: ${mostRecentYear}` : ''}
+                                      </div>
+                                    </div>
+                                    <div className="flex items-center gap-1 shrink-0">
+                                      <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                                        onClick={() => handleUnarchiveLeague(group)}
+                                        disabled={isArchiving}
+                                        title="Unarchive (show to your AI again)"
+                                      >
+                                        {isArchiving ? (
+                                          <Loader2 className="h-4 w-4 animate-spin" />
+                                        ) : (
+                                          <ArchiveRestore className="h-4 w-4" />
+                                        )}
+                                      </Button>
+                                      <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        className="h-8 w-8 text-muted-foreground hover:text-destructive"
+                                        onClick={() => {
+                                          if (group.platform === 'espn') {
+                                            handleDeleteLeague(group.leagueId, group.sport);
+                                          } else {
+                                            handleDeleteSleeperLeagueGroup(group.seasons, group.leagueId);
+                                          }
+                                        }}
+                                        disabled={isDeleting}
+                                        title="Delete league"
+                                      >
+                                        {isDeleting ? (
+                                          <Loader2 className="h-4 w-4 animate-spin" />
+                                        ) : (
+                                          <Trash2 className="h-4 w-4" />
+                                        )}
+                                      </Button>
+                                    </div>
                                   </div>
                                 </div>
                               );

--- a/web/app/api/leagues/archive/route.ts
+++ b/web/app/api/leagues/archive/route.ts
@@ -20,6 +20,10 @@ interface ArchiveRequestBody {
   recurringLeagueId?: string;
 }
 
+// Intentional aggregate archived-leagues feed across all platforms. The leagues page
+// currently derives `archived` from the per-platform endpoints, so this is not on the
+// hot path — it's kept for future use (e.g. a dedicated archived-leagues view) and is
+// not dead code.
 export async function GET() {
   try {
     const { userId, getToken } = await auth();

--- a/web/app/api/leagues/archive/route.ts
+++ b/web/app/api/leagues/archive/route.ts
@@ -1,0 +1,148 @@
+/**
+ * League Archive API Route
+ * ---------------------------------------------------------------------------
+ * Proxies the manual league archive endpoints to the Auth-Worker (FLA-124).
+ *
+ * - GET    → list the user's archived leagues (feeds the Archived UI section)
+ * - POST   → archive a league (hide it from the AI; survives re-sync)
+ * - DELETE → unarchive a league (restore it to the visible/AI surfaces)
+ *
+ * Body for POST/DELETE: { platform, sport, recurringLeagueId }. ESPN + Sleeper
+ * only — Yahoo archive is gated to Phase 1b (D9), enforced by the Auth-Worker.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@clerk/nextjs/server';
+
+interface ArchiveRequestBody {
+  platform?: string;
+  sport?: string;
+  recurringLeagueId?: string;
+}
+
+export async function GET() {
+  try {
+    const { userId, getToken } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+    }
+
+    const authWorkerUrl = process.env.NEXT_PUBLIC_AUTH_WORKER_URL;
+    if (!authWorkerUrl) {
+      return NextResponse.json({ error: 'NEXT_PUBLIC_AUTH_WORKER_URL is not configured' }, { status: 500 });
+    }
+
+    const bearer = await getToken?.();
+    if (!bearer) {
+      return NextResponse.json({ error: 'Authentication token unavailable' }, { status: 401 });
+    }
+
+    const workerResponse = await fetch(`${authWorkerUrl}/leagues/archive`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${bearer}`,
+      },
+    });
+
+    if (workerResponse.status === 404) {
+      return NextResponse.json({ leagues: [] }, { status: 200 });
+    }
+
+    const data = await workerResponse.json().catch(() => ({ error: 'Unknown error' })) as Record<string, unknown>;
+    return NextResponse.json(data, { status: workerResponse.status });
+  } catch (error) {
+    console.error('Archived leagues GET API error:', error);
+    return NextResponse.json({ error: 'Failed to fetch archived leagues' }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const { userId, getToken } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+    }
+
+    const body = await request.json() as ArchiveRequestBody;
+    if (!body.platform || !body.sport || !body.recurringLeagueId) {
+      return NextResponse.json({
+        error: 'platform, sport, and recurringLeagueId are required',
+      }, { status: 400 });
+    }
+
+    const authWorkerUrl = process.env.NEXT_PUBLIC_AUTH_WORKER_URL;
+    if (!authWorkerUrl) {
+      return NextResponse.json({ error: 'NEXT_PUBLIC_AUTH_WORKER_URL is not configured' }, { status: 500 });
+    }
+
+    const bearer = await getToken?.();
+    if (!bearer) {
+      return NextResponse.json({ error: 'Authentication token unavailable' }, { status: 401 });
+    }
+
+    const workerResponse = await fetch(`${authWorkerUrl}/leagues/archive`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${bearer}`,
+      },
+      body: JSON.stringify({
+        platform: body.platform,
+        sport: body.sport,
+        recurringLeagueId: body.recurringLeagueId,
+      }),
+    });
+
+    const data = await workerResponse.json().catch(() => ({ error: 'Unknown error' })) as Record<string, unknown>;
+    return NextResponse.json(data, { status: workerResponse.status });
+  } catch (error) {
+    console.error('Archive league POST API error:', error);
+    return NextResponse.json({ error: 'Failed to archive league' }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  try {
+    const { userId, getToken } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+    }
+
+    const body = await request.json() as ArchiveRequestBody;
+    if (!body.platform || !body.sport || !body.recurringLeagueId) {
+      return NextResponse.json({
+        error: 'platform, sport, and recurringLeagueId are required',
+      }, { status: 400 });
+    }
+
+    const authWorkerUrl = process.env.NEXT_PUBLIC_AUTH_WORKER_URL;
+    if (!authWorkerUrl) {
+      return NextResponse.json({ error: 'NEXT_PUBLIC_AUTH_WORKER_URL is not configured' }, { status: 500 });
+    }
+
+    const bearer = await getToken?.();
+    if (!bearer) {
+      return NextResponse.json({ error: 'Authentication token unavailable' }, { status: 401 });
+    }
+
+    const workerResponse = await fetch(`${authWorkerUrl}/leagues/archive`, {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${bearer}`,
+      },
+      body: JSON.stringify({
+        platform: body.platform,
+        sport: body.sport,
+        recurringLeagueId: body.recurringLeagueId,
+      }),
+    });
+
+    const data = await workerResponse.json().catch(() => ({ error: 'Unknown error' })) as Record<string, unknown>;
+    return NextResponse.json(data, { status: workerResponse.status });
+  } catch (error) {
+    console.error('Unarchive league DELETE API error:', error);
+    return NextResponse.json({ error: 'Failed to unarchive league' }, { status: 500 });
+  }
+}

--- a/web/app/api/leagues/archive/route.ts
+++ b/web/app/api/leagues/archive/route.ts
@@ -34,7 +34,7 @@ async function getArchiveAuthContext(): Promise<{ bearer: string; workerUrl: str
     return NextResponse.json({ error: 'NEXT_PUBLIC_AUTH_WORKER_URL is not configured' }, { status: 500 });
   }
 
-  const bearer = await getToken?.();
+  const bearer = await getToken();
   if (!bearer) {
     return NextResponse.json({ error: 'Authentication token unavailable' }, { status: 401 });
   }

--- a/web/app/api/leagues/archive/route.ts
+++ b/web/app/api/leagues/archive/route.ts
@@ -8,7 +8,7 @@
  * - DELETE → unarchive a league (restore it to the visible/AI surfaces)
  *
  * Body for POST/DELETE: { platform, sport, recurringLeagueId }. ESPN + Sleeper
- * only — Yahoo archive is gated to Phase 1b (D9), enforced by the Auth-Worker.
+ * only — Yahoo archive is deferred to a later phase, enforced by the Auth-Worker.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
@@ -20,28 +20,41 @@ interface ArchiveRequestBody {
   recurringLeagueId?: string;
 }
 
+// Shared auth/url/token resolution for the GET/POST/DELETE handlers. Returns the
+// bearer token + worker URL, or a NextResponse to return early when something is
+// missing (callers check via `instanceof NextResponse`).
+async function getArchiveAuthContext(): Promise<{ bearer: string; workerUrl: string } | NextResponse> {
+  const { userId, getToken } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+  }
+
+  const workerUrl = process.env.NEXT_PUBLIC_AUTH_WORKER_URL;
+  if (!workerUrl) {
+    return NextResponse.json({ error: 'NEXT_PUBLIC_AUTH_WORKER_URL is not configured' }, { status: 500 });
+  }
+
+  const bearer = await getToken?.();
+  if (!bearer) {
+    return NextResponse.json({ error: 'Authentication token unavailable' }, { status: 401 });
+  }
+
+  return { bearer, workerUrl };
+}
+
 // Intentional aggregate archived-leagues feed across all platforms. The leagues page
 // currently derives `archived` from the per-platform endpoints, so this is not on the
 // hot path — it's kept for future use (e.g. a dedicated archived-leagues view) and is
 // not dead code.
 export async function GET() {
   try {
-    const { userId, getToken } = await auth();
-    if (!userId) {
-      return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+    const authContext = await getArchiveAuthContext();
+    if (authContext instanceof NextResponse) {
+      return authContext;
     }
+    const { bearer, workerUrl } = authContext;
 
-    const authWorkerUrl = process.env.NEXT_PUBLIC_AUTH_WORKER_URL;
-    if (!authWorkerUrl) {
-      return NextResponse.json({ error: 'NEXT_PUBLIC_AUTH_WORKER_URL is not configured' }, { status: 500 });
-    }
-
-    const bearer = await getToken?.();
-    if (!bearer) {
-      return NextResponse.json({ error: 'Authentication token unavailable' }, { status: 401 });
-    }
-
-    const workerResponse = await fetch(`${authWorkerUrl}/leagues/archive`, {
+    const workerResponse = await fetch(`${workerUrl}/leagues/archive`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
@@ -63,10 +76,11 @@ export async function GET() {
 
 export async function POST(request: NextRequest) {
   try {
-    const { userId, getToken } = await auth();
-    if (!userId) {
-      return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+    const authContext = await getArchiveAuthContext();
+    if (authContext instanceof NextResponse) {
+      return authContext;
     }
+    const { bearer, workerUrl } = authContext;
 
     const body = await request.json() as ArchiveRequestBody;
     if (!body.platform || !body.sport || !body.recurringLeagueId) {
@@ -75,17 +89,7 @@ export async function POST(request: NextRequest) {
       }, { status: 400 });
     }
 
-    const authWorkerUrl = process.env.NEXT_PUBLIC_AUTH_WORKER_URL;
-    if (!authWorkerUrl) {
-      return NextResponse.json({ error: 'NEXT_PUBLIC_AUTH_WORKER_URL is not configured' }, { status: 500 });
-    }
-
-    const bearer = await getToken?.();
-    if (!bearer) {
-      return NextResponse.json({ error: 'Authentication token unavailable' }, { status: 401 });
-    }
-
-    const workerResponse = await fetch(`${authWorkerUrl}/leagues/archive`, {
+    const workerResponse = await fetch(`${workerUrl}/leagues/archive`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -108,10 +112,11 @@ export async function POST(request: NextRequest) {
 
 export async function DELETE(request: NextRequest) {
   try {
-    const { userId, getToken } = await auth();
-    if (!userId) {
-      return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+    const authContext = await getArchiveAuthContext();
+    if (authContext instanceof NextResponse) {
+      return authContext;
     }
+    const { bearer, workerUrl } = authContext;
 
     const body = await request.json() as ArchiveRequestBody;
     if (!body.platform || !body.sport || !body.recurringLeagueId) {
@@ -120,17 +125,7 @@ export async function DELETE(request: NextRequest) {
       }, { status: 400 });
     }
 
-    const authWorkerUrl = process.env.NEXT_PUBLIC_AUTH_WORKER_URL;
-    if (!authWorkerUrl) {
-      return NextResponse.json({ error: 'NEXT_PUBLIC_AUTH_WORKER_URL is not configured' }, { status: 500 });
-    }
-
-    const bearer = await getToken?.();
-    if (!bearer) {
-      return NextResponse.json({ error: 'Authentication token unavailable' }, { status: 401 });
-    }
-
-    const workerResponse = await fetch(`${authWorkerUrl}/leagues/archive`, {
+    const workerResponse = await fetch(`${workerUrl}/leagues/archive`, {
       method: 'DELETE',
       headers: {
         'Content-Type': 'application/json',

--- a/workers/auth-worker/src/__tests__/archive-route.test.ts
+++ b/workers/auth-worker/src/__tests__/archive-route.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { parseArchiveBody } from '../index-hono';
+
+describe('parseArchiveBody', () => {
+  it('accepts a valid espn body', () => {
+    const result = parseArchiveBody({ platform: 'espn', sport: 'football', recurringLeagueId: '123456' });
+    expect(result).toEqual({ ok: true, platform: 'espn', sport: 'football', recurringLeagueId: '123456' });
+  });
+
+  it('accepts a valid sleeper body', () => {
+    const result = parseArchiveBody({ platform: 'sleeper', sport: 'basketball', recurringLeagueId: '987654321098765432' });
+    expect(result).toEqual({ ok: true, platform: 'sleeper', sport: 'basketball', recurringLeagueId: '987654321098765432' });
+  });
+
+  it('rejects yahoo (not in ARCHIVE_PLATFORMS)', () => {
+    const result = parseArchiveBody({ platform: 'yahoo', sport: 'football', recurringLeagueId: '449.l.123' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('yahoo');
+    }
+  });
+
+  it('rejects a missing recurringLeagueId', () => {
+    const result = parseArchiveBody({ platform: 'espn', sport: 'football' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('platform, sport, and recurringLeagueId are required');
+    }
+  });
+
+  it('rejects an invalid sport', () => {
+    const result = parseArchiveBody({ platform: 'espn', sport: 'soccer', recurringLeagueId: '123' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('Invalid sport');
+    }
+  });
+
+  it('rejects a recurringLeagueId longer than 255 chars', () => {
+    const tooLong = '1'.repeat(256);
+    const result = parseArchiveBody({ platform: 'espn', sport: 'football', recurringLeagueId: tooLong });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('Invalid recurringLeagueId');
+    }
+  });
+
+  it('accepts a recurringLeagueId at exactly 255 chars', () => {
+    const maxLength = '1'.repeat(255);
+    const result = parseArchiveBody({ platform: 'espn', sport: 'football', recurringLeagueId: maxLength });
+    expect(result.ok).toBe(true);
+  });
+
+  it.each([
+    ['a space', 'abc 123'],
+    ['a semicolon', 'abc;123'],
+    ['a single quote', "abc'123"],
+    ['a double quote', 'abc"123'],
+    ['a slash', 'abc/123'],
+  ])('rejects a recurringLeagueId containing %s', (_label, recurringLeagueId) => {
+    const result = parseArchiveBody({ platform: 'espn', sport: 'football', recurringLeagueId });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('Invalid recurringLeagueId');
+    }
+  });
+
+  it('accepts a valid dotted Yahoo-style id (e.g. 449.l.123) for a supported platform', () => {
+    // Yahoo as a platform is deferred, but the dotted-id charset must pass so the
+    // charset rule never becomes the reason a future Yahoo id is rejected.
+    const result = parseArchiveBody({ platform: 'sleeper', sport: 'football', recurringLeagueId: '449.l.123' });
+    expect(result).toEqual({ ok: true, platform: 'sleeper', sport: 'football', recurringLeagueId: '449.l.123' });
+  });
+});

--- a/workers/auth-worker/src/__tests__/archive-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/archive-storage.test.ts
@@ -123,7 +123,7 @@ describe('ArchiveStorage', () => {
 
     it('throws (fail-closed) on a database error', async () => {
       // Exclude-path callers let this propagate so archived leagues never leak to
-      // the AI on a transient error; annotate-path callers catch it (audit #10).
+      // the AI on a transient error; annotate-path callers catch it.
       const eqPlatform = vi.fn().mockResolvedValue({ data: null, error: { message: 'boom' } });
       const eqUser = vi.fn().mockReturnValue({ eq: eqPlatform });
       const select = vi.fn().mockReturnValue({ eq: eqUser });

--- a/workers/auth-worker/src/__tests__/archive-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/archive-storage.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ArchiveStorage } from '../archive-storage';
+
+const mockFrom = vi.fn();
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    from: mockFrom,
+  }),
+}));
+
+describe('ArchiveStorage', () => {
+  let storage: ArchiveStorage;
+
+  beforeEach(() => {
+    storage = new ArchiveStorage('https://example.supabase.co', 'test-key');
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('archiveLeague', () => {
+    it('upserts the archive row keyed on (user, platform, sport, recurring id)', async () => {
+      const mockUpsert = vi.fn().mockResolvedValue({ error: null });
+      mockFrom.mockReturnValue({ upsert: mockUpsert });
+
+      const ok = await storage.archiveLeague('user_123', 'espn', 'football', 'league-9', 'Zombie League');
+
+      expect(ok).toBe(true);
+      expect(mockFrom).toHaveBeenCalledWith('archived_leagues');
+      const [payload, options] = mockUpsert.mock.calls[0];
+      expect(payload).toMatchObject({
+        clerk_user_id: 'user_123',
+        platform: 'espn',
+        sport: 'football',
+        recurring_league_id: 'league-9',
+        league_name: 'Zombie League',
+      });
+      expect(options).toEqual({ onConflict: 'clerk_user_id,platform,sport,recurring_league_id' });
+    });
+
+    it('returns false when the recurring id is missing', async () => {
+      const mockUpsert = vi.fn();
+      mockFrom.mockReturnValue({ upsert: mockUpsert });
+
+      const ok = await storage.archiveLeague('user_123', 'espn', 'football', '');
+
+      expect(ok).toBe(false);
+      expect(mockUpsert).not.toHaveBeenCalled();
+    });
+
+    it('returns false on a database error', async () => {
+      const mockUpsert = vi.fn().mockResolvedValue({ error: { message: 'boom' } });
+      mockFrom.mockReturnValue({ upsert: mockUpsert });
+
+      const ok = await storage.archiveLeague('user_123', 'sleeper', 'football', 'root-1');
+
+      expect(ok).toBe(false);
+    });
+  });
+
+  describe('unarchiveLeague', () => {
+    it('deletes the matching archive row', async () => {
+      // delete().eq(user).eq(platform).eq(sport).eq(recurring) — the final eq resolves.
+      const eq = vi.fn();
+      let calls = 0;
+      eq.mockImplementation(() => {
+        calls += 1;
+        if (calls >= 4) return Promise.resolve({ error: null });
+        return { eq };
+      });
+      const mockDelete = vi.fn().mockReturnValue({ eq });
+      mockFrom.mockReturnValue({ delete: mockDelete });
+
+      const ok = await storage.unarchiveLeague('user_123', 'espn', 'football', 'league-9');
+
+      expect(ok).toBe(true);
+      expect(mockFrom).toHaveBeenCalledWith('archived_leagues');
+      expect(mockDelete).toHaveBeenCalled();
+      expect(calls).toBe(4);
+    });
+  });
+
+  describe('getArchivedSet', () => {
+    it('returns the set of recurring ids for a platform', async () => {
+      const eqPlatform = vi.fn().mockResolvedValue({
+        data: [{ recurring_league_id: 'a' }, { recurring_league_id: 'b' }],
+        error: null,
+      });
+      const eqUser = vi.fn().mockReturnValue({ eq: eqPlatform });
+      const select = vi.fn().mockReturnValue({ eq: eqUser });
+      mockFrom.mockReturnValue({ select });
+
+      const set = await storage.getArchivedSet('user_123', 'espn');
+
+      expect(set.has('a')).toBe(true);
+      expect(set.has('b')).toBe(true);
+      expect(set.size).toBe(2);
+    });
+
+    it('throws (fail-closed) on a database error', async () => {
+      // Exclude-path callers let this propagate so archived leagues never leak to
+      // the AI on a transient error; annotate-path callers catch it (audit #10).
+      const eqPlatform = vi.fn().mockResolvedValue({ data: null, error: { message: 'boom' } });
+      const eqUser = vi.fn().mockReturnValue({ eq: eqPlatform });
+      const select = vi.fn().mockReturnValue({ eq: eqUser });
+      mockFrom.mockReturnValue({ select });
+
+      await expect(storage.getArchivedSet('user_123', 'sleeper')).rejects.toThrow('Failed to get archived set');
+    });
+  });
+
+  describe('listArchived', () => {
+    it('maps rows into ArchivedLeague objects', async () => {
+      const eqUser = vi.fn().mockResolvedValue({
+        data: [
+          {
+            platform: 'sleeper',
+            sport: 'football',
+            recurring_league_id: 'root-1',
+            league_name: 'Dynasty',
+            archived_at: '2026-06-20T00:00:00.000Z',
+          },
+        ],
+        error: null,
+      });
+      const select = vi.fn().mockReturnValue({ eq: eqUser });
+      mockFrom.mockReturnValue({ select });
+
+      const result = await storage.listArchived('user_123');
+
+      expect(result).toEqual([
+        {
+          platform: 'sleeper',
+          sport: 'football',
+          recurringLeagueId: 'root-1',
+          leagueName: 'Dynasty',
+          archivedAt: '2026-06-20T00:00:00.000Z',
+        },
+      ]);
+    });
+  });
+});

--- a/workers/auth-worker/src/__tests__/archive-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/archive-storage.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { ArchiveStorage } from '../archive-storage';
+import { ArchiveStorage, archivedKey } from '../archive-storage';
 
 const mockFrom = vi.fn();
 
@@ -84,9 +84,12 @@ describe('ArchiveStorage', () => {
   });
 
   describe('getArchivedSet', () => {
-    it('returns the set of recurring ids for a platform', async () => {
+    it('returns the set keyed by sport:recurringId for a platform', async () => {
       const eqPlatform = vi.fn().mockResolvedValue({
-        data: [{ recurring_league_id: 'a' }, { recurring_league_id: 'b' }],
+        data: [
+          { sport: 'football', recurring_league_id: 'a' },
+          { sport: 'basketball', recurring_league_id: 'b' },
+        ],
         error: null,
       });
       const eqUser = vi.fn().mockReturnValue({ eq: eqPlatform });
@@ -95,9 +98,27 @@ describe('ArchiveStorage', () => {
 
       const set = await storage.getArchivedSet('user_123', 'espn');
 
-      expect(set.has('a')).toBe(true);
-      expect(set.has('b')).toBe(true);
+      expect(select).toHaveBeenCalledWith('sport, recurring_league_id');
+      expect(set.has(archivedKey('football', 'a'))).toBe(true);
+      expect(set.has(archivedKey('basketball', 'b'))).toBe(true);
       expect(set.size).toBe(2);
+    });
+
+    it('keys are sport-scoped so a shared recurring id across sports does not collide', async () => {
+      // ESPN football `123` and ESPN basketball `123` are distinct leagues that
+      // share an id space; archiving one must not over-hide the other.
+      const eqPlatform = vi.fn().mockResolvedValue({
+        data: [{ sport: 'football', recurring_league_id: '123' }],
+        error: null,
+      });
+      const eqUser = vi.fn().mockReturnValue({ eq: eqPlatform });
+      const select = vi.fn().mockReturnValue({ eq: eqUser });
+      mockFrom.mockReturnValue({ select });
+
+      const set = await storage.getArchivedSet('user_123', 'espn');
+
+      expect(set.has(archivedKey('football', '123'))).toBe(true);
+      expect(set.has(archivedKey('basketball', '123'))).toBe(false);
     });
 
     it('throws (fail-closed) on a database error', async () => {

--- a/workers/auth-worker/src/__tests__/sleeper-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/sleeper-connect-handlers.test.ts
@@ -21,10 +21,14 @@ vi.mock('../sleeper-storage', () => ({
 // (annotate / exclude). Mock it so no real Supabase client is created and the
 // archived set is controllable per test (defaults to empty).
 const mockGetArchivedSet = vi.fn(async () => new Set<string>());
+// Keep the real archivedKey so the handler's composite-key membership check
+// (sport:recurringId) uses the production key format.
+const archivedKey = (sport: string, recurringLeagueId: string) => `${sport}:${recurringLeagueId}`;
 vi.mock('../archive-storage', () => ({
   ArchiveStorage: {
     fromEnvironment: vi.fn(() => ({ getArchivedSet: mockGetArchivedSet })),
   },
+  archivedKey: (sport: string, recurringLeagueId: string) => `${sport}:${recurringLeagueId}`,
 }));
 
 vi.mock('../season-utils', () => ({
@@ -796,13 +800,25 @@ describe('sleeper-connect-handlers', () => {
 
     it('public path annotates archived=true when the recurring id is archived', async () => {
       mockStorage.getSleeperLeagues.mockResolvedValue(stored);
-      mockGetArchivedSet.mockResolvedValue(new Set(['sleeper-root']));
+      // Composite key: the archived set is keyed by sport:recurringId.
+      mockGetArchivedSet.mockResolvedValue(new Set([archivedKey('football', 'sleeper-root')]));
 
       const response = await handleSleeperLeagues(env, 'user_1', corsHeaders);
       const body = (await response.json()) as { leagues: Array<{ archived?: boolean }> };
 
       expect(mockStorage.getSleeperLeagues).toHaveBeenCalledWith('user_1', true);
       expect(body.leagues[0].archived).toBe(true);
+    });
+
+    it('public path does NOT annotate archived for a same recurring id in a different sport', async () => {
+      // Stored league is football; archiving basketball:sleeper-root must not flag it.
+      mockStorage.getSleeperLeagues.mockResolvedValue(stored);
+      mockGetArchivedSet.mockResolvedValue(new Set([archivedKey('basketball', 'sleeper-root')]));
+
+      const response = await handleSleeperLeagues(env, 'user_1', corsHeaders);
+      const body = (await response.json()) as { leagues: Array<{ archived?: boolean }> };
+
+      expect(body.leagues[0].archived).toBe(false);
     });
 
     it('internal path excludes archived rows and omits the flag', async () => {

--- a/workers/auth-worker/src/__tests__/sleeper-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/sleeper-connect-handlers.test.ts
@@ -761,7 +761,7 @@ describe('sleeper-connect-handlers', () => {
       expect(mockStorage.getSleeperLeagues).not.toHaveBeenCalled();
     });
 
-    it('excludes archived leagues from the status leagueCount (§9)', async () => {
+    it('excludes archived leagues from the status leagueCount', async () => {
       mockStorage.getSleeperConnection.mockResolvedValue({
         sleeperUserId: 'sleeper_123',
         sleeperUsername: 'demo_user',
@@ -780,7 +780,7 @@ describe('sleeper-connect-handlers', () => {
   });
 
   // ===========================================================================
-  // Public annotate vs internal exclude (D3)
+  // Public annotate vs internal exclude (UI annotates archived; AI surfaces exclude)
   // ===========================================================================
 
   describe('handleSleeperLeagues archive annotation', () => {
@@ -833,7 +833,7 @@ describe('sleeper-connect-handlers', () => {
       expect(body.leagues[0].archived).toBeUndefined();
     });
 
-    it('public path fails OPEN on an archive-set error — returns leagues unflagged (audit #10)', async () => {
+    it('public path fails OPEN on an archive-set error — returns leagues unflagged', async () => {
       mockStorage.getSleeperLeagues.mockResolvedValue(stored);
       mockGetArchivedSet.mockRejectedValue(new Error('Failed to get archived set: boom'));
 
@@ -848,7 +848,7 @@ describe('sleeper-connect-handlers', () => {
   });
 
   // ===========================================================================
-  // Sleeper id-flip: archive write resolves the canonical root fresh (§8.5 #1)
+  // Sleeper id-flip: archive write resolves the canonical root fresh
   // ===========================================================================
 
   describe('resolveSleeperArchiveTarget', () => {
@@ -899,7 +899,7 @@ describe('sleeper-connect-handlers', () => {
       expect(target.seasonLeagueIds).toContain('sleeper-2025');
       expect(target.leagueName).toBe('Zombie');
       // Persists the resolved root onto the group's rows so the read-filter key
-      // (recurring_league_id ?? league_id) equals the archive key (D2a / §8.5 #1).
+      // (recurring_league_id ?? league_id) equals the archive key.
       expect(mockStorage.persistRecurringRoot).toHaveBeenCalledWith(
         'user_1',
         ['sleeper-2025'],

--- a/workers/auth-worker/src/__tests__/sleeper-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/sleeper-connect-handlers.test.ts
@@ -4,6 +4,8 @@ import {
   handleSleeperLeagueDelete,
   handleSleeperLeagues,
   handleSleeperStatus,
+  resolveSleeperArchiveTarget,
+  backfillSleeperRecurringIds,
   type SleeperConnectEnv,
 } from '../sleeper-connect-handlers';
 import { SleeperStorage } from '../sleeper-storage';
@@ -12,6 +14,16 @@ import { getDefaultSeasonYear } from '../season-utils';
 vi.mock('../sleeper-storage', () => ({
   SleeperStorage: {
     fromEnvironment: vi.fn(),
+  },
+}));
+
+// ArchiveStorage is constructed inside the public/internal Sleeper league handlers
+// (annotate / exclude). Mock it so no real Supabase client is created and the
+// archived set is controllable per test (defaults to empty).
+const mockGetArchivedSet = vi.fn(async () => new Set<string>());
+vi.mock('../archive-storage', () => ({
+  ArchiveStorage: {
+    fromEnvironment: vi.fn(() => ({ getArchivedSet: mockGetArchivedSet })),
   },
 }));
 
@@ -45,11 +57,13 @@ describe('sleeper-connect-handlers', () => {
     deleteSleeperLeague: ReturnType<typeof vi.fn>;
     getSleeperConnection: ReturnType<typeof vi.fn>;
     getSleeperLeagues: ReturnType<typeof vi.fn>;
+    persistRecurringRoot: ReturnType<typeof vi.fn>;
   };
 
   beforeEach(() => {
     vi.clearAllMocks();
     mockFetch.mockReset();
+    mockGetArchivedSet.mockImplementation(async () => new Set<string>());
 
     mockStorage = {
       saveSleeperConnection: vi.fn().mockResolvedValue(undefined),
@@ -57,6 +71,7 @@ describe('sleeper-connect-handlers', () => {
       deleteSleeperLeague: vi.fn().mockResolvedValue(undefined),
       getSleeperConnection: vi.fn().mockResolvedValue(null),
       getSleeperLeagues: vi.fn().mockResolvedValue([]),
+      persistRecurringRoot: vi.fn().mockResolvedValue(undefined),
     };
 
     vi.mocked(SleeperStorage.fromEnvironment).mockReturnValue(mockStorage as unknown as SleeperStorage);
@@ -740,6 +755,192 @@ describe('sleeper-connect-handlers', () => {
       expect(body.connected).toBe(false);
       expect(body.lastUpdated).toBeUndefined();
       expect(mockStorage.getSleeperLeagues).not.toHaveBeenCalled();
+    });
+
+    it('excludes archived leagues from the status leagueCount (§9)', async () => {
+      mockStorage.getSleeperConnection.mockResolvedValue({
+        sleeperUserId: 'sleeper_123',
+        sleeperUsername: 'demo_user',
+        updatedAt: '2026-01-25T12:00:00.000Z',
+      });
+      // Status passes includeArchived:false; the storage mock here returns the
+      // already-filtered set, so assert the count reflects what the handler got.
+      mockStorage.getSleeperLeagues.mockResolvedValue([]);
+
+      const response = await handleSleeperStatus(env, 'user_1', corsHeaders);
+      const body = (await response.json()) as Record<string, unknown>;
+
+      expect(body.leagueCount).toBe(0);
+      expect(mockStorage.getSleeperLeagues).toHaveBeenCalledWith('user_1', false);
+    });
+  });
+
+  // ===========================================================================
+  // Public annotate vs internal exclude (D3)
+  // ===========================================================================
+
+  describe('handleSleeperLeagues archive annotation', () => {
+    const stored = [
+      {
+        id: 'row-2025',
+        clerkUserId: 'user_1',
+        leagueId: 'sleeper-2025',
+        sport: 'football',
+        seasonYear: 2025,
+        leagueName: 'Zombie',
+        rosterId: 7,
+        recurringLeagueId: 'sleeper-root',
+        sleeperUserId: 'sleeper_123',
+      },
+    ];
+
+    it('public path annotates archived=true when the recurring id is archived', async () => {
+      mockStorage.getSleeperLeagues.mockResolvedValue(stored);
+      mockGetArchivedSet.mockResolvedValue(new Set(['sleeper-root']));
+
+      const response = await handleSleeperLeagues(env, 'user_1', corsHeaders);
+      const body = (await response.json()) as { leagues: Array<{ archived?: boolean }> };
+
+      expect(mockStorage.getSleeperLeagues).toHaveBeenCalledWith('user_1', true);
+      expect(body.leagues[0].archived).toBe(true);
+    });
+
+    it('internal path excludes archived rows and omits the flag', async () => {
+      mockStorage.getSleeperLeagues.mockResolvedValue(stored);
+
+      const response = await handleSleeperLeagues(env, 'user_1', corsHeaders, { includeArchived: false });
+      const body = (await response.json()) as { leagues: Array<{ archived?: boolean }> };
+
+      // Storage was asked to exclude archived; archive set is not consulted for annotation.
+      expect(mockStorage.getSleeperLeagues).toHaveBeenCalledWith('user_1', false);
+      expect(mockGetArchivedSet).not.toHaveBeenCalled();
+      expect(body.leagues[0].archived).toBeUndefined();
+    });
+
+    it('public path fails OPEN on an archive-set error — returns leagues unflagged (audit #10)', async () => {
+      mockStorage.getSleeperLeagues.mockResolvedValue(stored);
+      mockGetArchivedSet.mockRejectedValue(new Error('Failed to get archived set: boom'));
+
+      const response = await handleSleeperLeagues(env, 'user_1', corsHeaders);
+      const body = (await response.json()) as { leagues: Array<{ archived?: boolean }> };
+
+      // The list still returns 200; the archived flag is simply absent/false.
+      expect(response.status).toBe(200);
+      expect(body.leagues).toHaveLength(1);
+      expect(body.leagues[0].archived).toBe(false);
+    });
+  });
+
+  // ===========================================================================
+  // Sleeper id-flip: archive write resolves the canonical root fresh (§8.5 #1)
+  // ===========================================================================
+
+  describe('resolveSleeperArchiveTarget', () => {
+    it('re-resolves the canonical root fresh when a row was keyed on a fallback id', async () => {
+      // Stored rows are keyed on a season-scoped fallback (recurringLeagueId == leagueId).
+      mockStorage.getSleeperLeagues.mockResolvedValue([
+        {
+          id: 'row-2025',
+          clerkUserId: 'user_1',
+          leagueId: 'sleeper-2025',
+          sport: 'football',
+          seasonYear: 2025,
+          leagueName: 'Zombie',
+          rosterId: 7,
+          recurringLeagueId: 'sleeper-2025', // fallback id
+          sleeperUserId: 'sleeper_123',
+        },
+      ]);
+
+      // Fresh chain walk: 2025 -> 2024 (root, no previous_league_id).
+      mockFetch.mockImplementation(async (input) => {
+        const url = String(input);
+        if (url.endsWith('/league/sleeper-2025')) {
+          return jsonResponse({
+            league_id: 'sleeper-2025',
+            name: 'Zombie',
+            sport: 'nfl',
+            season: '2025',
+            previous_league_id: 'sleeper-2024',
+          });
+        }
+        if (url.endsWith('/league/sleeper-2024')) {
+          return jsonResponse({
+            league_id: 'sleeper-2024',
+            name: 'Zombie',
+            sport: 'nfl',
+            season: '2024',
+            previous_league_id: null,
+          });
+        }
+        return new Response(null, { status: 404 });
+      });
+
+      // The UI sent the displayed (fallback) id; archive must resolve the true root.
+      const target = await resolveSleeperArchiveTarget(env, 'user_1', 'sleeper-2025');
+
+      expect(target.recurringLeagueId).toBe('sleeper-2024');
+      expect(target.seasonLeagueIds).toContain('sleeper-2025');
+      expect(target.leagueName).toBe('Zombie');
+      // Persists the resolved root onto the group's rows so the read-filter key
+      // (recurring_league_id ?? league_id) equals the archive key (D2a / §8.5 #1).
+      expect(mockStorage.persistRecurringRoot).toHaveBeenCalledWith(
+        'user_1',
+        ['sleeper-2025'],
+        'sleeper-2024',
+      );
+    });
+  });
+
+  // ===========================================================================
+  // Backfill mechanism (chain-resolving, not the = league_id shortcut)
+  // ===========================================================================
+
+  describe('backfillSleeperRecurringIds', () => {
+    it('resolves the chain root and persists it when the stored value differs', async () => {
+      mockStorage.getSleeperLeagues.mockResolvedValue([
+        {
+          id: 'row-2025',
+          clerkUserId: 'user_1',
+          leagueId: 'sleeper-2025',
+          sport: 'football',
+          seasonYear: 2025,
+          leagueName: 'Zombie',
+          rosterId: 7,
+          recurringLeagueId: 'sleeper-2025', // stale fallback
+          sleeperUserId: 'sleeper_123',
+        },
+      ]);
+
+      mockFetch.mockImplementation(async (input) => {
+        const url = String(input);
+        if (url.endsWith('/league/sleeper-2025')) {
+          return jsonResponse({
+            league_id: 'sleeper-2025',
+            name: 'Zombie',
+            sport: 'nfl',
+            season: '2025',
+            previous_league_id: 'sleeper-2024',
+          });
+        }
+        if (url.endsWith('/league/sleeper-2024')) {
+          return jsonResponse({
+            league_id: 'sleeper-2024',
+            name: 'Zombie',
+            sport: 'nfl',
+            season: '2024',
+            previous_league_id: null,
+          });
+        }
+        return new Response(null, { status: 404 });
+      });
+
+      const result = await backfillSleeperRecurringIds(env, 'user_1');
+
+      expect(result).toEqual({ processed: 1, resolved: 1 });
+      expect(mockStorage.saveSleeperLeague).toHaveBeenCalledWith(
+        expect.objectContaining({ leagueId: 'sleeper-2025', recurringLeagueId: 'sleeper-2024' }),
+      );
     });
   });
 });

--- a/workers/auth-worker/src/__tests__/sleeper-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/sleeper-storage.test.ts
@@ -328,6 +328,64 @@ describe('SleeperStorage', () => {
       // upsert should NOT be called — 2025 row deleted but 2024 default is untouched
       expect(mockPrefsUpsert).not.toHaveBeenCalled();
     });
+
+    // archive cleanup: a true delete unarchives the matching (platform, sport, recurringId).
+    it('removes the matching archive row keyed on (sleeper, sport, recurringId)', async () => {
+      const mockArchiveDelete = vi.fn();
+      // Two sequential sleeper_leagues selects: (1) {league_id, season_year},
+      // (2) {recurring_league_id, sport}. Drive maybeSingle by call order.
+      let sleeperSelectCall = 0;
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'sleeper_leagues') {
+          const maybeSingle = vi.fn().mockImplementation(async () => {
+            sleeperSelectCall += 1;
+            return sleeperSelectCall === 1
+              ? { data: { league_id: 'L2025', season_year: 2025 }, error: null }
+              : { data: { recurring_league_id: 'ROOT', sport: 'basketball' }, error: null };
+          });
+          const eqFn = vi.fn();
+          eqFn.mockReturnValue({ eq: eqFn, maybeSingle, error: null });
+          return {
+            select: vi.fn().mockReturnValue({ eq: eqFn }),
+            delete: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ error: null }) }) }),
+          };
+        }
+        if (table === 'user_preferences') {
+          const prefEq = vi.fn().mockReturnValue({
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: { default_football: null, default_baseball: null, default_basketball: null, default_hockey: null },
+              error: null,
+            }),
+          });
+          return { select: vi.fn().mockReturnValue({ eq: prefEq }), upsert: vi.fn() };
+        }
+        if (table === 'archived_leagues') {
+          // delete().eq(user).eq(platform).eq(sport).eq(recurring) — final eq resolves
+          let calls = 0;
+          const eq = vi.fn();
+          eq.mockImplementation(() => {
+            calls += 1;
+            if (calls >= 4) return Promise.resolve({ error: null });
+            return { eq };
+          });
+          return { delete: mockArchiveDelete.mockReturnValue({ eq }) };
+        }
+        return {};
+      });
+
+      await storage.deleteSleeperLeague('user_123', 'league-uuid');
+
+      expect(mockArchiveDelete).toHaveBeenCalled();
+      // Assert the archive delete was keyed on the actual (platform, sport, recurringId),
+      // not just that it ran — a wrong sport/id would otherwise pass.
+      const eqMock = mockArchiveDelete.mock.results[0].value.eq;
+      const eqArgs = eqMock.mock.calls.map((c: unknown[]) => c as [string, string]);
+      expect(eqArgs).toContainEqual(['clerk_user_id', 'user_123']);
+      expect(eqArgs).toContainEqual(['platform', 'sleeper']);
+      expect(eqArgs).toContainEqual(['sport', 'basketball']);
+      expect(eqArgs).toContainEqual(['recurring_league_id', 'ROOT']);
+    });
   });
 
   // ===========================================================================
@@ -411,10 +469,16 @@ describe('SleeperStorage', () => {
       const eq = vi.fn().mockReturnValue({ order });
       return { select: vi.fn().mockReturnValue({ eq }) };
     }
-    // archived_leagues read: .select('recurring_league_id').eq(user).eq(platform)
-    function mockArchiveRead(ids: string[]) {
+    // archived_leagues read: .select('sport, recurring_league_id').eq(user).eq(platform).
+    // Rows default to football (matching the league fixtures); pass [sport, id] tuples
+    // to archive a specific sport.
+    function mockArchiveRead(ids: (string | [string, string])[]) {
       const eqPlatform = vi.fn().mockResolvedValue({
-        data: ids.map((recurring_league_id) => ({ recurring_league_id })),
+        data: ids.map((entry) =>
+          Array.isArray(entry)
+            ? { sport: entry[0], recurring_league_id: entry[1] }
+            : { sport: 'football', recurring_league_id: entry }
+        ),
         error: null,
       });
       const eqUser = vi.fn().mockReturnValue({ eq: eqPlatform });
@@ -435,6 +499,27 @@ describe('SleeperStorage', () => {
 
       const result = await storage.getSleeperLeagues('u', false);
       expect(result.map((l) => l.leagueId)).toEqual(['K2025']);
+    });
+
+    it('does NOT over-hide a same recurring id in a different sport (cross-sport no-collision)', async () => {
+      // Archive football ROOT; a basketball league that shares the recurring id ROOT
+      // is a distinct league and must remain visible.
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'sleeper_leagues') {
+          return mockLeaguesRead([
+            { id: 'a', clerk_user_id: 'u', league_id: 'L2025', sport: 'football', season_year: 2025, league_name: 'FB Zombie', roster_id: 1, recurring_league_id: 'ROOT', sleeper_user_id: 's' },
+            { id: 'b', clerk_user_id: 'u', league_id: 'B2025', sport: 'basketball', season_year: 2025, league_name: 'BB Keep', roster_id: 2, recurring_league_id: 'ROOT', sleeper_user_id: 's' },
+          ]);
+        }
+        if (table === 'archived_leagues') return mockArchiveRead([['football', 'ROOT']]);
+        return {};
+      });
+
+      const result = await storage.getSleeperLeagues('u', false);
+      // Only the football ROOT is hidden; the basketball ROOT survives.
+      expect(result.map((l) => ({ leagueId: l.leagueId, sport: l.sport }))).toEqual([
+        { leagueId: 'B2025', sport: 'basketball' },
+      ]);
     });
 
     it('falls back to league_id when recurring_league_id is null (null-recurring fallback)', async () => {
@@ -521,7 +606,7 @@ describe('SleeperStorage', () => {
       // archived_leagues read: archive key is the resolved root ROOT2024.
       function mockArchiveRead() {
         const eqPlatform = vi.fn().mockResolvedValue({
-          data: [{ recurring_league_id: 'ROOT2024' }],
+          data: [{ sport: 'football', recurring_league_id: 'ROOT2024' }],
           error: null,
         });
         const eqUser = vi.fn().mockReturnValue({ eq: eqPlatform });

--- a/workers/auth-worker/src/__tests__/sleeper-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/sleeper-storage.test.ts
@@ -399,4 +399,224 @@ describe('SleeperStorage', () => {
       expect(instance).toBeInstanceOf(SleeperStorage);
     });
   });
+
+  // ===========================================================================
+  // includeArchived filter (Sleeper) — D2, recurring_league_id ?? league_id
+  // ===========================================================================
+
+  describe('getSleeperLeagues includeArchived', () => {
+    // sleeper_leagues read: .select('*').eq('clerk_user_id', ...).order(...)
+    function mockLeaguesRead(rows: unknown[]) {
+      const order = vi.fn().mockResolvedValue({ data: rows, error: null });
+      const eq = vi.fn().mockReturnValue({ order });
+      return { select: vi.fn().mockReturnValue({ eq }) };
+    }
+    // archived_leagues read: .select('recurring_league_id').eq(user).eq(platform)
+    function mockArchiveRead(ids: string[]) {
+      const eqPlatform = vi.fn().mockResolvedValue({
+        data: ids.map((recurring_league_id) => ({ recurring_league_id })),
+        error: null,
+      });
+      const eqUser = vi.fn().mockReturnValue({ eq: eqPlatform });
+      return { select: vi.fn().mockReturnValue({ eq: eqUser }) };
+    }
+
+    it('excludes a row whose recurring_league_id is archived', async () => {
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'sleeper_leagues') {
+          return mockLeaguesRead([
+            { id: 'a', clerk_user_id: 'u', league_id: 'L2025', sport: 'football', season_year: 2025, league_name: 'Zombie', roster_id: 1, recurring_league_id: 'ROOT', sleeper_user_id: 's' },
+            { id: 'b', clerk_user_id: 'u', league_id: 'K2025', sport: 'football', season_year: 2025, league_name: 'Keep', roster_id: 2, recurring_league_id: 'KROOT', sleeper_user_id: 's' },
+          ]);
+        }
+        if (table === 'archived_leagues') return mockArchiveRead(['ROOT']);
+        return {};
+      });
+
+      const result = await storage.getSleeperLeagues('u', false);
+      expect(result.map((l) => l.leagueId)).toEqual(['K2025']);
+    });
+
+    it('falls back to league_id when recurring_league_id is null (null-recurring fallback)', async () => {
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'sleeper_leagues') {
+          return mockLeaguesRead([
+            { id: 'a', clerk_user_id: 'u', league_id: 'L2025', sport: 'football', season_year: 2025, league_name: 'Zombie', roster_id: 1, recurring_league_id: null, sleeper_user_id: 's' },
+            { id: 'b', clerk_user_id: 'u', league_id: 'K2025', sport: 'football', season_year: 2025, league_name: 'Keep', roster_id: 2, recurring_league_id: null, sleeper_user_id: 's' },
+          ]);
+        }
+        // Archived on the season-scoped fallback id L2025
+        if (table === 'archived_leagues') return mockArchiveRead(['L2025']);
+        return {};
+      });
+
+      const result = await storage.getSleeperLeagues('u', false);
+      expect(result.map((l) => l.leagueId)).toEqual(['K2025']);
+    });
+
+    it('fails CLOSED: propagates a thrown archive-set error on the exclude path (audit #10)', async () => {
+      // archived_leagues read errors → getArchivedSet throws → getSleeperLeagues
+      // (includeArchived:false) propagates rather than returning unfiltered rows.
+      function mockArchiveError() {
+        const eqPlatform = vi.fn().mockResolvedValue({ data: null, error: { message: 'boom' } });
+        const eqUser = vi.fn().mockReturnValue({ eq: eqPlatform });
+        return { select: vi.fn().mockReturnValue({ eq: eqUser }) };
+      }
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'sleeper_leagues') {
+          return mockLeaguesRead([
+            { id: 'a', clerk_user_id: 'u', league_id: 'L2025', sport: 'football', season_year: 2025, league_name: 'Zombie', roster_id: 1, recurring_league_id: 'ROOT', sleeper_user_id: 's' },
+          ]);
+        }
+        if (table === 'archived_leagues') return mockArchiveError();
+        return {};
+      });
+
+      await expect(storage.getSleeperLeagues('u', false)).rejects.toThrow('Failed to get archived set');
+    });
+
+    it('returns all rows and skips the archive read when includeArchived is true', async () => {
+      const archiveSelect = vi.fn();
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'sleeper_leagues') {
+          return mockLeaguesRead([
+            { id: 'a', clerk_user_id: 'u', league_id: 'L2025', sport: 'football', season_year: 2025, league_name: 'Zombie', roster_id: 1, recurring_league_id: 'ROOT', sleeper_user_id: 's' },
+          ]);
+        }
+        if (table === 'archived_leagues') return { select: archiveSelect };
+        return {};
+      });
+
+      const result = await storage.getSleeperLeagues('u');
+      expect(result.map((l) => l.leagueId)).toEqual(['L2025']);
+      expect(archiveSelect).not.toHaveBeenCalled();
+    });
+  });
+
+  // ===========================================================================
+  // persistRecurringRoot + read-filter parity (D2a / §8.5 #1)
+  // ===========================================================================
+
+  describe('persistRecurringRoot', () => {
+    it('persists the resolved root so the read-filter excludes a NULL-recurring archived row', async () => {
+      // sleeper_leagues UPDATE: .update({...}).eq('clerk_user_id', user).in('league_id', ids)
+      const mockUpdateIn = vi.fn().mockResolvedValue({ error: null });
+      const mockUpdateEq = vi.fn().mockReturnValue({ in: mockUpdateIn });
+      const mockUpdate = vi.fn().mockReturnValue({ eq: mockUpdateEq });
+
+      // Row starts with recurring_league_id = NULL; after persist it stores ROOT2024.
+      let storedRecurring: string | null = null;
+
+      // sleeper_leagues read: .select('*').eq('clerk_user_id', ...).order(...)
+      function mockLeaguesRead() {
+        const order = vi.fn().mockImplementation(async () => ({
+          data: [
+            { id: 'a', clerk_user_id: 'u', league_id: 'L2025', sport: 'football', season_year: 2025, league_name: 'Zombie', roster_id: 1, recurring_league_id: storedRecurring, sleeper_user_id: 's' },
+          ],
+          error: null,
+        }));
+        const eq = vi.fn().mockReturnValue({ order });
+        return { select: vi.fn().mockReturnValue({ eq }), update: mockUpdate };
+      }
+      // archived_leagues read: archive key is the resolved root ROOT2024.
+      function mockArchiveRead() {
+        const eqPlatform = vi.fn().mockResolvedValue({
+          data: [{ recurring_league_id: 'ROOT2024' }],
+          error: null,
+        });
+        const eqUser = vi.fn().mockReturnValue({ eq: eqPlatform });
+        return { select: vi.fn().mockReturnValue({ eq: eqUser }) };
+      }
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'sleeper_leagues') return mockLeaguesRead();
+        if (table === 'archived_leagues') return mockArchiveRead();
+        return {};
+      });
+
+      // (a) Persist the resolved root onto the season-scoped row.
+      await storage.persistRecurringRoot('u', ['L2025'], 'ROOT2024');
+      expect(mockUpdate).toHaveBeenCalledOnce();
+      expect(mockUpdate.mock.calls[0][0]).toMatchObject({ recurring_league_id: 'ROOT2024' });
+      expect(mockUpdateEq).toHaveBeenCalledWith('clerk_user_id', 'u');
+      expect(mockUpdateIn).toHaveBeenCalledWith('league_id', ['L2025']);
+
+      // Simulate the persisted column for the subsequent read.
+      storedRecurring = 'ROOT2024';
+
+      // (b) The exclude filter now keys on the stored root and drops the row.
+      const result = await storage.getSleeperLeagues('u', false);
+      expect(result.map((l) => l.leagueId)).toEqual([]);
+    });
+
+    it('is a no-op when the recurring_league_id column is missing (pre-migration)', async () => {
+      const mockUpdateIn = vi.fn().mockResolvedValue({
+        error: { code: '42703', message: 'column sleeper_leagues.recurring_league_id does not exist' },
+      });
+      const mockUpdateEq = vi.fn().mockReturnValue({ in: mockUpdateIn });
+      const mockUpdate = vi.fn().mockReturnValue({ eq: mockUpdateEq });
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'sleeper_leagues') return { update: mockUpdate };
+        return {};
+      });
+
+      // Tolerates the missing column instead of throwing (mirrors saveSleeperLeague).
+      await expect(storage.persistRecurringRoot('u', ['L2025'], 'ROOT2024')).resolves.toBeUndefined();
+    });
+  });
+
+  // ===========================================================================
+  // deleteSleeperLeague also removes the archive row (D8)
+  // ===========================================================================
+
+  describe('deleteSleeperLeague archive cleanup', () => {
+    it('unarchives the matching recurring id on a true delete', async () => {
+      const mockArchiveDelete = vi.fn();
+
+      // First lookup: .select('league_id, season_year').eq(user).eq(id).maybeSingle()
+      // Recurring lookup: .select('recurring_league_id, sport').eq(user).eq(id).maybeSingle()
+      // maybeSingle is hoisted OUT of the factory so its Once queue advances across
+      // both lookups — re-creating it per from() call would reset the queue and feed
+      // the recurring lookup the first (sport-less) row, skipping unarchive.
+      const sleeperMaybeSingle = vi.fn()
+        .mockResolvedValueOnce({ data: { league_id: 'L2025', season_year: 2025 }, error: null })
+        .mockResolvedValueOnce({ data: { recurring_league_id: 'ROOT', sport: 'football' }, error: null });
+      const sleeperEq = vi.fn();
+      sleeperEq.mockReturnValue({ eq: sleeperEq, maybeSingle: sleeperMaybeSingle, error: null });
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'sleeper_leagues') {
+          return {
+            select: vi.fn().mockReturnValue({ eq: sleeperEq }),
+            delete: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ error: null }) }) }),
+          };
+        }
+        if (table === 'user_preferences') {
+          const prefEq = vi.fn().mockReturnValue({
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: { default_football: null, default_baseball: null, default_basketball: null, default_hockey: null },
+              error: null,
+            }),
+          });
+          return { select: vi.fn().mockReturnValue({ eq: prefEq }), upsert: vi.fn().mockReturnValue({ error: null }) };
+        }
+        if (table === 'archived_leagues') {
+          let calls = 0;
+          const eq = vi.fn();
+          eq.mockImplementation(() => {
+            calls += 1;
+            if (calls >= 4) return Promise.resolve({ error: null });
+            return { eq };
+          });
+          return { delete: mockArchiveDelete.mockReturnValue({ eq }) };
+        }
+        return {};
+      });
+
+      await storage.deleteSleeperLeague('u', 'row-uuid');
+
+      expect(mockArchiveDelete).toHaveBeenCalled();
+    });
+  });
 });

--- a/workers/auth-worker/src/__tests__/sleeper-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/sleeper-storage.test.ts
@@ -455,7 +455,7 @@ describe('SleeperStorage', () => {
   });
 
   // ===========================================================================
-  // includeArchived filter (Sleeper) — D2, recurring_league_id ?? league_id
+  // includeArchived filter (Sleeper) — archive key is recurring_league_id ?? league_id
   // ===========================================================================
 
   describe('getSleeperLeagues includeArchived', () => {
@@ -535,7 +535,7 @@ describe('SleeperStorage', () => {
       expect(result.map((l) => l.leagueId)).toEqual(['K2025']);
     });
 
-    it('fails CLOSED: propagates a thrown archive-set error on the exclude path (audit #10)', async () => {
+    it('fails CLOSED: propagates a thrown archive-set error on the exclude path', async () => {
       // archived_leagues read errors → getArchivedSet throws → getSleeperLeagues
       // (includeArchived:false) propagates rather than returning unfiltered rows.
       function mockArchiveError() {
@@ -575,7 +575,7 @@ describe('SleeperStorage', () => {
   });
 
   // ===========================================================================
-  // persistRecurringRoot + read-filter parity (D2a / §8.5 #1)
+  // persistRecurringRoot + read-filter parity (stored recurring root matches the archive key)
   // ===========================================================================
 
   describe('persistRecurringRoot', () => {
@@ -648,7 +648,7 @@ describe('SleeperStorage', () => {
   });
 
   // ===========================================================================
-  // deleteSleeperLeague also removes the archive row (D8)
+  // deleteSleeperLeague also removes the archive row
   // ===========================================================================
 
   describe('deleteSleeperLeague archive cleanup', () => {

--- a/workers/auth-worker/src/__tests__/sleeper-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/sleeper-storage.test.ts
@@ -332,17 +332,13 @@ describe('SleeperStorage', () => {
     // archive cleanup: a true delete unarchives the matching (platform, sport, recurringId).
     it('removes the matching archive row keyed on (sleeper, sport, recurringId)', async () => {
       const mockArchiveDelete = vi.fn();
-      // Two sequential sleeper_leagues selects: (1) {league_id, season_year},
-      // (2) {recurring_league_id, sport}. Drive maybeSingle by call order.
-      let sleeperSelectCall = 0;
-
+      // Single sleeper_leagues select returns all four columns
+      // {league_id, season_year, recurring_league_id, sport}.
       mockFrom.mockImplementation((table: string) => {
         if (table === 'sleeper_leagues') {
-          const maybeSingle = vi.fn().mockImplementation(async () => {
-            sleeperSelectCall += 1;
-            return sleeperSelectCall === 1
-              ? { data: { league_id: 'L2025', season_year: 2025 }, error: null }
-              : { data: { recurring_league_id: 'ROOT', sport: 'basketball' }, error: null };
+          const maybeSingle = vi.fn().mockResolvedValue({
+            data: { league_id: 'L2025', season_year: 2025, recurring_league_id: 'ROOT', sport: 'basketball' },
+            error: null,
           });
           const eqFn = vi.fn();
           eqFn.mockReturnValue({ eq: eqFn, maybeSingle, error: null });
@@ -659,14 +655,11 @@ describe('SleeperStorage', () => {
     it('unarchives the matching recurring id on a true delete', async () => {
       const mockArchiveDelete = vi.fn();
 
-      // First lookup: .select('league_id, season_year').eq(user).eq(id).maybeSingle()
-      // Recurring lookup: .select('recurring_league_id, sport').eq(user).eq(id).maybeSingle()
-      // maybeSingle is hoisted OUT of the factory so its Once queue advances across
-      // both lookups — re-creating it per from() call would reset the queue and feed
-      // the recurring lookup the first (sport-less) row, skipping unarchive.
+      // Single lookup: .select('league_id, season_year, recurring_league_id, sport')
+      // .eq(user).eq(id).maybeSingle() returns all four columns for both the
+      // default-clear and the archive cleanup.
       const sleeperMaybeSingle = vi.fn()
-        .mockResolvedValueOnce({ data: { league_id: 'L2025', season_year: 2025 }, error: null })
-        .mockResolvedValueOnce({ data: { recurring_league_id: 'ROOT', sport: 'football' }, error: null });
+        .mockResolvedValue({ data: { league_id: 'L2025', season_year: 2025, recurring_league_id: 'ROOT', sport: 'football' }, error: null });
       const sleeperEq = vi.fn();
       sleeperEq.mockReturnValue({ eq: sleeperEq, maybeSingle: sleeperMaybeSingle, error: null });
 

--- a/workers/auth-worker/src/__tests__/supabase-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/supabase-storage.test.ts
@@ -190,7 +190,7 @@ describe('EspnSupabaseStorage', () => {
     ]);
   });
 
-  it('getLeagues fails CLOSED: propagates a thrown archive-set error on the exclude path (audit #10)', async () => {
+  it('getLeagues fails CLOSED: propagates a thrown archive-set error on the exclude path', async () => {
     mockFrom.mockImplementation((table: string) => {
       if (table === 'espn_leagues') {
         const eq = vi.fn().mockResolvedValue({
@@ -213,7 +213,7 @@ describe('EspnSupabaseStorage', () => {
     await expect(storage.getLeagues('user_123', false)).rejects.toThrow('Failed to get archived set');
   });
 
-  it('setDefaultLeague fails OPEN on an archive-set error — allows the default (audit #10)', async () => {
+  it('setDefaultLeague fails OPEN on an archive-set error — allows the default', async () => {
     const mockPrefsUpsert = vi.fn().mockReturnValue({ error: null });
     mockFrom.mockImplementation((table: string) => {
       if (table === 'espn_leagues') {
@@ -266,7 +266,7 @@ describe('EspnSupabaseStorage', () => {
   });
 
   // ===========================================================================
-  // setDefaultLeague rejects an archived league (§9)
+  // setDefaultLeague rejects an archived league
   // ===========================================================================
 
   it('setDefaultLeague rejects an archived ESPN league', async () => {
@@ -296,7 +296,7 @@ describe('EspnSupabaseStorage', () => {
   });
 
   // ===========================================================================
-  // removeLeague also deletes the matching archive row (D8)
+  // removeLeague also deletes the matching archive row
   // ===========================================================================
 
   it('removeLeague deletes the matching archived_leagues row', async () => {

--- a/workers/auth-worker/src/__tests__/supabase-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/supabase-storage.test.ts
@@ -130,4 +130,184 @@ describe('EspnSupabaseStorage', () => {
     expect(result).toEqual({ success: false, error: 'League not found' });
     expect(mockPrefsUpsert).not.toHaveBeenCalled();
   });
+
+  // ===========================================================================
+  // includeArchived filter (ESPN)
+  // ===========================================================================
+
+  it('getLeagues excludes archived rows when includeArchived is false', async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'espn_leagues') {
+        // .select(...).eq('clerk_user_id', ...) resolves with all rows
+        const eq = vi.fn().mockResolvedValue({
+          data: [
+            { league_id: '111', sport: 'football', team_id: 't1', team_name: 'A', league_name: 'Keep', season_year: 2025 },
+            { league_id: '222', sport: 'football', team_id: 't2', team_name: 'B', league_name: 'Zombie', season_year: 2025 },
+          ],
+          error: null,
+        });
+        return { select: vi.fn().mockReturnValue({ eq }) };
+      }
+      if (table === 'archived_leagues') {
+        // .select('recurring_league_id').eq(user).eq(platform) resolves with archived ids
+        const eqPlatform = vi.fn().mockResolvedValue({ data: [{ recurring_league_id: '222' }], error: null });
+        const eqUser = vi.fn().mockReturnValue({ eq: eqPlatform });
+        return { select: vi.fn().mockReturnValue({ eq: eqUser }) };
+      }
+      return {};
+    });
+
+    const filtered = await storage.getLeagues('user_123', false);
+    expect(filtered.map(l => l.leagueId)).toEqual(['111']);
+  });
+
+  it('getLeagues fails CLOSED: propagates a thrown archive-set error on the exclude path (audit #10)', async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'espn_leagues') {
+        const eq = vi.fn().mockResolvedValue({
+          data: [
+            { league_id: '111', sport: 'football', team_id: 't1', team_name: 'A', league_name: 'Keep', season_year: 2025 },
+          ],
+          error: null,
+        });
+        return { select: vi.fn().mockReturnValue({ eq }) };
+      }
+      if (table === 'archived_leagues') {
+        // archive read errors → getArchivedSet throws → getLeagues(false) propagates
+        const eqPlatform = vi.fn().mockResolvedValue({ data: null, error: { message: 'boom' } });
+        const eqUser = vi.fn().mockReturnValue({ eq: eqPlatform });
+        return { select: vi.fn().mockReturnValue({ eq: eqUser }) };
+      }
+      return {};
+    });
+
+    await expect(storage.getLeagues('user_123', false)).rejects.toThrow('Failed to get archived set');
+  });
+
+  it('setDefaultLeague fails OPEN on an archive-set error — allows the default (audit #10)', async () => {
+    const mockPrefsUpsert = vi.fn().mockReturnValue({ error: null });
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'espn_leagues') {
+        const single = vi.fn().mockResolvedValue({ data: { league_id: '222', team_id: 't2' }, error: null });
+        const eq = vi.fn();
+        eq.mockReturnValue({ eq, single });
+        return { select: vi.fn().mockReturnValue({ eq }) };
+      }
+      if (table === 'archived_leagues') {
+        // Archive lookup errors — fail-open treats nothing as archived.
+        const eqPlatform = vi.fn().mockResolvedValue({ data: null, error: { message: 'boom' } });
+        const eqUser = vi.fn().mockReturnValue({ eq: eqPlatform });
+        return { select: vi.fn().mockReturnValue({ eq: eqUser }) };
+      }
+      if (table === 'user_preferences') {
+        return { upsert: mockPrefsUpsert };
+      }
+      return {};
+    });
+
+    const result = await storage.setDefaultLeague('user_123', 'espn', 'football', '222', 2025);
+
+    expect(result).toEqual({ success: true });
+    expect(mockPrefsUpsert).toHaveBeenCalledOnce();
+  });
+
+  it('getLeagues returns all rows when includeArchived defaults to true', async () => {
+    const archivedSelect = vi.fn();
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'espn_leagues') {
+        const eq = vi.fn().mockResolvedValue({
+          data: [
+            { league_id: '111', sport: 'football', team_id: 't1', team_name: 'A', league_name: 'Keep', season_year: 2025 },
+            { league_id: '222', sport: 'football', team_id: 't2', team_name: 'B', league_name: 'Zombie', season_year: 2025 },
+          ],
+          error: null,
+        });
+        return { select: vi.fn().mockReturnValue({ eq }) };
+      }
+      if (table === 'archived_leagues') {
+        return { select: archivedSelect };
+      }
+      return {};
+    });
+
+    const all = await storage.getLeagues('user_123');
+    expect(all.map(l => l.leagueId)).toEqual(['111', '222']);
+    // Archive set must NOT be consulted on the default (unfiltered) path.
+    expect(archivedSelect).not.toHaveBeenCalled();
+  });
+
+  // ===========================================================================
+  // setDefaultLeague rejects an archived league (§9)
+  // ===========================================================================
+
+  it('setDefaultLeague rejects an archived ESPN league', async () => {
+    const mockPrefsUpsert = vi.fn();
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'espn_leagues') {
+        const single = vi.fn().mockResolvedValue({ data: { league_id: '222', team_id: 't2' }, error: null });
+        const eq = vi.fn();
+        eq.mockReturnValue({ eq, single });
+        return { select: vi.fn().mockReturnValue({ eq }) };
+      }
+      if (table === 'archived_leagues') {
+        const eqPlatform = vi.fn().mockResolvedValue({ data: [{ recurring_league_id: '222' }], error: null });
+        const eqUser = vi.fn().mockReturnValue({ eq: eqPlatform });
+        return { select: vi.fn().mockReturnValue({ eq: eqUser }) };
+      }
+      if (table === 'user_preferences') {
+        return { upsert: mockPrefsUpsert };
+      }
+      return {};
+    });
+
+    const result = await storage.setDefaultLeague('user_123', 'espn', 'football', '222', 2025);
+
+    expect(result).toEqual({ success: false, error: 'Cannot set default: league is archived' });
+    expect(mockPrefsUpsert).not.toHaveBeenCalled();
+  });
+
+  // ===========================================================================
+  // removeLeague also deletes the matching archive row (D8)
+  // ===========================================================================
+
+  it('removeLeague deletes the matching archived_leagues row', async () => {
+    const mockArchiveDelete = vi.fn();
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'espn_leagues') {
+        const selectFn = vi.fn().mockResolvedValue({
+          data: [{ id: 'row-1', league_id: '222', sport: 'football', season_year: 2025 }],
+          error: null,
+        });
+        const eqFn = vi.fn();
+        eqFn.mockReturnValue({ eq: eqFn, select: selectFn });
+        return { delete: vi.fn().mockReturnValue({ eq: eqFn }) };
+      }
+      if (table === 'user_preferences') {
+        const prefEq = vi.fn().mockReturnValue({
+          maybeSingle: vi.fn().mockResolvedValue({
+            data: { default_football: null, default_baseball: null, default_basketball: null, default_hockey: null },
+            error: null,
+          }),
+        });
+        return { select: vi.fn().mockReturnValue({ eq: prefEq }), upsert: vi.fn() };
+      }
+      if (table === 'archived_leagues') {
+        // delete().eq(user).eq(platform).eq(sport).eq(recurring) — final eq resolves
+        let calls = 0;
+        const eq = vi.fn();
+        eq.mockImplementation(() => {
+          calls += 1;
+          if (calls >= 4) return Promise.resolve({ error: null });
+          return { eq };
+        });
+        return { delete: mockArchiveDelete.mockReturnValue({ eq }) };
+      }
+      return {};
+    });
+
+    const result = await storage.removeLeague('user_123', '222', 'football');
+
+    expect(result).toBe(true);
+    expect(mockArchiveDelete).toHaveBeenCalled();
+  });
 });

--- a/workers/auth-worker/src/__tests__/supabase-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/supabase-storage.test.ts
@@ -149,8 +149,8 @@ describe('EspnSupabaseStorage', () => {
         return { select: vi.fn().mockReturnValue({ eq }) };
       }
       if (table === 'archived_leagues') {
-        // .select('recurring_league_id').eq(user).eq(platform) resolves with archived ids
-        const eqPlatform = vi.fn().mockResolvedValue({ data: [{ recurring_league_id: '222' }], error: null });
+        // .select('sport, recurring_league_id').eq(user).eq(platform) resolves with archived rows
+        const eqPlatform = vi.fn().mockResolvedValue({ data: [{ sport: 'football', recurring_league_id: '222' }], error: null });
         const eqUser = vi.fn().mockReturnValue({ eq: eqPlatform });
         return { select: vi.fn().mockReturnValue({ eq: eqUser }) };
       }
@@ -159,6 +159,35 @@ describe('EspnSupabaseStorage', () => {
 
     const filtered = await storage.getLeagues('user_123', false);
     expect(filtered.map(l => l.leagueId)).toEqual(['111']);
+  });
+
+  it('getLeagues does NOT over-hide a same-id league in a different sport (cross-sport no-collision)', async () => {
+    // Archive ESPN football `123`; ESPN basketball `123` is a distinct league that
+    // shares the id space and must remain visible.
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'espn_leagues') {
+        const eq = vi.fn().mockResolvedValue({
+          data: [
+            { league_id: '123', sport: 'football', team_id: 't1', team_name: 'A', league_name: 'FB Zombie', season_year: 2025 },
+            { league_id: '123', sport: 'basketball', team_id: 't2', team_name: 'B', league_name: 'BB Keep', season_year: 2025 },
+          ],
+          error: null,
+        });
+        return { select: vi.fn().mockReturnValue({ eq }) };
+      }
+      if (table === 'archived_leagues') {
+        const eqPlatform = vi.fn().mockResolvedValue({ data: [{ sport: 'football', recurring_league_id: '123' }], error: null });
+        const eqUser = vi.fn().mockReturnValue({ eq: eqPlatform });
+        return { select: vi.fn().mockReturnValue({ eq: eqUser }) };
+      }
+      return {};
+    });
+
+    const filtered = await storage.getLeagues('user_123', false);
+    // Only the football `123` is hidden; the basketball `123` survives.
+    expect(filtered.map(l => ({ leagueId: l.leagueId, sport: l.sport }))).toEqual([
+      { leagueId: '123', sport: 'basketball' },
+    ]);
   });
 
   it('getLeagues fails CLOSED: propagates a thrown archive-set error on the exclude path (audit #10)', async () => {
@@ -250,7 +279,7 @@ describe('EspnSupabaseStorage', () => {
         return { select: vi.fn().mockReturnValue({ eq }) };
       }
       if (table === 'archived_leagues') {
-        const eqPlatform = vi.fn().mockResolvedValue({ data: [{ recurring_league_id: '222' }], error: null });
+        const eqPlatform = vi.fn().mockResolvedValue({ data: [{ sport: 'football', recurring_league_id: '222' }], error: null });
         const eqUser = vi.fn().mockReturnValue({ eq: eqPlatform });
         return { select: vi.fn().mockReturnValue({ eq: eqUser }) };
       }
@@ -292,7 +321,8 @@ describe('EspnSupabaseStorage', () => {
         return { select: vi.fn().mockReturnValue({ eq: prefEq }), upsert: vi.fn() };
       }
       if (table === 'archived_leagues') {
-        // delete().eq(user).eq(platform).eq(sport).eq(recurring) — final eq resolves
+        // delete().eq(user).eq(platform).eq(sport).eq(recurring) — final eq resolves.
+        // Record every (column, value) so we can assert the actual archive key.
         let calls = 0;
         const eq = vi.fn();
         eq.mockImplementation(() => {
@@ -309,5 +339,13 @@ describe('EspnSupabaseStorage', () => {
 
     expect(result).toBe(true);
     expect(mockArchiveDelete).toHaveBeenCalled();
+    // Assert the archive delete was keyed on the correct (platform, sport, leagueId),
+    // not just that it ran — a wrong sport/id would otherwise pass.
+    const eqMock = mockArchiveDelete.mock.results[0].value.eq;
+    const eqArgs = eqMock.mock.calls.map((c: unknown[]) => c as [string, string]);
+    expect(eqArgs).toContainEqual(['clerk_user_id', 'user_123']);
+    expect(eqArgs).toContainEqual(['platform', 'espn']);
+    expect(eqArgs).toContainEqual(['sport', 'football']);
+    expect(eqArgs).toContainEqual(['recurring_league_id', '222']);
   });
 });

--- a/workers/auth-worker/src/archive-storage.ts
+++ b/workers/auth-worker/src/archive-storage.ts
@@ -11,7 +11,7 @@
  * where `recurring_league_id` is the SAME value the league row stores
  * (ESPN: `league_id`; Sleeper: `recurring_league_id ?? league_id`). The read-path
  * filter is therefore a plain column comparison against the archived set — no
- * separate key-computation and no dependency on display-grouping heuristics (D2).
+ * separate key-computation and no dependency on display-grouping heuristics.
  *
  * All access uses the Supabase service-role key (bypasses RLS), matching every
  * existing league table.
@@ -180,13 +180,13 @@ export class ArchiveStorage {
   /**
    * Return the set of archived leagues for a user + platform, keyed by
    * `sport:recurringId` (see `archivedKey`). Used by the read-path filter as a
-   * plain composite-key comparison (D2). The sport is part of the key because
+   * plain composite-key comparison. The sport is part of the key because
    * recurring ids are only unique within a sport.
    *
    * THROWS on a DB error (fail-closed). Exclude-path callers (internal
    * `includeArchived:false`) let it propagate so a transient error fails the
    * league read rather than silently un-hiding archived leagues from the AI —
-   * the gateway already tolerates a platform fetch failure (audit #10). Annotate-path
+   * the gateway already tolerates a platform fetch failure. Annotate-path
    * callers (public UI) catch it and fall back to an empty set (fail-open) so the
    * UI just loses the archived flag.
    */

--- a/workers/auth-worker/src/archive-storage.ts
+++ b/workers/auth-worker/src/archive-storage.ts
@@ -1,0 +1,197 @@
+/**
+ * Manual league archive storage (FLA-124).
+ * ---------------------------------------------------------------------------
+ *
+ * Archive state lives in its own `archived_leagues` table keyed on a stable
+ * recurring-league identity — NOT a column on the season-scoped league tables.
+ * This is what makes archive survive annual re-syncs: discovery upserts league
+ * rows for new seasons without touching this table, so the league stays hidden.
+ *
+ * The archive key is `(clerk_user_id, platform, sport, recurring_league_id)`,
+ * where `recurring_league_id` is the SAME value the league row stores
+ * (ESPN: `league_id`; Sleeper: `recurring_league_id ?? league_id`). The read-path
+ * filter is therefore a plain column comparison against the archived set — no
+ * separate key-computation and no dependency on display-grouping heuristics (D2).
+ *
+ * All access uses the Supabase service-role key (bypasses RLS), matching every
+ * existing league table.
+ */
+
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+
+export type ArchivePlatform = 'espn' | 'yahoo' | 'sleeper';
+export type ArchiveSport = 'football' | 'baseball' | 'basketball' | 'hockey';
+
+export interface ArchivedLeague {
+  platform: ArchivePlatform;
+  sport: ArchiveSport;
+  recurringLeagueId: string;
+  leagueName?: string;
+  archivedAt?: string;
+}
+
+interface ArchivedLeagueRow {
+  platform: string;
+  sport: string;
+  recurring_league_id: string;
+  league_name: string | null;
+  archived_at: string | null;
+}
+
+function maskUserId(userId: string): string {
+  if (!userId || userId.length <= 8) return '***';
+  return `${userId.substring(0, 8)}...`;
+}
+
+export interface ArchiveStorageEnv {
+  SUPABASE_URL: string;
+  SUPABASE_SERVICE_KEY: string;
+}
+
+export class ArchiveStorage {
+  private supabase: SupabaseClient;
+
+  constructor(supabaseUrl: string, supabaseKey: string) {
+    this.supabase = createClient(supabaseUrl, supabaseKey);
+  }
+
+  static fromEnvironment(env: ArchiveStorageEnv): ArchiveStorage {
+    return new ArchiveStorage(env.SUPABASE_URL, env.SUPABASE_SERVICE_KEY);
+  }
+
+  /**
+   * Archive a league for a user. Idempotent — re-archiving the same
+   * (platform, sport, recurringLeagueId) updates the denormalized name.
+   */
+  async archiveLeague(
+    clerkUserId: string,
+    platform: ArchivePlatform,
+    sport: ArchiveSport,
+    recurringLeagueId: string,
+    leagueName?: string
+  ): Promise<boolean> {
+    try {
+      if (!clerkUserId || !recurringLeagueId) return false;
+
+      const { error } = await this.supabase
+        .from('archived_leagues')
+        .upsert(
+          {
+            clerk_user_id: clerkUserId,
+            platform,
+            sport,
+            recurring_league_id: recurringLeagueId,
+            league_name: leagueName ?? null,
+            archived_at: new Date().toISOString(),
+          },
+          { onConflict: 'clerk_user_id,platform,sport,recurring_league_id' }
+        );
+
+      if (error) {
+        console.error('[archive-storage] archiveLeague error:', error);
+        return false;
+      }
+
+      console.log(
+        `[archive-storage] archiveLeague: archived ${platform}:${sport}:${recurringLeagueId} for user ${maskUserId(clerkUserId)}`
+      );
+      return true;
+    } catch (error) {
+      console.error('[archive-storage] Failed to archive league:', error);
+      return false;
+    }
+  }
+
+  /**
+   * Remove an archive entry (restore the league to the visible/AI surfaces).
+   */
+  async unarchiveLeague(
+    clerkUserId: string,
+    platform: ArchivePlatform,
+    sport: ArchiveSport,
+    recurringLeagueId: string
+  ): Promise<boolean> {
+    try {
+      if (!clerkUserId || !recurringLeagueId) return false;
+
+      const { error } = await this.supabase
+        .from('archived_leagues')
+        .delete()
+        .eq('clerk_user_id', clerkUserId)
+        .eq('platform', platform)
+        .eq('sport', sport)
+        .eq('recurring_league_id', recurringLeagueId);
+
+      if (error) {
+        console.error('[archive-storage] unarchiveLeague error:', error);
+        return false;
+      }
+
+      console.log(
+        `[archive-storage] unarchiveLeague: restored ${platform}:${sport}:${recurringLeagueId} for user ${maskUserId(clerkUserId)}`
+      );
+      return true;
+    } catch (error) {
+      console.error('[archive-storage] Failed to unarchive league:', error);
+      return false;
+    }
+  }
+
+  /**
+   * List all archived leagues for a user (for the Archived UI section).
+   */
+  async listArchived(clerkUserId: string): Promise<ArchivedLeague[]> {
+    try {
+      if (!clerkUserId) return [];
+
+      const { data, error } = await this.supabase
+        .from('archived_leagues')
+        .select('platform, sport, recurring_league_id, league_name, archived_at')
+        .eq('clerk_user_id', clerkUserId);
+
+      if (error || !data) {
+        if (error) console.error('[archive-storage] listArchived error:', error);
+        return [];
+      }
+
+      return (data as ArchivedLeagueRow[]).map((row) => ({
+        platform: row.platform as ArchivePlatform,
+        sport: row.sport as ArchiveSport,
+        recurringLeagueId: row.recurring_league_id,
+        leagueName: row.league_name ?? undefined,
+        archivedAt: row.archived_at ?? undefined,
+      }));
+    } catch (error) {
+      console.error('[archive-storage] Failed to list archived leagues:', error);
+      return [];
+    }
+  }
+
+  /**
+   * Return the set of archived `recurring_league_id`s for a user + platform.
+   * Used by the read-path filter as a plain column comparison (D2).
+   *
+   * THROWS on a DB error (fail-closed). Exclude-path callers (internal
+   * `includeArchived:false`) let it propagate so a transient error fails the
+   * league read rather than silently un-hiding archived leagues from the AI —
+   * the gateway already tolerates a platform fetch failure (audit #10). Annotate-path
+   * callers (public UI) catch it and fall back to an empty set (fail-open) so the
+   * UI just loses the archived flag.
+   */
+  async getArchivedSet(clerkUserId: string, platform: ArchivePlatform): Promise<Set<string>> {
+    if (!clerkUserId) return new Set();
+
+    const { data, error } = await this.supabase
+      .from('archived_leagues')
+      .select('recurring_league_id')
+      .eq('clerk_user_id', clerkUserId)
+      .eq('platform', platform);
+
+    if (error || !data) {
+      console.error('[archive-storage] getArchivedSet error:', error);
+      throw new Error(`Failed to get archived set: ${error?.message ?? 'no data returned'}`);
+    }
+
+    return new Set((data as { recurring_league_id: string }[]).map((row) => row.recurring_league_id));
+  }
+}

--- a/workers/auth-worker/src/archive-storage.ts
+++ b/workers/auth-worker/src/archive-storage.ts
@@ -43,6 +43,16 @@ function maskUserId(userId: string): string {
   return `${userId.substring(0, 8)}...`;
 }
 
+/**
+ * Composite key for the archived set: `sport:recurringId`. The archive table key
+ * includes sport, and recurring-league ids are only unique within a sport (the id
+ * space is shared across sports), so membership checks must scope by sport too.
+ * Centralized here so the read-path and write-path key format can't drift.
+ */
+export function archivedKey(sport: string, recurringLeagueId: string): string {
+  return `${sport}:${recurringLeagueId}`;
+}
+
 export interface ArchiveStorageEnv {
   SUPABASE_URL: string;
   SUPABASE_SERVICE_KEY: string;
@@ -168,8 +178,10 @@ export class ArchiveStorage {
   }
 
   /**
-   * Return the set of archived `recurring_league_id`s for a user + platform.
-   * Used by the read-path filter as a plain column comparison (D2).
+   * Return the set of archived leagues for a user + platform, keyed by
+   * `sport:recurringId` (see `archivedKey`). Used by the read-path filter as a
+   * plain composite-key comparison (D2). The sport is part of the key because
+   * recurring ids are only unique within a sport.
    *
    * THROWS on a DB error (fail-closed). Exclude-path callers (internal
    * `includeArchived:false`) let it propagate so a transient error fails the
@@ -183,7 +195,7 @@ export class ArchiveStorage {
 
     const { data, error } = await this.supabase
       .from('archived_leagues')
-      .select('recurring_league_id')
+      .select('sport, recurring_league_id')
       .eq('clerk_user_id', clerkUserId)
       .eq('platform', platform);
 
@@ -192,6 +204,10 @@ export class ArchiveStorage {
       throw new Error(`Failed to get archived set: ${error?.message ?? 'no data returned'}`);
     }
 
-    return new Set((data as { recurring_league_id: string }[]).map((row) => row.recurring_league_id));
+    return new Set(
+      (data as { sport: string; recurring_league_id: string }[]).map((row) =>
+        archivedKey(row.sport, row.recurring_league_id)
+      )
+    );
   }
 }

--- a/workers/auth-worker/src/index-hono.ts
+++ b/workers/auth-worker/src/index-hono.ts
@@ -59,6 +59,7 @@ import {
   YahooConnectEnv,
 } from './yahoo-connect-handlers';
 import { YahooStorage } from './yahoo-storage';
+import { ArchiveStorage, type ArchivePlatform, type ArchiveSport } from './archive-storage';
 import { logSetupSignal, type SetupSignalEvent } from '@flaim/worker-shared';
 import {
   handleSleeperDiscover,
@@ -66,6 +67,7 @@ import {
   handleSleeperDisconnect,
   handleSleeperLeagues,
   handleSleeperLeagueDelete,
+  resolveSleeperArchiveTarget,
   type SleeperConnectEnv,
 } from './sleeper-connect-handlers';
 import { logEvalEvent } from './logging';
@@ -1121,7 +1123,10 @@ api.get('/internal/leagues/yahoo', async (c) => {
   }
 
   const storage = YahooStorage.fromEnvironment(c.env);
-  const leagues = await storage.getYahooLeagues(userId);
+  // Internal (gateway-facing) endpoint excludes archived leagues so they vanish
+  // from the AI surfaces (D3). No-op in 1a (Yahoo archived set is empty until 1b),
+  // but prevents a latent leak once Yahoo recurring ids ship.
+  const leagues = await storage.getYahooLeagues(userId, false);
 
   return c.json({ leagues }, 200);
 });
@@ -1208,7 +1213,8 @@ api.get('/internal/leagues/sleeper', async (c) => {
       error_description: authError || 'Authentication required',
     }, authStatus ?? 401);
   }
-  return handleSleeperLeagues(c.env as SleeperConnectEnv, userId, getCorsHeaders(c.req.raw));
+  // Internal (gateway-facing) endpoint excludes archived leagues (D3).
+  return handleSleeperLeagues(c.env as SleeperConnectEnv, userId, getCorsHeaders(c.req.raw), { includeArchived: false });
 });
 
 // Delete Sleeper league (requires auth)
@@ -1223,6 +1229,121 @@ api.delete('/leagues/sleeper/:id', async (c) => {
   const leagueId = c.req.param('id');
   if (!leagueId) return c.json({ error: 'League ID required' }, 400);
   return handleSleeperLeagueDelete(c.env as SleeperConnectEnv, userId, leagueId, getCorsHeaders(c.req.raw));
+});
+
+// =============================================================================
+// LEAGUE ARCHIVE ROUTES (FLA-124)
+// =============================================================================
+
+const ARCHIVE_PLATFORMS: ArchivePlatform[] = ['espn', 'sleeper'];
+const ARCHIVE_SPORTS: ArchiveSport[] = ['football', 'baseball', 'basketball', 'hockey'];
+
+interface ArchiveRequestBody {
+  platform?: string;
+  sport?: string;
+  recurringLeagueId?: string;
+}
+
+function parseArchiveBody(body: ArchiveRequestBody):
+  | { ok: true; platform: ArchivePlatform; sport: ArchiveSport; recurringLeagueId: string }
+  | { ok: false; error: string } {
+  const { platform, sport, recurringLeagueId } = body;
+  if (!platform || !sport || !recurringLeagueId) {
+    return { ok: false, error: 'platform, sport, and recurringLeagueId are required' };
+  }
+  // Yahoo archive is gated to Phase 1b (D9): no stable stored recurring id yet.
+  if (!ARCHIVE_PLATFORMS.includes(platform as ArchivePlatform)) {
+    return { ok: false, error: `Archive is not supported for platform '${platform}'` };
+  }
+  if (!ARCHIVE_SPORTS.includes(sport as ArchiveSport)) {
+    return { ok: false, error: 'Invalid sport' };
+  }
+  return {
+    ok: true,
+    platform: platform as ArchivePlatform,
+    sport: sport as ArchiveSport,
+    recurringLeagueId,
+  };
+}
+
+// List archived leagues for the user (feeds the web Archived UI section). All
+// platforms — annotation/exclusion happens on the per-platform /leagues* routes.
+api.get('/leagues/archive', async (c) => {
+  const { userId, error: authError } = await getClerkUserId(c.req.raw, c.env);
+  if (!userId) {
+    return c.json({ error: 'unauthorized', error_description: authError || 'Authentication required' }, 401);
+  }
+
+  const archiveStorage = ArchiveStorage.fromEnvironment(c.env);
+  const leagues = await archiveStorage.listArchived(userId);
+
+  return c.json({ leagues }, 200);
+});
+
+// Archive a league (hide it from the AI; survives re-sync). ESPN + Sleeper only (D9).
+api.post('/leagues/archive', async (c) => {
+  const { userId, error: authError } = await getClerkUserId(c.req.raw, c.env);
+  if (!userId) {
+    return c.json({ error: 'unauthorized', error_description: authError || 'Authentication required' }, 401);
+  }
+
+  const parsed = parseArchiveBody((await c.req.json()) as ArchiveRequestBody);
+  if (!parsed.ok) {
+    return c.json({ error: parsed.error }, 400);
+  }
+  const { platform, sport } = parsed;
+
+  const archiveStorage = ArchiveStorage.fromEnvironment(c.env);
+  const espnStorage = EspnSupabaseStorage.fromEnvironment(c.env);
+
+  // Resolve the canonical recurring key + the per-season ids whose defaults to clear.
+  let recurringLeagueId = parsed.recurringLeagueId;
+  let leagueName: string | undefined;
+  let seasonLeagueIds: string[] = [recurringLeagueId];
+
+  if (platform === 'sleeper') {
+    // Resolve the canonical root fresh — never archive on a season-scoped fallback (§8.5 #1).
+    const target = await resolveSleeperArchiveTarget(c.env as SleeperConnectEnv, userId, recurringLeagueId);
+    recurringLeagueId = target.recurringLeagueId;
+    leagueName = target.leagueName;
+    // Clear defaults per per-season league_id of the group (D6 / §8.5 #3).
+    seasonLeagueIds = target.seasonLeagueIds.length > 0 ? target.seasonLeagueIds : [recurringLeagueId];
+  }
+
+  const archived = await archiveStorage.archiveLeague(userId, platform, sport, recurringLeagueId, leagueName);
+  if (!archived) {
+    return c.json({ error: 'Failed to archive league' }, 500);
+  }
+
+  // Auto-clear defaults on archive (D6). ESPN is a single call on the stable
+  // league_id; Sleeper clears once per per-season id in the recurring group.
+  for (const seasonLeagueId of seasonLeagueIds) {
+    await espnStorage.clearStaleDefaultForLeague(userId, platform, seasonLeagueId, undefined, sport);
+  }
+
+  return c.json({ success: true, platform, sport, recurringLeagueId });
+});
+
+// Unarchive a league (restore it to the visible/AI surfaces).
+api.delete('/leagues/archive', async (c) => {
+  const { userId, error: authError } = await getClerkUserId(c.req.raw, c.env);
+  if (!userId) {
+    return c.json({ error: 'unauthorized', error_description: authError || 'Authentication required' }, 401);
+  }
+
+  const parsed = parseArchiveBody((await c.req.json()) as ArchiveRequestBody);
+  if (!parsed.ok) {
+    return c.json({ error: parsed.error }, 400);
+  }
+  const { platform, sport, recurringLeagueId } = parsed;
+
+  const archiveStorage = ArchiveStorage.fromEnvironment(c.env);
+  const ok = await archiveStorage.unarchiveLeague(userId, platform, sport, recurringLeagueId);
+  if (!ok) {
+    return c.json({ error: 'Failed to unarchive league' }, 500);
+  }
+
+  return c.json({ success: true, platform, sport, recurringLeagueId });
 });
 
 // =============================================================================
@@ -1565,7 +1686,9 @@ api.get('/internal/leagues', async (c) => {
   }
 
   const storage = EspnSupabaseStorage.fromEnvironment(c.env);
-  const leagues = await storage.getLeagues(clerkUserId);
+  // Internal (gateway-facing) endpoint excludes archived leagues so they vanish
+  // from get_user_session and get_ancient_history automatically (D3).
+  const leagues = await storage.getLeagues(clerkUserId, false);
   const leaguesWithPlatform = leagues.map(league => ({
     ...league,
     platform: 'espn' as const
@@ -1621,12 +1744,24 @@ async function handleLeagues(c: Context<{ Bindings: Env }>, method: string): Pro
     });
 
   } else if (method === 'GET') {
+    // Public (UI) endpoint returns ALL leagues with an `archived` boolean so the
+    // UI can bucket them into the Archived section (D3). ESPN recurring id = league_id.
     const leagues = await storage.getLeagues(clerkUserId);
+    const archiveStorage = ArchiveStorage.fromEnvironment(env);
+    // Annotate path fails OPEN: a transient archive-set error just drops the flag
+    // (the UI loses bucketing) rather than failing the whole league list (audit #10).
+    let archivedSet: Set<string>;
+    try {
+      archivedSet = await archiveStorage.getArchivedSet(clerkUserId, 'espn');
+    } catch (error) {
+      console.error('[auth-worker] /leagues archived-set lookup failed; annotating none:', error);
+      archivedSet = new Set();
+    }
 
-    // Add platform field to all leagues (currently all are ESPN)
     const leaguesWithPlatform = leagues.map(league => ({
       ...league,
-      platform: 'espn' as const
+      platform: 'espn' as const,
+      archived: archivedSet.has(league.leagueId),
     }));
 
     return c.json({

--- a/workers/auth-worker/src/index-hono.ts
+++ b/workers/auth-worker/src/index-hono.ts
@@ -1294,7 +1294,9 @@ api.post('/leagues/archive', async (c) => {
   const { platform, sport } = parsed;
 
   const archiveStorage = ArchiveStorage.fromEnvironment(c.env);
-  const espnStorage = EspnSupabaseStorage.fromEnvironment(c.env);
+  // clearStaleDefaultForLeague operates on user_preferences and is platform-agnostic,
+  // so a single storage instance handles the default-clear for every platform.
+  const sharedStorage = EspnSupabaseStorage.fromEnvironment(c.env);
 
   // Resolve the canonical recurring key + the per-season ids whose defaults to clear.
   let recurringLeagueId = parsed.recurringLeagueId;
@@ -1318,7 +1320,7 @@ api.post('/leagues/archive', async (c) => {
   // Auto-clear defaults on archive (D6). ESPN is a single call on the stable
   // league_id; Sleeper clears once per per-season id in the recurring group.
   for (const seasonLeagueId of seasonLeagueIds) {
-    await espnStorage.clearStaleDefaultForLeague(userId, platform, seasonLeagueId, undefined, sport);
+    await sharedStorage.clearStaleDefaultForLeague(userId, platform, seasonLeagueId, undefined, sport);
   }
 
   return c.json({ success: true, platform, sport, recurringLeagueId });

--- a/workers/auth-worker/src/index-hono.ts
+++ b/workers/auth-worker/src/index-hono.ts
@@ -1238,13 +1238,20 @@ api.delete('/leagues/sleeper/:id', async (c) => {
 const ARCHIVE_PLATFORMS: ArchivePlatform[] = ['espn', 'sleeper'];
 const ARCHIVE_SPORTS: ArchiveSport[] = ['football', 'baseball', 'basketball', 'hockey'];
 
+// recurringLeagueId allowlist: numeric ESPN/Sleeper ids plus dotted Yahoo-style
+// league_keys (e.g. "449.l.123"). Dots, dashes, and underscores are permitted; no
+// whitespace or other punctuation. Capped at 255 chars to bound storage/key length.
+const RECURRING_LEAGUE_ID_MAX_LENGTH = 255;
+const RECURRING_LEAGUE_ID_PATTERN = /^[A-Za-z0-9._-]+$/;
+
 interface ArchiveRequestBody {
   platform?: string;
   sport?: string;
   recurringLeagueId?: string;
 }
 
-function parseArchiveBody(body: ArchiveRequestBody):
+// Exported for unit tests — pure validation, no side effects.
+export function parseArchiveBody(body: ArchiveRequestBody):
   | { ok: true; platform: ArchivePlatform; sport: ArchiveSport; recurringLeagueId: string }
   | { ok: false; error: string } {
   const { platform, sport, recurringLeagueId } = body;
@@ -1257,6 +1264,12 @@ function parseArchiveBody(body: ArchiveRequestBody):
   }
   if (!ARCHIVE_SPORTS.includes(sport as ArchiveSport)) {
     return { ok: false, error: 'Invalid sport' };
+  }
+  if (recurringLeagueId.length > RECURRING_LEAGUE_ID_MAX_LENGTH) {
+    return { ok: false, error: 'Invalid recurringLeagueId' };
+  }
+  if (!RECURRING_LEAGUE_ID_PATTERN.test(recurringLeagueId)) {
+    return { ok: false, error: 'Invalid recurringLeagueId' };
   }
   return {
     ok: true,

--- a/workers/auth-worker/src/index-hono.ts
+++ b/workers/auth-worker/src/index-hono.ts
@@ -59,7 +59,7 @@ import {
   YahooConnectEnv,
 } from './yahoo-connect-handlers';
 import { YahooStorage } from './yahoo-storage';
-import { ArchiveStorage, type ArchivePlatform, type ArchiveSport } from './archive-storage';
+import { ArchiveStorage, archivedKey, type ArchivePlatform, type ArchiveSport } from './archive-storage';
 import { logSetupSignal, type SetupSignalEvent } from '@flaim/worker-shared';
 import {
   handleSleeperDiscover,
@@ -1761,7 +1761,7 @@ async function handleLeagues(c: Context<{ Bindings: Env }>, method: string): Pro
     const leaguesWithPlatform = leagues.map(league => ({
       ...league,
       platform: 'espn' as const,
-      archived: archivedSet.has(league.leagueId),
+      archived: archivedSet.has(archivedKey(league.sport, league.leagueId)),
     }));
 
     return c.json({

--- a/workers/auth-worker/src/index-hono.ts
+++ b/workers/auth-worker/src/index-hono.ts
@@ -1124,8 +1124,8 @@ api.get('/internal/leagues/yahoo', async (c) => {
 
   const storage = YahooStorage.fromEnvironment(c.env);
   // Internal (gateway-facing) endpoint excludes archived leagues so they vanish
-  // from the AI surfaces (D3). No-op in 1a (Yahoo archived set is empty until 1b),
-  // but prevents a latent leak once Yahoo recurring ids ship.
+  // from the AI surfaces. No-op for now (the Yahoo archived set stays empty until
+  // Yahoo archive lands), but prevents a latent leak once Yahoo recurring ids ship.
   const leagues = await storage.getYahooLeagues(userId, false);
 
   return c.json({ leagues }, 200);
@@ -1213,7 +1213,7 @@ api.get('/internal/leagues/sleeper', async (c) => {
       error_description: authError || 'Authentication required',
     }, authStatus ?? 401);
   }
-  // Internal (gateway-facing) endpoint excludes archived leagues (D3).
+  // Internal (gateway-facing) endpoint excludes archived leagues from the AI.
   return handleSleeperLeagues(c.env as SleeperConnectEnv, userId, getCorsHeaders(c.req.raw), { includeArchived: false });
 });
 
@@ -1251,7 +1251,7 @@ function parseArchiveBody(body: ArchiveRequestBody):
   if (!platform || !sport || !recurringLeagueId) {
     return { ok: false, error: 'platform, sport, and recurringLeagueId are required' };
   }
-  // Yahoo archive is gated to Phase 1b (D9): no stable stored recurring id yet.
+  // Yahoo archive is deferred to a later phase: no stable stored recurring id yet.
   if (!ARCHIVE_PLATFORMS.includes(platform as ArchivePlatform)) {
     return { ok: false, error: `Archive is not supported for platform '${platform}'` };
   }
@@ -1280,7 +1280,7 @@ api.get('/leagues/archive', async (c) => {
   return c.json({ leagues }, 200);
 });
 
-// Archive a league (hide it from the AI; survives re-sync). ESPN + Sleeper only (D9).
+// Archive a league (hide it from the AI; survives re-sync). ESPN + Sleeper only (Yahoo deferred to a later phase).
 api.post('/leagues/archive', async (c) => {
   const { userId, error: authError } = await getClerkUserId(c.req.raw, c.env);
   if (!userId) {
@@ -1304,11 +1304,11 @@ api.post('/leagues/archive', async (c) => {
   let seasonLeagueIds: string[] = [recurringLeagueId];
 
   if (platform === 'sleeper') {
-    // Resolve the canonical root fresh — never archive on a season-scoped fallback (§8.5 #1).
+    // Resolve the canonical recurring root fresh so the archive key matches the row's stored id — never archive on a season-scoped fallback.
     const target = await resolveSleeperArchiveTarget(c.env as SleeperConnectEnv, userId, recurringLeagueId);
     recurringLeagueId = target.recurringLeagueId;
     leagueName = target.leagueName;
-    // Clear defaults per per-season league_id of the group (D6 / §8.5 #3).
+    // Clear defaults per per-season league_id of the recurring group.
     seasonLeagueIds = target.seasonLeagueIds.length > 0 ? target.seasonLeagueIds : [recurringLeagueId];
   }
 
@@ -1317,7 +1317,7 @@ api.post('/leagues/archive', async (c) => {
     return c.json({ error: 'Failed to archive league' }, 500);
   }
 
-  // Auto-clear defaults on archive (D6). ESPN is a single call on the stable
+  // Auto-clear any default pointing at an archived league. ESPN is a single call on the stable
   // league_id; Sleeper clears once per per-season id in the recurring group.
   for (const seasonLeagueId of seasonLeagueIds) {
     await sharedStorage.clearStaleDefaultForLeague(userId, platform, seasonLeagueId, undefined, sport);
@@ -1689,7 +1689,7 @@ api.get('/internal/leagues', async (c) => {
 
   const storage = EspnSupabaseStorage.fromEnvironment(c.env);
   // Internal (gateway-facing) endpoint excludes archived leagues so they vanish
-  // from get_user_session and get_ancient_history automatically (D3).
+  // from get_user_session and get_ancient_history automatically.
   const leagues = await storage.getLeagues(clerkUserId, false);
   const leaguesWithPlatform = leagues.map(league => ({
     ...league,
@@ -1747,11 +1747,11 @@ async function handleLeagues(c: Context<{ Bindings: Env }>, method: string): Pro
 
   } else if (method === 'GET') {
     // Public (UI) endpoint returns ALL leagues with an `archived` boolean so the
-    // UI can bucket them into the Archived section (D3). ESPN recurring id = league_id.
+    // UI can bucket them into the Archived section. ESPN recurring id = league_id.
     const leagues = await storage.getLeagues(clerkUserId);
     const archiveStorage = ArchiveStorage.fromEnvironment(env);
     // Annotate path fails OPEN: a transient archive-set error just drops the flag
-    // (the UI loses bucketing) rather than failing the whole league list (audit #10).
+    // (the UI loses bucketing) rather than failing the whole league list.
     let archivedSet: Set<string>;
     try {
       archivedSet = await archiveStorage.getArchivedSet(clerkUserId, 'espn');

--- a/workers/auth-worker/src/sleeper-connect-handlers.ts
+++ b/workers/auth-worker/src/sleeper-connect-handlers.ts
@@ -1,5 +1,5 @@
 import { SleeperStorage, type SleeperLeague } from './sleeper-storage';
-import { ArchiveStorage } from './archive-storage';
+import { ArchiveStorage, archivedKey } from './archive-storage';
 import { getDefaultSeasonYear } from './season-utils';
 
 const SLEEPER_API = 'https://api.sleeper.app/v1';
@@ -209,7 +209,7 @@ async function buildSleeperLeagueResponse(
       recurringLeagueId,
       // Public (UI) responses annotate the archive state so the UI can bucket
       // archived leagues; internal responses omit the flag and exclude the rows.
-      ...(archivedSet ? { archived: archivedSet.has(recurringLeagueId) } : {}),
+      ...(archivedSet ? { archived: archivedSet.has(archivedKey(league.sport, recurringLeagueId)) } : {}),
     };
   }));
 }

--- a/workers/auth-worker/src/sleeper-connect-handlers.ts
+++ b/workers/auth-worker/src/sleeper-connect-handlers.ts
@@ -1,4 +1,5 @@
 import { SleeperStorage, type SleeperLeague } from './sleeper-storage';
+import { ArchiveStorage } from './archive-storage';
 import { getDefaultSeasonYear } from './season-utils';
 
 const SLEEPER_API = 'https://api.sleeper.app/v1';
@@ -36,11 +37,27 @@ interface SleeperLeagueResponse {
   rosterId: number | null;
   seasonYear: number;
   recurringLeagueId: string;
+  archived?: boolean;
 }
 
 interface RecurringLeagueResolutionResult {
   recurringLeagueId?: string;
   failureReason?: string;
+}
+
+/**
+ * Annotate-path archive-set lookup that fails OPEN: a transient DB error treats
+ * nothing as archived (the UI just loses the `archived` flag) rather than failing
+ * the whole league list. The exclude path keeps fail-closed via getSleeperLeagues
+ * letting getArchivedSet's throw propagate (audit #10).
+ */
+async function getArchivedSetFailOpen(env: SleeperConnectEnv, userId: string): Promise<Set<string>> {
+  try {
+    return await ArchiveStorage.fromEnvironment(env).getArchivedSet(userId, 'sleeper');
+  } catch (error) {
+    console.error('[sleeper-connect] getArchivedSet failed; annotating none (fail-open):', error);
+    return new Set();
+  }
 }
 
 function mapSport(sleeperSport: string): string {
@@ -165,7 +182,10 @@ async function resolveRecurringLeagueId(
   return leagueId;
 }
 
-async function buildSleeperLeagueResponse(leagues: SleeperLeague[]): Promise<SleeperLeagueResponse[]> {
+async function buildSleeperLeagueResponse(
+  leagues: SleeperLeague[],
+  archivedSet?: Set<string>
+): Promise<SleeperLeagueResponse[]> {
   const recurringIdCache = new Map<string, string | null>();
   const leagueCache = new Map<string, Promise<SleeperApiLeague | null>>();
   for (const league of leagues) {
@@ -187,8 +207,119 @@ async function buildSleeperLeagueResponse(leagues: SleeperLeague[]): Promise<Sle
       rosterId: league.rosterId,
       seasonYear: league.seasonYear,
       recurringLeagueId,
+      // Public (UI) responses annotate the archive state so the UI can bucket
+      // archived leagues; internal responses omit the flag and exclude the rows.
+      ...(archivedSet ? { archived: archivedSet.has(recurringLeagueId) } : {}),
     };
   }));
+}
+
+/**
+ * Backfill `recurring_league_id` for a user's existing Sleeper rows by re-running
+ * the previous_league_id chain walk (§5/§8.5) — NOT the cheap `= league_id`
+ * shortcut. For each row, resolves the canonical root and persists it via
+ * saveSleeperLeague (which upserts on (clerk_user_id, league_id, season_year) and
+ * tolerates a missing column). Where a chain is genuinely unresolvable, the
+ * resolver already falls back to the season-scoped league_id.
+ *
+ * This is a callable mechanism only; nothing invokes it automatically. Run it
+ * deliberately (e.g. via a one-off route or script) after migration 023 ships.
+ */
+export async function backfillSleeperRecurringIds(
+  env: SleeperConnectEnv,
+  userId: string
+): Promise<{ processed: number; resolved: number }> {
+  const storage = SleeperStorage.fromEnvironment(env);
+  const leagues = await storage.getSleeperLeagues(userId, true);
+
+  const recurringIdCache = new Map<string, string | null>();
+  const leagueCache = new Map<string, Promise<SleeperApiLeague | null>>();
+
+  let processed = 0;
+  let resolved = 0;
+
+  for (const league of leagues) {
+    processed++;
+    const resolution = await tryResolveRecurringLeagueId(league.leagueId, recurringIdCache, leagueCache);
+    // Use the resolved root; only fall back to the season-scoped id when the
+    // chain is genuinely unresolvable (mirrors discovery's safety net).
+    const recurringLeagueId = resolution.recurringLeagueId ?? league.leagueId;
+    if (resolution.recurringLeagueId) resolved++;
+
+    // Skip a write when the stored value already matches the resolved root.
+    if (league.recurringLeagueId === recurringLeagueId) continue;
+
+    await storage.saveSleeperLeague({
+      clerkUserId: userId,
+      leagueId: league.leagueId,
+      sport: league.sport,
+      seasonYear: league.seasonYear,
+      leagueName: league.leagueName,
+      rosterId: league.rosterId,
+      recurringLeagueId,
+      sleeperUserId: league.sleeperUserId,
+    });
+  }
+
+  return { processed, resolved };
+}
+
+/**
+ * Resolve the canonical recurring root for a Sleeper archive write, fresh from
+ * the previous_league_id chain (§8.5 #1) — never persisting a season-scoped
+ * fallback as the archive key when the real root is resolvable. Also returns the
+ * per-season league_ids of the recurring group present in storage, so defaults
+ * can be cleared per per-season id (D6 / §8.5 #3).
+ *
+ * `requestedRecurringId` is the id the UI sent (the displayed recurring id). We
+ * use it to find the group's stored rows, then re-resolve the canonical root from
+ * the freshest (most recent) season's league_id.
+ */
+export async function resolveSleeperArchiveTarget(
+  env: SleeperConnectEnv,
+  userId: string,
+  requestedRecurringId: string
+): Promise<{ recurringLeagueId: string; leagueName?: string; seasonLeagueIds: string[] }> {
+  const storage = SleeperStorage.fromEnvironment(env);
+  const allLeagues = await storage.getSleeperLeagues(userId, true);
+
+  // Rows belonging to this recurring group: either their stored recurring id
+  // matches, or (fallback) their season-scoped league_id equals the requested id.
+  const groupRows = allLeagues.filter((l) => {
+    const stored = l.recurringLeagueId ?? l.leagueId;
+    return stored === requestedRecurringId || l.leagueId === requestedRecurringId;
+  });
+
+  // When groupRows is empty (no stored rows matched the requested id), seasonLeagueIds
+  // falls back to [recurringLeagueId] below — not a season-scoped league_id — so the
+  // default-clear matches nothing. Benign/self-healing per §8.5 #3.
+  const seasonLeagueIds = Array.from(new Set(groupRows.map((l) => l.leagueId)));
+
+  // Re-resolve the canonical root fresh from the most-recent season's league_id
+  // (groupRows are not season-sorted here; pick the max season_year row).
+  const freshest = groupRows.reduce<SleeperLeague | undefined>((best, cur) => {
+    if (!best) return cur;
+    return cur.seasonYear > best.seasonYear ? cur : best;
+  }, undefined);
+
+  let recurringLeagueId = requestedRecurringId;
+  if (freshest) {
+    const recurringIdCache = new Map<string, string | null>();
+    const leagueCache = new Map<string, Promise<SleeperApiLeague | null>>();
+    recurringLeagueId = await resolveRecurringLeagueId(freshest.leagueId, recurringIdCache, leagueCache);
+  }
+
+  // Persist the resolved root onto every row in the group (D2a / §8.5 #1) so the
+  // read-filter's stored key (`recurring_league_id ?? league_id`) equals the archive
+  // key. Without this, a NULL-recurring row keys the filter on its season-scoped
+  // league_id while archive keys on the root, and the archived league leaks back in.
+  // Tolerates the pre-migration missing-column case (persist becomes a no-op).
+  if (seasonLeagueIds.length > 0) {
+    await storage.persistRecurringRoot(userId, seasonLeagueIds, recurringLeagueId);
+  }
+
+  const leagueName = freshest?.leagueName;
+  return { recurringLeagueId, leagueName, seasonLeagueIds };
 }
 
 export async function handleSleeperDiscover(
@@ -336,7 +467,8 @@ export async function handleSleeperStatus(
         headers: { ...corsHeaders, 'Content-Type': 'application/json' },
       });
     }
-    const leagues = await storage.getSleeperLeagues(userId);
+    // Status-card leagueCount excludes archived to match the visible active list (§9).
+    const leagues = await storage.getSleeperLeagues(userId, false);
     return new Response(
       JSON.stringify({
         connected: true,
@@ -380,12 +512,24 @@ export async function handleSleeperDisconnect(
 export async function handleSleeperLeagues(
   env: SleeperConnectEnv,
   userId: string,
-  corsHeaders: Record<string, string>
+  corsHeaders: Record<string, string>,
+  options: { includeArchived?: boolean } = {}
 ): Promise<Response> {
   try {
+    const includeArchived = options.includeArchived ?? true;
     const storage = SleeperStorage.fromEnvironment(env);
-    const leagues = await storage.getSleeperLeagues(userId);
-    const responseLeagues = await buildSleeperLeagueResponse(leagues);
+    // Internal (gateway-facing) callers pass includeArchived:false so archived
+    // leagues are excluded from the AI surfaces (D3). Public (UI) callers keep
+    // the default and annotate each league with an `archived` boolean instead.
+    const leagues = await storage.getSleeperLeagues(userId, includeArchived);
+    // Annotate path (includeArchived:true, public UI) fails OPEN: a transient
+    // archive-set error just drops the `archived` flag rather than 500-ing the list
+    // (audit #10). The exclude path (includeArchived:false) lets getSleeperLeagues
+    // propagate the throw — fail-closed so archived leagues never leak to the AI.
+    const archivedSet = includeArchived
+      ? await getArchivedSetFailOpen(env, userId)
+      : undefined;
+    const responseLeagues = await buildSleeperLeagueResponse(leagues, archivedSet);
     return new Response(
       JSON.stringify({
         leagues: responseLeagues,
@@ -410,8 +554,11 @@ export async function handleSleeperLeagueDelete(
   try {
     const storage = SleeperStorage.fromEnvironment(env);
     await storage.deleteSleeperLeague(userId, leagueId);
+    // Return the public (annotated) list — this feeds the UI directly. Annotate
+    // path fails open on an archive-set error (audit #10).
     const leagues = await storage.getSleeperLeagues(userId);
-    const responseLeagues = await buildSleeperLeagueResponse(leagues);
+    const archivedSet = await getArchivedSetFailOpen(env, userId);
+    const responseLeagues = await buildSleeperLeagueResponse(leagues, archivedSet);
     return new Response(
       JSON.stringify({
         success: true,

--- a/workers/auth-worker/src/sleeper-connect-handlers.ts
+++ b/workers/auth-worker/src/sleeper-connect-handlers.ts
@@ -49,7 +49,8 @@ interface RecurringLeagueResolutionResult {
  * Annotate-path archive-set lookup that fails OPEN: a transient DB error treats
  * nothing as archived (the UI just loses the `archived` flag) rather than failing
  * the whole league list. The exclude path keeps fail-closed via getSleeperLeagues
- * letting getArchivedSet's throw propagate (audit #10).
+ * letting getArchivedSet's throw propagate — a DB error there fails the read
+ * rather than leaking archived leagues to the AI.
  */
 async function getArchivedSetFailOpen(env: SleeperConnectEnv, userId: string): Promise<Set<string>> {
   try {
@@ -216,7 +217,7 @@ async function buildSleeperLeagueResponse(
 
 /**
  * Backfill `recurring_league_id` for a user's existing Sleeper rows by re-running
- * the previous_league_id chain walk (§5/§8.5) — NOT the cheap `= league_id`
+ * the full previous_league_id chain walk — NOT the cheap `= league_id`
  * shortcut. For each row, resolves the canonical root and persists it via
  * saveSleeperLeague (which upserts on (clerk_user_id, league_id, season_year) and
  * tolerates a missing column). Where a chain is genuinely unresolvable, the
@@ -225,6 +226,7 @@ async function buildSleeperLeagueResponse(
  * This is a callable mechanism only; nothing invokes it automatically. Run it
  * deliberately (e.g. via a one-off route or script) after migration 023 ships.
  */
+// TODO(FLA-124): one-off backfill mechanism — wire to an admin route/script after the recurring_league_id migration ships. Intentionally not auto-invoked.
 export async function backfillSleeperRecurringIds(
   env: SleeperConnectEnv,
   userId: string
@@ -266,10 +268,10 @@ export async function backfillSleeperRecurringIds(
 
 /**
  * Resolve the canonical recurring root for a Sleeper archive write, fresh from
- * the previous_league_id chain (§8.5 #1) — never persisting a season-scoped
- * fallback as the archive key when the real root is resolvable. Also returns the
- * per-season league_ids of the recurring group present in storage, so defaults
- * can be cleared per per-season id (D6 / §8.5 #3).
+ * the previous_league_id chain — never persisting a season-scoped fallback as the
+ * archive key when the real root is resolvable. Also returns the per-season
+ * league_ids of the recurring group present in storage, so the matching defaults
+ * can be cleared per per-season id.
  *
  * `requestedRecurringId` is the id the UI sent (the displayed recurring id). We
  * use it to find the group's stored rows, then re-resolve the canonical root from
@@ -292,7 +294,7 @@ export async function resolveSleeperArchiveTarget(
 
   // When groupRows is empty (no stored rows matched the requested id), seasonLeagueIds
   // falls back to [recurringLeagueId] below — not a season-scoped league_id — so the
-  // default-clear matches nothing. Benign/self-healing per §8.5 #3.
+  // default-clear matches nothing. Benign/self-healing.
   const seasonLeagueIds = Array.from(new Set(groupRows.map((l) => l.leagueId)));
 
   // Re-resolve the canonical root fresh from the most-recent season's league_id
@@ -309,7 +311,7 @@ export async function resolveSleeperArchiveTarget(
     recurringLeagueId = await resolveRecurringLeagueId(freshest.leagueId, recurringIdCache, leagueCache);
   }
 
-  // Persist the resolved root onto every row in the group (D2a / §8.5 #1) so the
+  // Persist the resolved root onto every row in the group so the
   // read-filter's stored key (`recurring_league_id ?? league_id`) equals the archive
   // key. Without this, a NULL-recurring row keys the filter on its season-scoped
   // league_id while archive keys on the root, and the archived league leaks back in.
@@ -467,7 +469,7 @@ export async function handleSleeperStatus(
         headers: { ...corsHeaders, 'Content-Type': 'application/json' },
       });
     }
-    // Status-card leagueCount excludes archived to match the visible active list (§9).
+    // Status-card leagueCount excludes archived to match the visible active list.
     const leagues = await storage.getSleeperLeagues(userId, false);
     return new Response(
       JSON.stringify({
@@ -519,12 +521,12 @@ export async function handleSleeperLeagues(
     const includeArchived = options.includeArchived ?? true;
     const storage = SleeperStorage.fromEnvironment(env);
     // Internal (gateway-facing) callers pass includeArchived:false so archived
-    // leagues are excluded from the AI surfaces (D3). Public (UI) callers keep
-    // the default and annotate each league with an `archived` boolean instead.
+    // leagues are excluded from the AI surfaces. Public (UI) callers keep the
+    // default and annotate each league with an `archived` boolean instead.
     const leagues = await storage.getSleeperLeagues(userId, includeArchived);
     // Annotate path (includeArchived:true, public UI) fails OPEN: a transient
-    // archive-set error just drops the `archived` flag rather than 500-ing the list
-    // (audit #10). The exclude path (includeArchived:false) lets getSleeperLeagues
+    // archive-set error just drops the `archived` flag rather than 500-ing the
+    // list. The exclude path (includeArchived:false) lets getSleeperLeagues
     // propagate the throw — fail-closed so archived leagues never leak to the AI.
     const archivedSet = includeArchived
       ? await getArchivedSetFailOpen(env, userId)
@@ -555,7 +557,7 @@ export async function handleSleeperLeagueDelete(
     const storage = SleeperStorage.fromEnvironment(env);
     await storage.deleteSleeperLeague(userId, leagueId);
     // Return the public (annotated) list — this feeds the UI directly. Annotate
-    // path fails open on an archive-set error (audit #10).
+    // path fails open on an archive-set error (drops the flag rather than failing the list).
     const leagues = await storage.getSleeperLeagues(userId);
     const archivedSet = await getArchivedSetFailOpen(env, userId);
     const responseLeagues = await buildSleeperLeagueResponse(leagues, archivedSet);

--- a/workers/auth-worker/src/sleeper-storage.ts
+++ b/workers/auth-worker/src/sleeper-storage.ts
@@ -234,10 +234,12 @@ export class SleeperStorage {
   }
 
   async deleteSleeperLeague(clerkUserId: string, leagueId: string): Promise<void> {
-    // Resolve platform identifiers before deleting (route arg is DB row UUID)
+    // Resolve platform identifiers before deleting (route arg is DB row UUID).
+    // Single read serves both the default-clear (league_id + season_year) and the
+    // archive cleanup (sport + recurring archive key).
     const { data: row, error: lookupError } = await this.supabase
       .from('sleeper_leagues')
-      .select('league_id, season_year')
+      .select('league_id, season_year, recurring_league_id, sport')
       .eq('clerk_user_id', clerkUserId)
       .eq('id', leagueId)
       .maybeSingle();
@@ -250,15 +252,9 @@ export class SleeperStorage {
     // missing recurring_league_id column (pre-migration) by falling back to league_id.
     let archiveRecurringId: { sport: string; recurringLeagueId: string } | null = null;
     if (row) {
-      const { data: recurringRow } = await this.supabase
-        .from('sleeper_leagues')
-        .select('recurring_league_id, sport')
-        .eq('clerk_user_id', clerkUserId)
-        .eq('id', leagueId)
-        .maybeSingle();
       const recurringId =
-        (recurringRow as { recurring_league_id?: string | null } | null)?.recurring_league_id ?? row.league_id;
-      const sport = (recurringRow as { sport?: string } | null)?.sport;
+        (row as { recurring_league_id?: string | null }).recurring_league_id ?? row.league_id;
+      const sport = (row as { sport?: string }).sport;
       if (sport) {
         archiveRecurringId = { sport, recurringLeagueId: recurringId };
       }

--- a/workers/auth-worker/src/sleeper-storage.ts
+++ b/workers/auth-worker/src/sleeper-storage.ts
@@ -1,6 +1,6 @@
 import { createClient } from '@supabase/supabase-js';
 import { clearDefaultsForLeague as _clearDefaultsForLeague, clearDefaultsForPlatform as _clearDefaultsForPlatform } from './preference-defaults';
-import { ArchiveStorage } from './archive-storage';
+import { ArchiveStorage, archivedKey } from './archive-storage';
 
 function maskUserId(userId: string): string {
   if (!userId || userId.length <= 8) return '***';
@@ -134,7 +134,7 @@ export class SleeperStorage {
     const rows = (data as SleeperLeagueRow[]).filter((row) => {
       if (!archivedSet) return true;
       const recurringId = row.recurring_league_id ?? row.league_id;
-      return !archivedSet.has(recurringId);
+      return !archivedSet.has(archivedKey(row.sport, recurringId));
     });
 
     return rows.map((row) => ({

--- a/workers/auth-worker/src/sleeper-storage.ts
+++ b/workers/auth-worker/src/sleeper-storage.ts
@@ -115,7 +115,7 @@ export class SleeperStorage {
    * Retrieve Sleeper leagues for a user.
    * When `includeArchived` is false, rows whose recurring identity
    * (`recurring_league_id ?? league_id`) is in the user's archived set are
-   * excluded (D2). The default (`true`) keeps dedupe/discovery readers unfiltered.
+   * excluded. The default (`true`) keeps dedupe/discovery readers unfiltered.
    */
   async getSleeperLeagues(clerkUserId: string, includeArchived: boolean = true): Promise<SleeperLeague[]> {
     const { data, error } = await this.supabase
@@ -197,8 +197,8 @@ export class SleeperStorage {
   }
 
   /**
-   * Persist the canonical recurring root onto every Sleeper row in a group (D2a /
-   * §8.5 #1). After an archive write resolves the chain root, this writes that root
+   * Persist the canonical recurring root onto every Sleeper row in a group.
+   * After an archive write resolves the chain root, this writes that root
    * into `recurring_league_id` for the given season-scoped `league_id`s, so the
    * STORED column the read-filter keys on (`recurring_league_id ?? league_id`) equals
    * the archive-table key. Without this, a row whose stored column is NULL would key
@@ -273,7 +273,7 @@ export class SleeperStorage {
       await this._clearDefaultsForLeague(clerkUserId, 'sleeper', row.league_id, row.season_year);
     }
 
-    // A true delete also removes the league's archive entry (D8).
+    // A true delete also removes the league's archive entry.
     if (archiveRecurringId) {
       await this.archive.unarchiveLeague(
         clerkUserId,

--- a/workers/auth-worker/src/sleeper-storage.ts
+++ b/workers/auth-worker/src/sleeper-storage.ts
@@ -1,5 +1,6 @@
 import { createClient } from '@supabase/supabase-js';
 import { clearDefaultsForLeague as _clearDefaultsForLeague, clearDefaultsForPlatform as _clearDefaultsForPlatform } from './preference-defaults';
+import { ArchiveStorage } from './archive-storage';
 
 function maskUserId(userId: string): string {
   if (!userId || userId.length <= 8) return '***';
@@ -58,10 +59,12 @@ function isMissingRecurringLeagueIdColumnError(error: SupabaseErrorLike | null |
 
 export class SleeperStorage {
   private supabase;
+  private archive: ArchiveStorage;
   private recurringLeagueIdColumnStatus: 'unknown' | 'available' | 'missing' = 'unknown';
 
   constructor(supabaseUrl: string, supabaseKey: string) {
     this.supabase = createClient(supabaseUrl, supabaseKey);
+    this.archive = new ArchiveStorage(supabaseUrl, supabaseKey);
   }
 
   static fromEnvironment(env: SleeperStorageEnv): SleeperStorage {
@@ -108,7 +111,13 @@ export class SleeperStorage {
     if (error) throw new Error(`Failed to delete Sleeper connection: ${error.message}`);
   }
 
-  async getSleeperLeagues(clerkUserId: string): Promise<SleeperLeague[]> {
+  /**
+   * Retrieve Sleeper leagues for a user.
+   * When `includeArchived` is false, rows whose recurring identity
+   * (`recurring_league_id ?? league_id`) is in the user's archived set are
+   * excluded (D2). The default (`true`) keeps dedupe/discovery readers unfiltered.
+   */
+  async getSleeperLeagues(clerkUserId: string, includeArchived: boolean = true): Promise<SleeperLeague[]> {
     const { data, error } = await this.supabase
       .from('sleeper_leagues')
       .select('*')
@@ -118,7 +127,17 @@ export class SleeperStorage {
     if (error) throw new Error(`Failed to get Sleeper leagues: ${error.message}`);
     if (!data) return [];
 
-    return (data as SleeperLeagueRow[]).map((row) => ({
+    const archivedSet = includeArchived
+      ? null
+      : await this.archive.getArchivedSet(clerkUserId, 'sleeper');
+
+    const rows = (data as SleeperLeagueRow[]).filter((row) => {
+      if (!archivedSet) return true;
+      const recurringId = row.recurring_league_id ?? row.league_id;
+      return !archivedSet.has(recurringId);
+    });
+
+    return rows.map((row) => ({
       id: row.id,
       clerkUserId: row.clerk_user_id,
       leagueId: row.league_id,
@@ -177,6 +196,43 @@ export class SleeperStorage {
     if (legacyError) throw new Error(`Failed to save Sleeper league: ${legacyError.message}`);
   }
 
+  /**
+   * Persist the canonical recurring root onto every Sleeper row in a group (D2a /
+   * §8.5 #1). After an archive write resolves the chain root, this writes that root
+   * into `recurring_league_id` for the given season-scoped `league_id`s, so the
+   * STORED column the read-filter keys on (`recurring_league_id ?? league_id`) equals
+   * the archive-table key. Without this, a row whose stored column is NULL would key
+   * the filter on its season-scoped `league_id` while the archive keys on the root —
+   * and the archived league would leak back into the AI surfaces.
+   *
+   * Tolerates the pre-migration missing-column case (same fallback as saveSleeperLeague):
+   * if the column is absent, the persist is a no-op and the read-filter already falls
+   * back to `league_id`, so callers should archive on the season-scoped id in that case.
+   */
+  async persistRecurringRoot(clerkUserId: string, leagueIds: string[], recurringRoot: string): Promise<void> {
+    if (!clerkUserId || leagueIds.length === 0 || this.recurringLeagueIdColumnStatus === 'missing') return;
+
+    const { error } = await this.supabase
+      .from('sleeper_leagues')
+      .update({ recurring_league_id: recurringRoot, updated_at: new Date().toISOString() })
+      .eq('clerk_user_id', clerkUserId)
+      .in('league_id', leagueIds);
+
+    if (!error) {
+      this.recurringLeagueIdColumnStatus = 'available';
+      return;
+    }
+
+    if (!isMissingRecurringLeagueIdColumnError(error as SupabaseErrorLike)) {
+      throw new Error(`Failed to persist Sleeper recurring root: ${(error as SupabaseErrorLike).message}`);
+    }
+
+    console.warn(
+      `[sleeper-storage] recurring_league_id column unavailable for user ${maskUserId(clerkUserId)}; skipping recurring-root persist (code=${(error as SupabaseErrorLike).code ?? 'unknown'})`
+    );
+    this.recurringLeagueIdColumnStatus = 'missing';
+  }
+
   async deleteSleeperLeague(clerkUserId: string, leagueId: string): Promise<void> {
     // Resolve platform identifiers before deleting (route arg is DB row UUID)
     const { data: row, error: lookupError } = await this.supabase
@@ -190,6 +246,24 @@ export class SleeperStorage {
       console.warn(`[sleeper-storage] Failed to look up Sleeper league ${leagueId} before delete:`, lookupError);
     }
 
+    // Resolve the recurring archive key before the row is gone. Tolerates a
+    // missing recurring_league_id column (pre-migration) by falling back to league_id.
+    let archiveRecurringId: { sport: string; recurringLeagueId: string } | null = null;
+    if (row) {
+      const { data: recurringRow } = await this.supabase
+        .from('sleeper_leagues')
+        .select('recurring_league_id, sport')
+        .eq('clerk_user_id', clerkUserId)
+        .eq('id', leagueId)
+        .maybeSingle();
+      const recurringId =
+        (recurringRow as { recurring_league_id?: string | null } | null)?.recurring_league_id ?? row.league_id;
+      const sport = (recurringRow as { sport?: string } | null)?.sport;
+      if (sport) {
+        archiveRecurringId = { sport, recurringLeagueId: recurringId };
+      }
+    }
+
     const { error } = await this.supabase
       .from('sleeper_leagues')
       .delete()
@@ -201,6 +275,16 @@ export class SleeperStorage {
     // Clear any sport default pointing to this league (keyed by platform league_id + season)
     if (row) {
       await this._clearDefaultsForLeague(clerkUserId, 'sleeper', row.league_id, row.season_year);
+    }
+
+    // A true delete also removes the league's archive entry (D8).
+    if (archiveRecurringId) {
+      await this.archive.unarchiveLeague(
+        clerkUserId,
+        'sleeper',
+        archiveRecurringId.sport as 'football' | 'baseball' | 'basketball' | 'hockey',
+        archiveRecurringId.recurringLeagueId
+      );
     }
   }
 

--- a/workers/auth-worker/src/supabase-storage.ts
+++ b/workers/auth-worker/src/supabase-storage.ts
@@ -16,6 +16,7 @@ import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { EspnCredentials, EspnCredentialsWithMetadata, EspnLeague, EspnUserData } from './espn-types';
 import { isCurrentSeason, type SeasonSport } from './season-utils';
 import { clearDefaultsForLeague as _clearDefaultsForLeague, clearDefaultsForPlatform as _clearDefaultsForPlatform } from './preference-defaults';
+import { ArchiveStorage } from './archive-storage';
 
 /**
  * Mask user ID for logging to avoid PII exposure
@@ -56,9 +57,11 @@ export interface UserPreferences {
 
 export class EspnSupabaseStorage {
   private supabase: SupabaseClient;
+  private archive: ArchiveStorage;
 
   constructor(options: SupabaseStorageOptions) {
     this.supabase = createClient(options.supabaseUrl, options.supabaseKey);
+    this.archive = new ArchiveStorage(options.supabaseUrl, options.supabaseKey);
   }
 
   // =============================================================================
@@ -325,9 +328,13 @@ export class EspnSupabaseStorage {
   }
 
   /**
-   * Retrieve ESPN leagues for a user
+   * Retrieve ESPN leagues for a user.
+   * When `includeArchived` is false, rows whose recurring identity (ESPN uses its
+   * stable `league_id`) is in the user's archived set are excluded (D2). The
+   * default (`true`) keeps dedupe/onboarding/discovery readers unfiltered (D5).
    */
-  async getLeagues(clerkUserId: string): Promise<EspnLeague[]> {
+  async getLeagues(clerkUserId: string, includeArchived: boolean = true): Promise<EspnLeague[]> {
+    let rawRows: { league_id: string; sport: string; team_id: string | null; team_name: string | null; league_name: string | null; season_year: number | null }[];
     try {
       if (!clerkUserId) return [];
 
@@ -337,19 +344,32 @@ export class EspnSupabaseStorage {
         .eq('clerk_user_id', clerkUserId);
 
       if (error || !data) return [];
-
-      return data.map(row => ({
-        leagueId: row.league_id,
-        sport: row.sport as 'football' | 'hockey' | 'baseball' | 'basketball',
-        teamId: row.team_id || undefined,
-        teamName: row.team_name || undefined,
-        leagueName: row.league_name || undefined,
-        seasonYear: row.season_year || undefined,
-      }));
+      rawRows = data;
     } catch (error) {
       console.error('Failed to retrieve ESPN leagues:', error);
       return [];
     }
+
+    // Exclude path (includeArchived:false) fails CLOSED: getArchivedSet throws on a
+    // DB error and we let it propagate rather than returning archived leagues
+    // unfiltered to the AI (audit #10). Annotate/unfiltered callers (default true)
+    // skip this entirely.
+    const archivedSet = includeArchived
+      ? null
+      : await this.archive.getArchivedSet(clerkUserId, 'espn');
+
+    const rows = archivedSet
+      ? rawRows.filter(row => !archivedSet.has(row.league_id))
+      : rawRows;
+
+    return rows.map(row => ({
+      leagueId: row.league_id,
+      sport: row.sport as 'football' | 'hockey' | 'baseball' | 'basketball',
+      teamId: row.team_id || undefined,
+      teamName: row.team_name || undefined,
+      leagueName: row.league_name || undefined,
+      seasonYear: row.season_year || undefined,
+    }));
   }
 
 
@@ -387,11 +407,11 @@ export class EspnSupabaseStorage {
    * Returns leagues where seasonYear matches the current season for their sport.
    * Uses sport-specific rollover logic (America/New_York timezone).
    */
-  async getCurrentSeasonLeagues(clerkUserId: string): Promise<EspnLeague[]> {
+  async getCurrentSeasonLeagues(clerkUserId: string, includeArchived: boolean = false): Promise<EspnLeague[]> {
     try {
       if (!clerkUserId) return [];
 
-      const allLeagues = await this.getLeagues(clerkUserId);
+      const allLeagues = await this.getLeagues(clerkUserId, includeArchived);
 
       // Filter to current season leagues only using sport-specific rollover rules
       return allLeagues.filter(league => {
@@ -493,6 +513,15 @@ export class EspnSupabaseStorage {
       // Clear any stale defaults pointing to this ESPN league for the deleted sport only
       await this.clearStaleDefaultForLeague(clerkUserId, 'espn', leagueId, undefined, sport);
 
+      // A true delete also removes the league's archive entry (D8): deleting then
+      // re-adding returns the league un-archived. ESPN recurring id is league_id.
+      await this.archive.unarchiveLeague(
+        clerkUserId,
+        'espn',
+        sport as 'football' | 'baseball' | 'basketball' | 'hockey',
+        leagueId
+      );
+
       return true;
     } catch (error) {
       console.error('[removeLeague] Failed to remove ESPN league:', error);
@@ -578,6 +607,13 @@ export class EspnSupabaseStorage {
         if (!targetLeague.team_id) {
           return { success: false, error: 'Cannot set default: no team selected for this league' };
         }
+
+        // Reject an archived league as a new default (§9). ESPN recurring id is league_id.
+        // Fail-open on a transient archive-set error: don't block setting a default.
+        const archivedSet = await this.getArchivedSetFailOpen(clerkUserId, 'espn');
+        if (archivedSet.has(leagueId)) {
+          return { success: false, error: 'Cannot set default: league is archived' };
+        }
       } else if (platform === 'yahoo') {
         const { data: targetLeague, error: checkError } = await this.supabase
           .from('yahoo_leagues')
@@ -603,6 +639,16 @@ export class EspnSupabaseStorage {
         if (checkError || !targetLeague) {
           console.error('Sleeper league not found for default:', checkError);
           return { success: false, error: 'League not found' };
+        }
+
+        // Reject an archived league as a new default (§9). Sleeper archive key is
+        // `recurring_league_id ?? league_id` (matches the read-path filter, D2).
+        // Resolve the row's recurring id separately so a missing column (pre-migration)
+        // fails open rather than breaking default validation.
+        const recurringId = await this.resolveSleeperRecurringId(clerkUserId, leagueId, seasonYear);
+        const archivedSet = await this.getArchivedSetFailOpen(clerkUserId, 'sleeper');
+        if (archivedSet.has(recurringId)) {
+          return { success: false, error: 'Cannot set default: league is archived' };
         }
       }
 
@@ -632,6 +678,57 @@ export class EspnSupabaseStorage {
     } catch (error) {
       console.error('Failed to set default league:', error);
       return { success: false, error: 'Internal error' };
+    }
+  }
+
+  /**
+   * Annotate/validation-path wrapper around `getArchivedSet` (which throws on a DB
+   * error to fail-closed for the exclude path). Here we fail-OPEN: a transient
+   * archive-set error treats nothing as archived rather than blocking default
+   * validation. The exclude path (internal `includeArchived:false`) calls
+   * `getArchivedSet` directly and lets the throw propagate (audit #10).
+   */
+  private async getArchivedSetFailOpen(
+    clerkUserId: string,
+    platform: 'espn' | 'yahoo' | 'sleeper'
+  ): Promise<Set<string>> {
+    try {
+      return await this.archive.getArchivedSet(clerkUserId, platform);
+    } catch (error) {
+      console.error('[supabase-storage] getArchivedSet failed; treating as empty (fail-open):', error);
+      return new Set();
+    }
+  }
+
+  /**
+   * Resolve the stored Sleeper recurring id for a season-scoped row, falling back
+   * to the season-scoped `league_id` when the `recurring_league_id` column is
+   * missing (pre-migration) or NULL. Keeps the archive filter key identical to
+   * `getSleeperLeagues` (`recurring_league_id ?? league_id`).
+   */
+  private async resolveSleeperRecurringId(
+    clerkUserId: string,
+    leagueId: string,
+    seasonYear: number
+  ): Promise<string> {
+    try {
+      const { data, error } = await this.supabase
+        .from('sleeper_leagues')
+        .select('recurring_league_id')
+        .eq('clerk_user_id', clerkUserId)
+        .eq('league_id', leagueId)
+        .eq('season_year', seasonYear)
+        .maybeSingle();
+
+      if (error) {
+        // Column missing or other read error — fall back to the season-scoped id.
+        return leagueId;
+      }
+
+      const recurring = (data as { recurring_league_id?: string | null } | null)?.recurring_league_id;
+      return recurring ?? leagueId;
+    } catch {
+      return leagueId;
     }
   }
 

--- a/workers/auth-worker/src/supabase-storage.ts
+++ b/workers/auth-worker/src/supabase-storage.ts
@@ -330,8 +330,8 @@ export class EspnSupabaseStorage {
   /**
    * Retrieve ESPN leagues for a user.
    * When `includeArchived` is false, rows whose recurring identity (ESPN uses its
-   * stable `league_id`) is in the user's archived set are excluded (D2). The
-   * default (`true`) keeps dedupe/onboarding/discovery readers unfiltered (D5).
+   * stable `league_id`) is in the user's archived set are excluded. The default
+   * (`true`) keeps dedupe/onboarding/discovery readers unfiltered.
    */
   async getLeagues(clerkUserId: string, includeArchived: boolean = true): Promise<EspnLeague[]> {
     let rawRows: { league_id: string; sport: string; team_id: string | null; team_name: string | null; league_name: string | null; season_year: number | null }[];
@@ -351,9 +351,9 @@ export class EspnSupabaseStorage {
     }
 
     // Exclude path (includeArchived:false) fails CLOSED: getArchivedSet throws on a
-    // DB error and we let it propagate rather than returning archived leagues
-    // unfiltered to the AI (audit #10). Annotate/unfiltered callers (default true)
-    // skip this entirely.
+    // DB error and we let it propagate rather than leaking archived leagues
+    // unfiltered to the AI. Annotate/unfiltered callers (default true) skip this
+    // entirely.
     const archivedSet = includeArchived
       ? null
       : await this.archive.getArchivedSet(clerkUserId, 'espn');
@@ -513,7 +513,7 @@ export class EspnSupabaseStorage {
       // Clear any stale defaults pointing to this ESPN league for the deleted sport only
       await this.clearStaleDefaultForLeague(clerkUserId, 'espn', leagueId, undefined, sport);
 
-      // A true delete also removes the league's archive entry (D8): deleting then
+      // A true delete also removes the league's archive entry: deleting then
       // re-adding returns the league un-archived. ESPN recurring id is league_id.
       await this.archive.unarchiveLeague(
         clerkUserId,
@@ -608,7 +608,7 @@ export class EspnSupabaseStorage {
           return { success: false, error: 'Cannot set default: no team selected for this league' };
         }
 
-        // Reject an archived league as a new default (§9). ESPN recurring id is league_id.
+        // Reject an archived league as a new default. ESPN recurring id is league_id.
         // Fail-open on a transient archive-set error: don't block setting a default.
         const archivedSet = await this.getArchivedSetFailOpen(clerkUserId, 'espn');
         if (archivedSet.has(archivedKey(sport, leagueId))) {
@@ -641,8 +641,8 @@ export class EspnSupabaseStorage {
           return { success: false, error: 'League not found' };
         }
 
-        // Reject an archived league as a new default (§9). Sleeper archive key is
-        // `recurring_league_id ?? league_id` (matches the read-path filter, D2).
+        // Reject an archived league as a new default. Sleeper archive key is
+        // `recurring_league_id ?? league_id` (matches the read-path filter).
         // Resolve the row's recurring id separately so a missing column (pre-migration)
         // fails open rather than breaking default validation.
         const recurringId = await this.resolveSleeperRecurringId(clerkUserId, leagueId, seasonYear);
@@ -686,7 +686,7 @@ export class EspnSupabaseStorage {
    * error to fail-closed for the exclude path). Here we fail-OPEN: a transient
    * archive-set error treats nothing as archived rather than blocking default
    * validation. The exclude path (internal `includeArchived:false`) calls
-   * `getArchivedSet` directly and lets the throw propagate (audit #10).
+   * `getArchivedSet` directly and lets the throw propagate (fail-closed).
    */
   private async getArchivedSetFailOpen(
     clerkUserId: string,

--- a/workers/auth-worker/src/supabase-storage.ts
+++ b/workers/auth-worker/src/supabase-storage.ts
@@ -16,7 +16,7 @@ import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { EspnCredentials, EspnCredentialsWithMetadata, EspnLeague, EspnUserData } from './espn-types';
 import { isCurrentSeason, type SeasonSport } from './season-utils';
 import { clearDefaultsForLeague as _clearDefaultsForLeague, clearDefaultsForPlatform as _clearDefaultsForPlatform } from './preference-defaults';
-import { ArchiveStorage } from './archive-storage';
+import { ArchiveStorage, archivedKey } from './archive-storage';
 
 /**
  * Mask user ID for logging to avoid PII exposure
@@ -359,7 +359,7 @@ export class EspnSupabaseStorage {
       : await this.archive.getArchivedSet(clerkUserId, 'espn');
 
     const rows = archivedSet
-      ? rawRows.filter(row => !archivedSet.has(row.league_id))
+      ? rawRows.filter(row => !archivedSet.has(archivedKey(row.sport, row.league_id)))
       : rawRows;
 
     return rows.map(row => ({
@@ -611,7 +611,7 @@ export class EspnSupabaseStorage {
         // Reject an archived league as a new default (§9). ESPN recurring id is league_id.
         // Fail-open on a transient archive-set error: don't block setting a default.
         const archivedSet = await this.getArchivedSetFailOpen(clerkUserId, 'espn');
-        if (archivedSet.has(leagueId)) {
+        if (archivedSet.has(archivedKey(sport, leagueId))) {
           return { success: false, error: 'Cannot set default: league is archived' };
         }
       } else if (platform === 'yahoo') {
@@ -647,7 +647,7 @@ export class EspnSupabaseStorage {
         // fails open rather than breaking default validation.
         const recurringId = await this.resolveSleeperRecurringId(clerkUserId, leagueId, seasonYear);
         const archivedSet = await this.getArchivedSetFailOpen(clerkUserId, 'sleeper');
-        if (archivedSet.has(recurringId)) {
+        if (archivedSet.has(archivedKey(sport, recurringId))) {
           return { success: false, error: 'Cannot set default: league is archived' };
         }
       }

--- a/workers/auth-worker/src/supabase-storage.ts
+++ b/workers/auth-worker/src/supabase-storage.ts
@@ -406,6 +406,11 @@ export class EspnSupabaseStorage {
    * Get current season leagues for a user (for default dropdown)
    * Returns leagues where seasonYear matches the current season for their sport.
    * Uses sport-specific rollover logic (America/New_York timezone).
+   *
+   * `includeArchived` defaults to false intentionally: the only callers are the
+   * post-discovery default-league dropdown, which must not surface a league the
+   * user has archived. A freshly discovered league is never archived, so this
+   * default does not hide anything the dropdown should show.
    */
   async getCurrentSeasonLeagues(clerkUserId: string, includeArchived: boolean = false): Promise<EspnLeague[]> {
     try {

--- a/workers/auth-worker/src/supabase-storage.ts
+++ b/workers/auth-worker/src/supabase-storage.ts
@@ -334,7 +334,7 @@ export class EspnSupabaseStorage {
    * (`true`) keeps dedupe/onboarding/discovery readers unfiltered.
    */
   async getLeagues(clerkUserId: string, includeArchived: boolean = true): Promise<EspnLeague[]> {
-    let rawRows: { league_id: string; sport: string; team_id: string | null; team_name: string | null; league_name: string | null; season_year: number | null }[];
+    let rawRows: { league_id: string; sport: string; team_id: string | null; team_name: string | null; league_name: string | null; season_year: number | null }[] = [];
     try {
       if (!clerkUserId) return [];
 

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -1863,7 +1863,9 @@ export async function handleYahooStatus(
     // Public status exposes only coarse, non-secret health for the web UI.
     const [credentials, leagues] = await Promise.all([
       storage.getYahooCredentialHealth(userId),
-      storage.getYahooLeagues(userId),
+      // Exclude archived to match §9 count semantics (inert in 1a, correct once
+      // Yahoo archive ships in 1b).
+      storage.getYahooLeagues(userId, false),
     ]);
     const checkedAtNowMs = Date.now();
 

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -1863,8 +1863,8 @@ export async function handleYahooStatus(
     // Public status exposes only coarse, non-secret health for the web UI.
     const [credentials, leagues] = await Promise.all([
       storage.getYahooCredentialHealth(userId),
-      // Exclude archived to match §9 count semantics (inert in 1a, correct once
-      // Yahoo archive ships in 1b).
+      // Exclude archived to match the visible active-list count semantics (inert
+      // for now since Yahoo has no archived set, correct once Yahoo archive ships).
       storage.getYahooLeagues(userId, false),
     ]);
     const checkedAtNowMs = Date.now();

--- a/workers/auth-worker/src/yahoo-storage.ts
+++ b/workers/auth-worker/src/yahoo-storage.ts
@@ -524,9 +524,15 @@ export class YahooStorage {
   }
 
   /**
-   * Get all Yahoo leagues for a user
+   * Get all Yahoo leagues for a user.
+   *
+   * The `includeArchived` parameter exists for read-path parity with ESPN/Sleeper
+   * (D2), but Yahoo archive is gated to Phase 1b (D9): no `recurring_league_id` is
+   * stored yet, so the archived set is always empty and this method returns all
+   * rows regardless of the flag. Phase 1b will resolve the Yahoo recurring id and
+   * apply the same column-comparison filter.
    */
-  async getYahooLeagues(clerkUserId: string): Promise<YahooLeague[]> {
+  async getYahooLeagues(clerkUserId: string, _includeArchived: boolean = true): Promise<YahooLeague[]> {
     const { data, error } = await this.supabase
       .from('yahoo_leagues')
       .select('id, clerk_user_id, sport, season_year, league_key, league_name, team_id, team_key, team_name')

--- a/workers/auth-worker/src/yahoo-storage.ts
+++ b/workers/auth-worker/src/yahoo-storage.ts
@@ -526,11 +526,11 @@ export class YahooStorage {
   /**
    * Get all Yahoo leagues for a user.
    *
-   * The `includeArchived` parameter exists for read-path parity with ESPN/Sleeper
-   * (D2), but Yahoo archive is gated to Phase 1b (D9): no `recurring_league_id` is
+   * The `includeArchived` parameter exists for read-path parity with ESPN/Sleeper,
+   * but Yahoo archive is deferred to a later phase: no `recurring_league_id` is
    * stored yet, so the archived set is always empty and this method returns all
-   * rows regardless of the flag. Phase 1b will resolve the Yahoo recurring id and
-   * apply the same column-comparison filter.
+   * rows regardless of the flag. A later phase will resolve the Yahoo recurring id
+   * and apply the same column-comparison filter.
    */
   async getYahooLeagues(clerkUserId: string, _includeArchived: boolean = true): Promise<YahooLeague[]> {
     const { data, error } = await this.supabase


### PR DESCRIPTION
## What & why

Phase 1a of manual league archive ([FLA-124](https://linear.app/flaim/issue/FLA-124)). Lets a user archive a recurring league so it is **hidden from the AI's MCP tools** (`get_user_session` and `get_ancient_history`) but stays **visible/restorable** in `/leagues`. Keyed on a stable recurring-league identity so the archive **survives annual re-syncs** — which is what the original "zombie auto-renewing Yahoo league" problem exposed.

This PR ships **ESPN + Sleeper**. Yahoo archive is deliberately gated to Phase 1b (needs `renew`-chain recurring-id resolution); the UI shows no archive action for Yahoo and the backend rejects it server-side.

## How it works

- New `archived_leagues` table keyed on `(clerk_user_id, platform, sport, recurring_league_id)` — a separate table, **not** a column on the season-scoped league rows, so discovery can upsert new seasons without un-archiving.
- Filter at the storage read chokepoint: `/internal/*` endpoints **exclude** archived (so both AI tools lose them); public `/leagues*` endpoints **annotate** an `archived` flag for the UI.
- Internal/exclude path **fails closed** (a DB error fails the read rather than leaking archived leagues to the AI); annotate path fails open.
- Archive write resolves the Sleeper recurring root fresh and persists it onto the rows so the read-filter key and archive key are identical by construction.
- Archiving auto-clears any per-sport default; a true delete also clears the archive row.

## Migrations (NOT yet applied)

`flaim-docs/migrations/022_archived_leagues.sql` and `023_sleeper_recurring_league_id.sql` are authored but not applied. They are additive/idempotent (metadata-only column add, no lock) and **must be applied to Supabase before the workers serve archive traffic** (migrations-first). Until applied, preview MCP archive behavior won't be live.

## Verification

- auth-worker: **363/363 tests**, `tsc --noEmit` clean
- web: `tsc` clean, lint clean, `ui:check` (design tokens) clean
- Reviewed via multi-agent audits: end-to-end AI-exclusion trace (no leak), migration SQL safety, regression blast-radius. Findings (a NULL-recurring leak path, a cross-sport over-hide) were fixed and re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
