### PR TITLE
docs: document league archive (FLA-124)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -28,7 +28,7 @@ Root, web, and workers use `pnpm` via Corepack. The Chrome extension is intentio
 - **Yahoo Client (`/workers/yahoo-client`)**: Internal worker handling all Yahoo Fantasy API calls for all sports (football, baseball, basketball, hockey). Called by fantasy-mcp gateway.
 - **Sleeper Client (`/workers/sleeper-client`)**: Internal worker handling all Sleeper API calls for NFL and NBA (public API, no auth required). Called by fantasy-mcp gateway.
 - **Shared package (`/workers/shared`)**: Common utilities (CORS middleware, auth-fetch helper, types) used by all workers.
-- **Supabase Postgres**: `espn_credentials`, `espn_leagues`, `yahoo_leagues`, `sleeper_connections`, `sleeper_leagues`, `user_preferences` (defaults), `oauth_tokens`, `oauth_codes`, plus deprecated `extension_tokens`/`extension_pairing_codes`.
+- **Supabase Postgres**: `espn_credentials`, `espn_leagues`, `yahoo_leagues`, `sleeper_connections`, `sleeper_leagues`, `archived_leagues` (manual league archive), `user_preferences` (defaults), `oauth_tokens`, `oauth_codes`, plus deprecated `extension_tokens`/`extension_pairing_codes`.
 
 ## Runtime Choices (Next.js)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,9 @@ Follow Keep a Changelog; stamp a version when submitting to directories.
 
 ## [Unreleased]
 
+### League Archive (FLA-124)
+- **Added**: Manual league archive for ESPN and Sleeper. Users can hide a league from the AI's MCP tools (`get_user_session`, `get_ancient_history`) and restore it from a new Archived section in `/leagues`. Archives are keyed on a stable recurring-league identity (`archived_leagues` table) so they survive annual re-syncs; the AI-facing read path fails closed, so a lookup error never leaks an archived league. Yahoo archive is deferred to a later phase.
+
 ## [8.1.0] - 2026-06-10
 
 ### Chrome Extension v1.5.2

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -99,6 +99,28 @@ Notes:
 - New discovery writes persist `recurring_league_id` when the column is available and the full Sleeper history chain resolves successfully.
 - During rollout, auth-worker retries writes without `recurring_league_id` if the live schema does not have the column yet; those legacy or unresolved rows still rely on read-time fallback until they are rediscovered.
 
+### archived_leagues
+Manual league archive (FLA-124). One row per archived recurring league. Archived leagues are hidden from the AI's MCP tools (`get_user_session`, `get_ancient_history`) but remain visible and restorable in `/leagues`.
+
+| Column | Type | Notes |
+|---|---|---|
+| id | uuid | Primary key |
+| clerk_user_id | text | User owner |
+| platform | text | `espn`, `yahoo`, or `sleeper` |
+| sport | text | football/baseball/basketball/hockey |
+| recurring_league_id | text | Stable recurring-league identity (ESPN: `league_id`; Sleeper: `recurring_league_id ?? league_id`; Yahoo reserved for a later phase) |
+| league_name | text | Denormalized name for the Archived UI list (optional) |
+| archived_at | timestamptz | When the league was archived |
+
+Constraints/Indexes:
+- Unique per archived league: `(clerk_user_id, platform, sport, recurring_league_id)`.
+- Index on `clerk_user_id`.
+
+Notes:
+- Keyed on a recurring identity (not a season-scoped row) so an archived league stays archived across annual re-syncs — discovery upserts new season rows without touching this table.
+- Read paths: internal/AI-facing league reads exclude archived rows (fail-closed on a lookup error); public/UI league reads annotate an `archived` flag instead.
+- Phase 1a covers ESPN and Sleeper; Yahoo archive is deferred to a later phase.
+
 ### platform_oauth_states
 Short-lived OAuth state values for platform-connect flows (separate from MCP OAuth state table).
 

--- a/workers/auth-worker/README.md
+++ b/workers/auth-worker/README.md
@@ -102,6 +102,18 @@ Refresh diagnostics are emitted as structured, non-secret `yahoo-connect` log ev
 | `GET /internal/leagues/sleeper` | Internal + Clerk JWT / OAuth / Eval key | Get stored Sleeper leagues for internal workers |
 | `DELETE /leagues/sleeper/:id` | Clerk JWT | Delete a Sleeper league |
 
+### League Archive
+
+Cross-platform manual archive (ESPN + Sleeper; Yahoo deferred to a later phase). Archive state lives in the `archived_leagues` table, keyed on a stable recurring-league identity so it survives re-sync. Archived leagues are **excluded** from the AI-facing `/internal/leagues*` reads and **annotated** with an `archived` flag on the public `/leagues*` reads.
+
+| Endpoint | Auth | Purpose |
+|----------|------|---------|
+| `POST /leagues/archive` | Clerk JWT | Archive a league `{ platform, sport, recurringLeagueId }` (ESPN/Sleeper) |
+| `DELETE /leagues/archive` | Clerk JWT | Unarchive a league (same body) |
+| `GET /leagues/archive` | Clerk JWT | List the user's archived leagues |
+
+The internal (AI-facing) league reads fail closed: if the archive lookup errors, the read fails rather than returning archived leagues unfiltered. The public/UI reads fail open (they just lose the `archived` flag).
+
 ### Extension APIs
 
 | Endpoint | Auth | Purpose |


### PR DESCRIPTION
Phase 1a closeout — repo docs updated to match the shipped league-archive feature (PR #118).

- `docs/DATABASE.md` — adds the `archived_leagues` table (recurring-identity-keyed, with the read-path/exclusion notes)
- `docs/CHANGELOG.md` — `[Unreleased]` entry
- `workers/auth-worker/README.md` — League Archive endpoints + the internal-exclude / public-annotate, fail-closed read behavior
- `docs/ARCHITECTURE.md` — `archived_leagues` added to the Supabase tables list

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
