### PR TITLE
Yahoo league archive — Phase 1b (FLA-124)

### DIFF
--- a/web/app/(site)/leagues/page.tsx
+++ b/web/app/(site)/leagues/page.tsx
@@ -61,6 +61,8 @@ interface YahooLeague {
   teamId?: string;
   teamKey?: string;
   teamName?: string;
+  recurringLeagueId?: string;
+  archived?: boolean;
 }
 
 interface SleeperLeague {
@@ -107,7 +109,7 @@ interface UnifiedLeague {
   // Sleeper-specific
   sleeperId?: string;    // DB UUID for deletion (Sleeper only)
   recurringLeagueId?: string;
-  // Archive state (annotated by the public /leagues* endpoints, ESPN + Sleeper)
+  // Archive state (annotated by the public /leagues* endpoints, ESPN + Yahoo + Sleeper)
   archived?: boolean;
 }
 
@@ -233,6 +235,8 @@ function yahooToUnified(leagues: YahooLeague[], preferences: UserPreferencesStat
       leagueId: l.leagueKey,
       teamId: l.teamId,
       yahooId: l.id,
+      recurringLeagueId: l.recurringLeagueId,
+      archived: l.archived ?? false,
     };
   });
 }
@@ -266,17 +270,18 @@ function sleeperToUnified(
 }
 
 // Resolve the recurring-league archive key for a group: ESPN keys on the stable
-// leagueId; Sleeper keys on its recurring id (falling back to the season league id).
+// leagueId; Sleeper and Yahoo key on their recurring id (falling back to the season
+// league id — for Yahoo that fallback is the season-scoped leagueKey).
 function getArchiveRecurringId(group: UnifiedLeagueGroup): string {
-  if (group.platform === 'sleeper') {
+  if (group.platform === 'sleeper' || group.platform === 'yahoo') {
     const withRecurring = group.seasons.find((s) => s.recurringLeagueId);
     return withRecurring?.recurringLeagueId || group.leagueId;
   }
   return group.leagueId;
 }
 
-// Archive icon-button shared by the active and old league sections. ESPN + Sleeper
-// only — Yahoo archive is deferred to a later phase, so callers only render this for those two.
+// Archive icon-button shared by the active and old league sections.
+// Rendered for all three platforms (ESPN, Yahoo, Sleeper).
 function ArchiveButton({
   group,
   archivingLeagueKey,
@@ -1168,10 +1173,10 @@ function LeaguesPageContent() {
     }
   };
 
-  // Archive/unarchive a league group (ESPN + Sleeper only — Yahoo archive is deferred to a
-  // later phase). Both directions share the flow: resolve key → set loading → fetch → refresh the
-  // affected platform so the `archived` flag re-buckets the group. POST archives (hides
-  // from the AI); DELETE unarchives (restores to the visible/AI surfaces).
+  // Archive/unarchive a league group (ESPN, Yahoo, Sleeper). Both directions share the
+  // flow: resolve key → set loading → fetch → refresh the affected platform so the
+  // `archived` flag re-buckets the group. POST archives (hides from the AI); DELETE
+  // unarchives (restores to the visible/AI surfaces).
   const performArchiveAction = async (group: UnifiedLeagueGroup, action: 'archive' | 'unarchive') => {
     const recurringLeagueId = getArchiveRecurringId(group);
     const actionKey = `${group.platform}:${recurringLeagueId}`;
@@ -1192,6 +1197,8 @@ function LeaguesPageContent() {
       }
       if (group.platform === 'espn') {
         await loadLeagues({ showSpinner: false, shouldApply });
+      } else if (group.platform === 'yahoo') {
+        await loadYahooLeagues(shouldApply);
       } else {
         await loadSleeperLeagues(shouldApply);
       }
@@ -1591,8 +1598,8 @@ function LeaguesPageContent() {
                                 </div>
                               </div>
                               <div className="flex items-center gap-1 shrink-0">
-                                {/* Archive: ESPN + Sleeper only (Yahoo deferred to a later phase). */}
-                                {(group.platform === 'espn' || group.platform === 'sleeper') && (
+                                {/* Archive: all three platforms (ESPN, Yahoo, Sleeper). */}
+                                {(group.platform === 'espn' || group.platform === 'yahoo' || group.platform === 'sleeper') && (
                                   <ArchiveButton
                                     group={group}
                                     archivingLeagueKey={archivingLeagueKey}
@@ -1707,8 +1714,8 @@ function LeaguesPageContent() {
                                       </div>
                                     </div>
                                     <div className="flex items-center gap-1 shrink-0">
-                                      {/* Archive: ESPN + Sleeper only (Yahoo deferred to a later phase). */}
-                                      {(group.platform === 'espn' || group.platform === 'sleeper') && (
+                                      {/* Archive: all three platforms (ESPN, Yahoo, Sleeper). */}
+                                      {(group.platform === 'espn' || group.platform === 'yahoo' || group.platform === 'sleeper') && (
                                         <ArchiveButton
                                           group={group}
                                           archivingLeagueKey={archivingLeagueKey}
@@ -1777,7 +1784,8 @@ function LeaguesPageContent() {
                               const baseKey = `${group.leagueId}-${group.sport}`;
                               const isDeleting =
                                 (group.platform === 'espn' && deletingLeagueKey === baseKey)
-                                || (group.platform === 'sleeper' && deletingSleeperKey === `sleeper:${group.leagueId}`);
+                                || (group.platform === 'sleeper' && deletingSleeperKey === `sleeper:${group.leagueId}`)
+                                || (group.platform === 'yahoo' && deletingLeagueKey === `yahoo:${group.seasons[0]?.yahooId}`);
                               const isArchiving = archivingLeagueKey === `${group.platform}:${getArchiveRecurringId(group)}`;
                               const mostRecentYear = group.seasons[0]?.seasonYear;
 
@@ -1790,7 +1798,7 @@ function LeaguesPageContent() {
                                         {group.leagueName || `League ${group.leagueId}`}
                                       </div>
                                       <div className="text-xs text-muted-foreground/70 break-words">
-                                        {group.platform === 'espn' ? 'ESPN' : 'Sleeper'}
+                                        {group.platform === 'espn' ? 'ESPN' : group.platform === 'yahoo' ? 'Yahoo' : 'Sleeper'}
                                         {mostRecentYear ? ` • Last active: ${mostRecentYear}` : ''}
                                       </div>
                                     </div>
@@ -1816,6 +1824,8 @@ function LeaguesPageContent() {
                                         onClick={() => {
                                           if (group.platform === 'espn') {
                                             handleDeleteLeague(group.leagueId, group.sport);
+                                          } else if (group.platform === 'yahoo') {
+                                            handleDeleteYahooLeagueGroup(group.seasons);
                                           } else {
                                             handleDeleteSleeperLeagueGroup(group.seasons, group.leagueId);
                                           }

--- a/workers/auth-worker/src/__tests__/archive-route.test.ts
+++ b/workers/auth-worker/src/__tests__/archive-route.test.ts
@@ -12,11 +12,16 @@ describe('parseArchiveBody', () => {
     expect(result).toEqual({ ok: true, platform: 'sleeper', sport: 'basketball', recurringLeagueId: '987654321098765432' });
   });
 
-  it('rejects yahoo (not in ARCHIVE_PLATFORMS)', () => {
+  it('accepts a valid yahoo body (Phase 1b — recurring id now resolved)', () => {
     const result = parseArchiveBody({ platform: 'yahoo', sport: 'football', recurringLeagueId: '449.l.123' });
+    expect(result).toEqual({ ok: true, platform: 'yahoo', sport: 'football', recurringLeagueId: '449.l.123' });
+  });
+
+  it('rejects an unsupported platform', () => {
+    const result = parseArchiveBody({ platform: 'cbs', sport: 'football', recurringLeagueId: '123' });
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.error).toContain('yahoo');
+      expect(result.error).toContain('cbs');
     }
   });
 

--- a/workers/auth-worker/src/__tests__/yahoo-archive-resolution.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-archive-resolution.test.ts
@@ -84,6 +84,52 @@ function discoveryResponse(leagueKey: string, season: string, renew: string): un
   };
 }
 
+// Build a bulk discovery response with two NFL leagues in the same game, each
+// carrying its own renew pointer. Used to exercise cross-league chain dedup.
+function twoLeagueDiscoveryResponse(
+  season: string,
+  leagueA: { leagueKey: string; renew: string },
+  leagueB: { leagueKey: string; renew: string }
+): unknown {
+  return {
+    fantasy_content: {
+      users: {
+        count: 1,
+        0: {
+          user: [
+            { guid: 'guid-1' },
+            {
+              games: {
+                count: 1,
+                0: {
+                  game: [
+                    { code: 'nfl', season },
+                    {
+                      leagues: {
+                        count: 2,
+                        0: {
+                          league: [
+                            { league_key: leagueA.leagueKey, name: 'League A', renew: leagueA.renew, renewed: '' },
+                          ],
+                        },
+                        1: {
+                          league: [
+                            { league_key: leagueB.leagueKey, name: 'League B', renew: leagueB.renew, renewed: '' },
+                          ],
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+  };
+}
+
 interface MockStorage {
   getYahooCredentials: ReturnType<typeof vi.fn>;
   getYahooLeagues: ReturnType<typeof vi.fn>;
@@ -165,6 +211,50 @@ describe('Yahoo recurring-id resolution', () => {
       const saved = mockStorage.upsertYahooLeague.mock.calls[0][0];
       // Empty renew on the bulk row → 449.l.99 is treated as the root itself.
       expect(saved.recurringLeagueId).toBe('449.l.99');
+    });
+
+    it('fetches a shared ancestor meta only once across two leagues that share a chain', async () => {
+      // Two 2025 leagues whose renew chains converge on a common ancestor:
+      //   A: 449.l.10 -(423_10)-> 423.l.10 -(308_10)-> 308.l.10 (root, empty renew)
+      //   B: 449.l.20 -(423_20)-> 423.l.20 -(308_10)-> 308.l.10 (same root)
+      // The shared 308.l.10 meta should be fetched exactly once: the metaCache /
+      // recurringIdCache shared across both leagues' walks dedups it.
+      const metaFetchCounts = new Map<string, number>();
+      mockFetch.mockImplementation(async (input) => {
+        const url = String(input);
+        if (url.includes('/users;use_login=1/games/leagues')) {
+          return jsonResponse(
+            twoLeagueDiscoveryResponse(
+              '2025',
+              { leagueKey: '449.l.10', renew: '423_10' },
+              { leagueKey: '449.l.20', renew: '423_20' }
+            )
+          );
+        }
+        const match = url.match(/\/league\/([^?]+)\?format=json$/);
+        if (match) {
+          const key = match[1];
+          metaFetchCounts.set(key, (metaFetchCounts.get(key) ?? 0) + 1);
+          if (key === '423.l.10') return jsonResponse(leagueMeta('423.l.10', '308_10'));
+          if (key === '423.l.20') return jsonResponse(leagueMeta('423.l.20', '308_10'));
+          if (key === '308.l.10') return jsonResponse(leagueMeta('308.l.10', '')); // shared root
+        }
+        return new Response(null, { status: 404 });
+      });
+
+      const res = await handleYahooDiscover(env, 'u', corsHeaders);
+      expect(res.status).toBe(200);
+
+      // Both leagues resolved to the shared root.
+      expect(mockStorage.upsertYahooLeague).toHaveBeenCalledTimes(2);
+      const savedRoots = mockStorage.upsertYahooLeague.mock.calls.map((call) => call[0].recurringLeagueId);
+      expect(savedRoots).toEqual(['308.l.10', '308.l.10']);
+
+      // The shared ancestor meta is fetched exactly once despite two chain walks
+      // reaching it; the per-walk seed covers the first hop of each league.
+      expect(metaFetchCounts.get('308.l.10')).toBe(1);
+      expect(metaFetchCounts.get('423.l.10')).toBe(1);
+      expect(metaFetchCounts.get('423.l.20')).toBe(1);
     });
   });
 

--- a/workers/auth-worker/src/__tests__/yahoo-archive-resolution.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-archive-resolution.test.ts
@@ -1,0 +1,369 @@
+import { beforeEach, describe, expect, it, vi, type MockedFunction } from 'vitest';
+import {
+  handleYahooDiscover,
+  resolveYahooArchiveTarget,
+  type YahooConnectEnv,
+} from '../yahoo-connect-handlers';
+import { YahooStorage } from '../yahoo-storage';
+
+// Mock YahooStorage so no real Supabase client is created and the league/credential
+// reads + writes are controllable per test.
+vi.mock('../yahoo-storage', () => ({
+  REFRESH_COOLDOWN_OWNER_PREFIX: 'cooldown:',
+  YahooStorage: {
+    fromEnvironment: vi.fn(),
+  },
+}));
+
+const mockFetch = vi.fn() as MockedFunction<typeof fetch>;
+vi.stubGlobal('fetch', mockFetch);
+
+const env: YahooConnectEnv = {
+  SUPABASE_URL: 'https://example.supabase.co',
+  SUPABASE_SERVICE_KEY: 'test-key',
+  YAHOO_CLIENT_ID: 'cid',
+  YAHOO_CLIENT_SECRET: 'secret',
+  NODE_ENV: 'test',
+  ENVIRONMENT: 'test',
+};
+
+const corsHeaders = { 'Access-Control-Allow-Origin': '*' };
+
+const YAHOO_API = 'https://fantasysports.yahooapis.com/fantasy/v2';
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+// Build a single-league meta response carrying a `renew` pointer.
+function leagueMeta(leagueKey: string, renew: string): unknown {
+  return { fantasy_content: { league: [{ league_key: leagueKey, renew, renewed: '' }] } };
+}
+
+// Build the bulk discovery response (one NFL league with a renew pointer + team).
+function discoveryResponse(leagueKey: string, season: string, renew: string): unknown {
+  return {
+    fantasy_content: {
+      users: {
+        count: 1,
+        0: {
+          user: [
+            { guid: 'guid-1' },
+            {
+              games: {
+                count: 1,
+                0: {
+                  game: [
+                    { code: 'nfl', season },
+                    {
+                      leagues: {
+                        count: 1,
+                        0: {
+                          league: [
+                            {
+                              league_key: leagueKey,
+                              name: 'Zombie League',
+                              renew,
+                              renewed: '',
+                            },
+                          ],
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+  };
+}
+
+interface MockStorage {
+  getYahooCredentials: ReturnType<typeof vi.fn>;
+  getYahooLeagues: ReturnType<typeof vi.fn>;
+  upsertYahooLeague: ReturnType<typeof vi.fn>;
+  persistYahooRecurringRoot: ReturnType<typeof vi.fn>;
+}
+
+function freshCredentials() {
+  return {
+    clerkUserId: 'u',
+    accessToken: 'token-abc',
+    refreshToken: 'refresh-abc',
+    expiresAt: new Date(Date.now() + 60 * 60 * 1000), // 1h out → no refresh
+    needsRefresh: false,
+  };
+}
+
+describe('Yahoo recurring-id resolution', () => {
+  let mockStorage: MockStorage;
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockStorage = {
+      getYahooCredentials: vi.fn().mockResolvedValue(freshCredentials()),
+      getYahooLeagues: vi.fn().mockResolvedValue([]),
+      upsertYahooLeague: vi.fn().mockResolvedValue('row-id'),
+      persistYahooRecurringRoot: vi.fn().mockResolvedValue(undefined),
+    };
+    (YahooStorage.fromEnvironment as unknown as MockedFunction<typeof YahooStorage.fromEnvironment>)
+      .mockReturnValue(mockStorage as unknown as YahooStorage);
+  });
+
+  // ===========================================================================
+  // handleYahooDiscover — renew-chain walk persists the resolved root
+  // ===========================================================================
+
+  describe('handleYahooDiscover renew chain', () => {
+    it('resolves the chain root and persists it as recurring_league_id', async () => {
+      // Bulk discovery: 2025 league "449.l.10" with renew "423_10" (prior season).
+      // Chain: 449.l.10 -> (renew 423_10) 423.l.10 -> (renew "" ) root.
+      mockFetch.mockImplementation(async (input) => {
+        const url = String(input);
+        if (url.includes('/users;use_login=1/games/leagues')) {
+          return jsonResponse(discoveryResponse('449.l.10', '2025', '423_10'));
+        }
+        if (url === `${YAHOO_API}/league/423.l.10?format=json`) {
+          // Oldest reachable league: empty renew terminates the chain.
+          return jsonResponse(leagueMeta('423.l.10', ''));
+        }
+        return new Response(null, { status: 404 });
+      });
+
+      const res = await handleYahooDiscover(env, 'u', corsHeaders);
+      expect(res.status).toBe(200);
+
+      // The seed renew from the bulk response skips the first meta fetch; only the
+      // prior season (423.l.10) is fetched.
+      expect(mockStorage.upsertYahooLeague).toHaveBeenCalledOnce();
+      const saved = mockStorage.upsertYahooLeague.mock.calls[0][0];
+      expect(saved).toMatchObject({
+        leagueKey: '449.l.10',
+        recurringLeagueId: '423.l.10',
+      });
+    });
+
+    it('falls back to the season-scoped league_key when the chain cannot resolve', async () => {
+      // Bulk discovery has no renew → first meta fetch fails (404) → fallback.
+      mockFetch.mockImplementation(async (input) => {
+        const url = String(input);
+        if (url.includes('/users;use_login=1/games/leagues')) {
+          return jsonResponse(discoveryResponse('449.l.99', '2025', ''));
+        }
+        return new Response(null, { status: 404 });
+      });
+
+      const res = await handleYahooDiscover(env, 'u', corsHeaders);
+      expect(res.status).toBe(200);
+
+      const saved = mockStorage.upsertYahooLeague.mock.calls[0][0];
+      // Empty renew on the bulk row → 449.l.99 is treated as the root itself.
+      expect(saved.recurringLeagueId).toBe('449.l.99');
+    });
+  });
+
+  // ===========================================================================
+  // resolveYahooArchiveTarget — fresh root re-resolution + persist parity
+  // ===========================================================================
+
+  describe('resolveYahooArchiveTarget', () => {
+    it('re-resolves the canonical root fresh when a row was keyed on a fallback id', async () => {
+      // Stored rows keyed on a season-scoped fallback (recurringLeagueId == leagueKey).
+      mockStorage.getYahooLeagues.mockResolvedValue([
+        {
+          id: 'row-2025', clerkUserId: 'u', sport: 'football', seasonYear: 2025,
+          leagueKey: '449.l.10', leagueName: 'Zombie', recurringLeagueId: '449.l.10',
+        },
+        {
+          id: 'row-2024', clerkUserId: 'u', sport: 'football', seasonYear: 2024,
+          leagueKey: '423.l.10', leagueName: 'Zombie', recurringLeagueId: '449.l.10',
+        },
+      ]);
+
+      // Fresh chain from the freshest row (449.l.10): renew 423_10 → 423.l.10 root.
+      mockFetch.mockImplementation(async (input) => {
+        const url = String(input);
+        if (url === `${YAHOO_API}/league/449.l.10?format=json`) {
+          return jsonResponse(leagueMeta('449.l.10', '423_10'));
+        }
+        if (url === `${YAHOO_API}/league/423.l.10?format=json`) {
+          return jsonResponse(leagueMeta('423.l.10', ''));
+        }
+        return new Response(null, { status: 404 });
+      });
+
+      const target = await resolveYahooArchiveTarget(env, 'u', '449.l.10');
+
+      expect(target.recurringLeagueId).toBe('423.l.10');
+      expect(target.seasonLeagueKeys.sort()).toEqual(['423.l.10', '449.l.10']);
+      expect(target.leagueName).toBe('Zombie');
+      // Persists the resolved root onto the group rows so the read-filter key
+      // (recurring_league_id ?? league_key) equals the archive key.
+      expect(mockStorage.persistYahooRecurringRoot).toHaveBeenCalledWith(
+        'u',
+        expect.arrayContaining(['449.l.10', '423.l.10']),
+        '423.l.10',
+      );
+    });
+
+    it('resolves without looping when the renew chain cycles back to a visited key', async () => {
+      // Stored group keyed on a season-scoped fallback so re-resolution runs.
+      mockStorage.getYahooLeagues.mockResolvedValue([
+        {
+          id: 'row-2025', clerkUserId: 'u', sport: 'football', seasonYear: 2025,
+          leagueKey: '449.l.10', leagueName: 'Zombie', recurringLeagueId: '449.l.10',
+        },
+      ]);
+
+      // Chain loops: 449.l.10 -> (renew 423_10) 423.l.10 -> (renew 449_10) 449.l.10.
+      // The visited guard must trip on the second visit to 449.l.10 rather than loop.
+      mockFetch.mockImplementation(async (input) => {
+        const url = String(input);
+        if (url === `${YAHOO_API}/league/449.l.10?format=json`) {
+          return jsonResponse(leagueMeta('449.l.10', '423_10'));
+        }
+        if (url === `${YAHOO_API}/league/423.l.10?format=json`) {
+          return jsonResponse(leagueMeta('423.l.10', '449_10')); // points back → cycle
+        }
+        return new Response(null, { status: 404 });
+      });
+
+      const target = await resolveYahooArchiveTarget(env, 'u', '449.l.10');
+
+      // Cycle → resolution fails → fall back to the freshest row's season-scoped id.
+      // The important assertion is that it returns at all (no infinite loop / hang).
+      expect(target.recurringLeagueId).toBe('449.l.10');
+      expect(mockStorage.persistYahooRecurringRoot).toHaveBeenCalledWith(
+        'u', ['449.l.10'], '449.l.10',
+      );
+    });
+
+    it('terminates and falls back when the renew chain exceeds the depth cap', async () => {
+      mockStorage.getYahooLeagues.mockResolvedValue([
+        {
+          id: 'row', clerkUserId: 'u', sport: 'football', seasonYear: 2025,
+          leagueKey: '1000.l.10', leagueName: 'Zombie', recurringLeagueId: '1000.l.10',
+        },
+      ]);
+
+      // An unbounded descending chain: every league points to the prior game key,
+      // never terminating. The depth cap (MAX_YAHOO_CHAIN_DEPTH) must stop the walk.
+      mockFetch.mockImplementation(async (input) => {
+        const url = String(input);
+        const match = url.match(/\/league\/(\d+)\.l\.10\?format=json$/);
+        if (match) {
+          const gameKey = Number(match[1]);
+          // Always point one game key lower → chain never reaches an empty renew.
+          return jsonResponse(leagueMeta(`${gameKey}.l.10`, `${gameKey - 1}_10`));
+        }
+        return new Response(null, { status: 404 });
+      });
+
+      const target = await resolveYahooArchiveTarget(env, 'u', '1000.l.10');
+
+      // Depth cap trips → fall back to the freshest row's season-scoped id.
+      expect(target.recurringLeagueId).toBe('1000.l.10');
+      expect(mockStorage.persistYahooRecurringRoot).toHaveBeenCalledWith(
+        'u', ['1000.l.10'], '1000.l.10',
+      );
+    });
+
+    it('returns the oldest reachable league when a meta fetch resolves but carries no further renew (§8.5 #2)', async () => {
+      mockStorage.getYahooLeagues.mockResolvedValue([
+        {
+          id: 'row-2025', clerkUserId: 'u', sport: 'football', seasonYear: 2025,
+          leagueKey: '449.l.10', leagueName: 'Zombie', recurringLeagueId: '449.l.10',
+        },
+      ]);
+
+      // Walk: 449.l.10 -> (renew 423_10) 423.l.10 -> (renew 308_10) 308.l.10.
+      // 308.l.10's meta is reachable but its renew is empty → it is the oldest
+      // reachable league and becomes the root. Not a throw, and not the
+      // season-scoped 449.l.10 fallback, since the earlier links resolved.
+      mockFetch.mockImplementation(async (input) => {
+        const url = String(input);
+        if (url === `${YAHOO_API}/league/449.l.10?format=json`) {
+          return jsonResponse(leagueMeta('449.l.10', '423_10'));
+        }
+        if (url === `${YAHOO_API}/league/423.l.10?format=json`) {
+          return jsonResponse(leagueMeta('423.l.10', '308_10'));
+        }
+        if (url === `${YAHOO_API}/league/308.l.10?format=json`) {
+          return jsonResponse(leagueMeta('308.l.10', '')); // oldest reachable
+        }
+        return new Response(null, { status: 404 });
+      });
+
+      const target = await resolveYahooArchiveTarget(env, 'u', '449.l.10');
+
+      // Oldest reachable league_key becomes the root, not the season-scoped fallback.
+      expect(target.recurringLeagueId).toBe('308.l.10');
+      expect(mockStorage.persistYahooRecurringRoot).toHaveBeenCalledWith(
+        'u',
+        ['449.l.10'],
+        '308.l.10',
+      );
+    });
+
+    it('uses the oldest reached league_key as root when a meta fetch 404s mid-walk (§8.5 #2)', async () => {
+      // The walk follows 449 -> 423 -> 308, but 308.l.10's own meta is unreachable
+      // (404 → getYahooLeagueMeta throws). Rather than collapsing to the season-scoped
+      // start (449.l.10), the resolver uses the oldest league it actually reached
+      // (308.l.10) as the root. A consistently-unreachable deep season then yields a
+      // stable root year-over-year, so the archived league does not resurface on the
+      // next re-sync.
+      mockStorage.getYahooLeagues.mockResolvedValue([
+        {
+          id: 'row-2025', clerkUserId: 'u', sport: 'football', seasonYear: 2025,
+          leagueKey: '449.l.10', leagueName: 'Zombie', recurringLeagueId: '449.l.10',
+        },
+      ]);
+
+      mockFetch.mockImplementation(async (input) => {
+        const url = String(input);
+        if (url === `${YAHOO_API}/league/449.l.10?format=json`) {
+          return jsonResponse(leagueMeta('449.l.10', '423_10'));
+        }
+        if (url === `${YAHOO_API}/league/423.l.10?format=json`) {
+          return jsonResponse(leagueMeta('423.l.10', '308_10'));
+        }
+        // 308.l.10 meta is unreachable → getYahooLeagueMeta throws mid-walk.
+        return new Response(null, { status: 404 });
+      });
+
+      const target = await resolveYahooArchiveTarget(env, 'u', '449.l.10');
+
+      // Oldest reached league_key (308.l.10) becomes the root, not the season-scoped
+      // 449.l.10 — and the walk does not throw.
+      expect(target.recurringLeagueId).toBe('308.l.10');
+      expect(mockStorage.persistYahooRecurringRoot).toHaveBeenCalledWith(
+        'u', ['449.l.10'], '308.l.10',
+      );
+    });
+
+    it('falls back to the freshest stored id when no usable token is available', async () => {
+      mockStorage.getYahooCredentials.mockResolvedValue(null);
+      mockStorage.getYahooLeagues.mockResolvedValue([
+        {
+          id: 'row-2025', clerkUserId: 'u', sport: 'football', seasonYear: 2025,
+          leagueKey: '449.l.10', leagueName: 'Zombie', recurringLeagueId: '300.l.10',
+        },
+      ]);
+
+      const target = await resolveYahooArchiveTarget(env, 'u', '300.l.10');
+
+      // No token → keep the freshest row's stored recurring id; no meta fetch.
+      expect(target.recurringLeagueId).toBe('300.l.10');
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(mockStorage.persistYahooRecurringRoot).toHaveBeenCalledWith(
+        'u', ['449.l.10'], '300.l.10',
+      );
+    });
+  });
+});

--- a/workers/auth-worker/src/__tests__/yahoo-archive-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-archive-storage.test.ts
@@ -1,0 +1,346 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { YahooStorage } from '../yahoo-storage';
+
+// Mock Supabase client — each test installs a per-table `from` implementation so
+// the yahoo_leagues read, the archived_leagues read, and the user_preferences
+// read/write can be controlled independently (mirrors sleeper-storage.test.ts).
+const mockFrom = vi.fn();
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({ from: mockFrom }),
+}));
+
+describe('YahooStorage archive surface', () => {
+  let storage: YahooStorage;
+
+  beforeEach(() => {
+    storage = new YahooStorage('https://example.supabase.co', 'test-key');
+    vi.clearAllMocks();
+  });
+
+  // ===========================================================================
+  // getYahooLeagues includeArchived filter — key is recurring_league_id ?? league_key
+  // ===========================================================================
+
+  describe('getYahooLeagues includeArchived', () => {
+    // yahoo_leagues read: .select('*').eq('clerk_user_id', ...)
+    function mockLeaguesRead(rows: unknown[]) {
+      const eq = vi.fn().mockResolvedValue({ data: rows, error: null });
+      return { select: vi.fn().mockReturnValue({ eq }) };
+    }
+    // archived_leagues read: .select('sport, recurring_league_id').eq(user).eq(platform)
+    function mockArchiveRead(ids: (string | [string, string])[]) {
+      const eqPlatform = vi.fn().mockResolvedValue({
+        data: ids.map((entry) =>
+          Array.isArray(entry)
+            ? { sport: entry[0], recurring_league_id: entry[1] }
+            : { sport: 'football', recurring_league_id: entry }
+        ),
+        error: null,
+      });
+      const eqUser = vi.fn().mockReturnValue({ eq: eqPlatform });
+      return { select: vi.fn().mockReturnValue({ eq: eqUser }) };
+    }
+
+    it('excludes a row whose recurring_league_id is archived', async () => {
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'yahoo_leagues') {
+          return mockLeaguesRead([
+            { id: 'a', clerk_user_id: 'u', sport: 'football', season_year: 2025, league_key: '449.l.10', league_name: 'Zombie', team_id: null, team_key: null, team_name: null, recurring_league_id: '300.l.10' },
+            { id: 'b', clerk_user_id: 'u', sport: 'football', season_year: 2025, league_key: '449.l.20', league_name: 'Keep', team_id: null, team_key: null, team_name: null, recurring_league_id: '300.l.20' },
+          ]);
+        }
+        if (table === 'archived_leagues') return mockArchiveRead(['300.l.10']);
+        return {};
+      });
+
+      const result = await storage.getYahooLeagues('u', false);
+      expect(result.map((l) => l.leagueKey)).toEqual(['449.l.20']);
+    });
+
+    it('falls back to league_key when recurring_league_id is null (null-recurring fallback)', async () => {
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'yahoo_leagues') {
+          return mockLeaguesRead([
+            { id: 'a', clerk_user_id: 'u', sport: 'football', season_year: 2025, league_key: '449.l.10', league_name: 'Zombie', team_id: null, team_key: null, team_name: null, recurring_league_id: null },
+            { id: 'b', clerk_user_id: 'u', sport: 'football', season_year: 2025, league_key: '449.l.20', league_name: 'Keep', team_id: null, team_key: null, team_name: null, recurring_league_id: null },
+          ]);
+        }
+        // Archived on the season-scoped fallback key 449.l.10
+        if (table === 'archived_leagues') return mockArchiveRead(['449.l.10']);
+        return {};
+      });
+
+      const result = await storage.getYahooLeagues('u', false);
+      expect(result.map((l) => l.leagueKey)).toEqual(['449.l.20']);
+    });
+
+    it('does NOT over-hide the same recurring id in a different sport (cross-sport no-collision)', async () => {
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'yahoo_leagues') {
+          return mockLeaguesRead([
+            { id: 'a', clerk_user_id: 'u', sport: 'football', season_year: 2025, league_key: '449.l.10', league_name: 'FB', team_id: null, team_key: null, team_name: null, recurring_league_id: 'ROOT' },
+            { id: 'b', clerk_user_id: 'u', sport: 'basketball', season_year: 2025, league_key: '454.l.10', league_name: 'BB', team_id: null, team_key: null, team_name: null, recurring_league_id: 'ROOT' },
+          ]);
+        }
+        if (table === 'archived_leagues') return mockArchiveRead([['football', 'ROOT']]);
+        return {};
+      });
+
+      const result = await storage.getYahooLeagues('u', false);
+      expect(result.map((l) => ({ leagueKey: l.leagueKey, sport: l.sport }))).toEqual([
+        { leagueKey: '454.l.10', sport: 'basketball' },
+      ]);
+    });
+
+    it('fails CLOSED: propagates a thrown archive-set error on the exclude path', async () => {
+      function mockArchiveError() {
+        const eqPlatform = vi.fn().mockResolvedValue({ data: null, error: { message: 'boom' } });
+        const eqUser = vi.fn().mockReturnValue({ eq: eqPlatform });
+        return { select: vi.fn().mockReturnValue({ eq: eqUser }) };
+      }
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'yahoo_leagues') {
+          return mockLeaguesRead([
+            { id: 'a', clerk_user_id: 'u', sport: 'football', season_year: 2025, league_key: '449.l.10', league_name: 'Zombie', team_id: null, team_key: null, team_name: null, recurring_league_id: 'ROOT' },
+          ]);
+        }
+        if (table === 'archived_leagues') return mockArchiveError();
+        return {};
+      });
+
+      await expect(storage.getYahooLeagues('u', false)).rejects.toThrow('Failed to get archived set');
+    });
+
+    it('returns all rows and skips the archive read when includeArchived is true', async () => {
+      const archiveSelect = vi.fn();
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'yahoo_leagues') {
+          return mockLeaguesRead([
+            { id: 'a', clerk_user_id: 'u', sport: 'football', season_year: 2025, league_key: '449.l.10', league_name: 'Zombie', team_id: null, team_key: null, team_name: null, recurring_league_id: 'ROOT' },
+          ]);
+        }
+        if (table === 'archived_leagues') return { select: archiveSelect };
+        return {};
+      });
+
+      const result = await storage.getYahooLeagues('u');
+      expect(result.map((l) => l.leagueKey)).toEqual(['449.l.10']);
+      expect(archiveSelect).not.toHaveBeenCalled();
+    });
+  });
+
+  // ===========================================================================
+  // upsertYahooLeague — recurring_league_id write + missing-column tolerance
+  // ===========================================================================
+
+  describe('upsertYahooLeague recurring_league_id', () => {
+    function mockUpsertChain(impl: () => { data: unknown; error: unknown }) {
+      const single = vi.fn().mockImplementation(async () => impl());
+      const select = vi.fn().mockReturnValue({ single });
+      const upsert = vi.fn().mockReturnValue({ select });
+      return { upsert, select, single };
+    }
+
+    it('persists recurring_league_id when the column is available', async () => {
+      const chain = mockUpsertChain(() => ({ data: { id: 'row-1' }, error: null }));
+      mockFrom.mockReturnValue(chain);
+
+      const id = await storage.upsertYahooLeague({
+        clerkUserId: 'u', sport: 'football', seasonYear: 2025,
+        leagueKey: '449.l.10', leagueName: 'Zombie', recurringLeagueId: '300.l.10',
+      });
+
+      expect(id).toBe('row-1');
+      expect(chain.upsert).toHaveBeenCalledOnce();
+      expect(chain.upsert.mock.calls[0][0]).toMatchObject({
+        league_key: '449.l.10',
+        recurring_league_id: '300.l.10',
+      });
+    });
+
+    it('retries without recurring_league_id when the column is unavailable', async () => {
+      let call = 0;
+      const single = vi.fn().mockImplementation(async () => {
+        call += 1;
+        if (call === 1) {
+          return { data: null, error: { code: '42703', message: 'column yahoo_leagues.recurring_league_id does not exist' } };
+        }
+        return { data: { id: 'row-1' }, error: null };
+      });
+      const select = vi.fn().mockReturnValue({ single });
+      const upsert = vi.fn().mockReturnValue({ select });
+      mockFrom.mockReturnValue({ upsert });
+
+      const id = await storage.upsertYahooLeague({
+        clerkUserId: 'u', sport: 'football', seasonYear: 2025,
+        leagueKey: '449.l.10', leagueName: 'Zombie', recurringLeagueId: '300.l.10',
+      });
+
+      expect(id).toBe('row-1');
+      expect(upsert).toHaveBeenCalledTimes(2);
+      expect(upsert.mock.calls[0][0]).toHaveProperty('recurring_league_id', '300.l.10');
+      expect(upsert.mock.calls[1][0]).not.toHaveProperty('recurring_league_id');
+
+      // Subsequent writes skip the recurring_league_id attempt entirely.
+      upsert.mockClear();
+      await storage.upsertYahooLeague({
+        clerkUserId: 'u', sport: 'football', seasonYear: 2024,
+        leagueKey: '423.l.10', leagueName: 'Zombie', recurringLeagueId: '300.l.10',
+      });
+      expect(upsert).toHaveBeenCalledOnce();
+      expect(upsert.mock.calls[0][0]).not.toHaveProperty('recurring_league_id');
+    });
+
+    it('does not treat unrelated errors as a missing column', async () => {
+      const single = vi.fn().mockResolvedValue({
+        data: null, error: { code: '42501', message: 'permission denied' },
+      });
+      const select = vi.fn().mockReturnValue({ single });
+      const upsert = vi.fn().mockReturnValue({ select });
+      mockFrom.mockReturnValue({ upsert });
+
+      await expect(
+        storage.upsertYahooLeague({
+          clerkUserId: 'u', sport: 'football', seasonYear: 2025,
+          leagueKey: '449.l.10', leagueName: 'Zombie', recurringLeagueId: '300.l.10',
+        })
+      ).rejects.toThrow('Failed to upsert Yahoo league');
+      expect(upsert).toHaveBeenCalledOnce();
+    });
+  });
+
+  // ===========================================================================
+  // persistYahooRecurringRoot — write root + missing-column tolerance
+  // ===========================================================================
+
+  describe('persistYahooRecurringRoot', () => {
+    it('writes the resolved root onto the group rows keyed by league_key', async () => {
+      const inFn = vi.fn().mockResolvedValue({ error: null });
+      const eq = vi.fn().mockReturnValue({ in: inFn });
+      const update = vi.fn().mockReturnValue({ eq });
+      mockFrom.mockReturnValue({ update });
+
+      await storage.persistYahooRecurringRoot('u', ['449.l.10', '423.l.10'], '300.l.10');
+
+      expect(update).toHaveBeenCalledOnce();
+      expect(update.mock.calls[0][0]).toMatchObject({ recurring_league_id: '300.l.10' });
+      expect(eq).toHaveBeenCalledWith('clerk_user_id', 'u');
+      expect(inFn).toHaveBeenCalledWith('league_key', ['449.l.10', '423.l.10']);
+    });
+
+    it('is a no-op when the recurring_league_id column is missing (pre-migration)', async () => {
+      const inFn = vi.fn().mockResolvedValue({
+        error: { code: '42703', message: 'column yahoo_leagues.recurring_league_id does not exist' },
+      });
+      const eq = vi.fn().mockReturnValue({ in: inFn });
+      const update = vi.fn().mockReturnValue({ eq });
+      mockFrom.mockReturnValue({ update });
+
+      await expect(
+        storage.persistYahooRecurringRoot('u', ['449.l.10'], '300.l.10')
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  // ===========================================================================
+  // deleteYahooLeague — D8 archive cleanup + default-clear (per-season league_key)
+  // ===========================================================================
+
+  describe('deleteYahooLeague archive cleanup', () => {
+    it('unarchives the matching (yahoo, sport, recurringId) on a true delete', async () => {
+      const mockArchiveDelete = vi.fn();
+      // Single yahoo_leagues lookup returns league_key/season_year/recurring/sport.
+      const yahooMaybeSingle = vi.fn().mockResolvedValue({
+        data: { league_key: '449.l.10', season_year: 2025, recurring_league_id: '300.l.10', sport: 'baseball' },
+        error: null,
+      });
+      const yahooEq = vi.fn();
+      yahooEq.mockReturnValue({ eq: yahooEq, maybeSingle: yahooMaybeSingle, error: null });
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'yahoo_leagues') {
+          return {
+            select: vi.fn().mockReturnValue({ eq: yahooEq }),
+            delete: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ error: null }) }) }),
+          };
+        }
+        if (table === 'user_preferences') {
+          const prefEq = vi.fn().mockReturnValue({
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: { default_football: null, default_baseball: null, default_basketball: null, default_hockey: null },
+              error: null,
+            }),
+          });
+          return { select: vi.fn().mockReturnValue({ eq: prefEq }), upsert: vi.fn().mockReturnValue({ error: null }) };
+        }
+        if (table === 'archived_leagues') {
+          let calls = 0;
+          const eq = vi.fn();
+          eq.mockImplementation(() => {
+            calls += 1;
+            if (calls >= 4) return Promise.resolve({ error: null });
+            return { eq };
+          });
+          return { delete: mockArchiveDelete.mockReturnValue({ eq }) };
+        }
+        return {};
+      });
+
+      await storage.deleteYahooLeague('u', 'row-uuid');
+
+      expect(mockArchiveDelete).toHaveBeenCalled();
+      const eqMock = mockArchiveDelete.mock.results[0].value.eq;
+      const eqArgs = eqMock.mock.calls.map((c: unknown[]) => c as [string, string]);
+      expect(eqArgs).toContainEqual(['clerk_user_id', 'u']);
+      expect(eqArgs).toContainEqual(['platform', 'yahoo']);
+      expect(eqArgs).toContainEqual(['sport', 'baseball']);
+      expect(eqArgs).toContainEqual(['recurring_league_id', '300.l.10']);
+    });
+
+    it('falls back to league_key for the archive key when recurring_league_id is null', async () => {
+      const mockArchiveDelete = vi.fn();
+      const yahooMaybeSingle = vi.fn().mockResolvedValue({
+        data: { league_key: '449.l.10', season_year: 2025, recurring_league_id: null, sport: 'football' },
+        error: null,
+      });
+      const yahooEq = vi.fn();
+      yahooEq.mockReturnValue({ eq: yahooEq, maybeSingle: yahooMaybeSingle, error: null });
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'yahoo_leagues') {
+          return {
+            select: vi.fn().mockReturnValue({ eq: yahooEq }),
+            delete: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnValue({ error: null }) }) }),
+          };
+        }
+        if (table === 'user_preferences') {
+          const prefEq = vi.fn().mockReturnValue({
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: { default_football: null, default_baseball: null, default_basketball: null, default_hockey: null },
+              error: null,
+            }),
+          });
+          return { select: vi.fn().mockReturnValue({ eq: prefEq }), upsert: vi.fn().mockReturnValue({ error: null }) };
+        }
+        if (table === 'archived_leagues') {
+          let calls = 0;
+          const eq = vi.fn();
+          eq.mockImplementation(() => {
+            calls += 1;
+            if (calls >= 4) return Promise.resolve({ error: null });
+            return { eq };
+          });
+          return { delete: mockArchiveDelete.mockReturnValue({ eq }) };
+        }
+        return {};
+      });
+
+      await storage.deleteYahooLeague('u', 'row-uuid');
+
+      const eqMock = mockArchiveDelete.mock.results[0].value.eq;
+      const eqArgs = eqMock.mock.calls.map((c: unknown[]) => c as [string, string]);
+      expect(eqArgs).toContainEqual(['recurring_league_id', '449.l.10']);
+    });
+  });
+});

--- a/workers/auth-worker/src/index-hono.ts
+++ b/workers/auth-worker/src/index-hono.ts
@@ -56,6 +56,7 @@ import {
   handleYahooDisconnect,
   handleYahooDiscover,
   handleYahooStatus,
+  resolveYahooArchiveTarget,
   YahooConnectEnv,
 } from './yahoo-connect-handlers';
 import { YahooStorage } from './yahoo-storage';
@@ -1110,7 +1111,22 @@ api.get('/leagues/yahoo', async (c) => {
   const storage = YahooStorage.fromEnvironment(c.env);
   const leagues = await storage.getYahooLeagues(userId);
 
-  return c.json({ leagues }, 200);
+  // Public (UI) endpoint: return all rows annotated with an `archived` boolean so
+  // the UI can bucket them. Fail-open on an archive-set error — a transient DB
+  // error just drops the flag rather than failing the whole list (mirrors Sleeper).
+  let archivedSet: Set<string>;
+  try {
+    archivedSet = await ArchiveStorage.fromEnvironment(c.env).getArchivedSet(userId, 'yahoo');
+  } catch (error) {
+    console.error('[index-hono] getArchivedSet (yahoo) failed; annotating none (fail-open):', error);
+    archivedSet = new Set();
+  }
+  const annotated = leagues.map((league) => ({
+    ...league,
+    archived: archivedSet.has(archivedKey(league.sport, league.recurringLeagueId ?? league.leagueKey)),
+  }));
+
+  return c.json({ leagues: annotated }, 200);
 });
 
 api.get('/internal/leagues/yahoo', async (c) => {
@@ -1124,8 +1140,7 @@ api.get('/internal/leagues/yahoo', async (c) => {
 
   const storage = YahooStorage.fromEnvironment(c.env);
   // Internal (gateway-facing) endpoint excludes archived leagues so they vanish
-  // from the AI surfaces. No-op for now (the Yahoo archived set stays empty until
-  // Yahoo archive lands), but prevents a latent leak once Yahoo recurring ids ship.
+  // from the AI surfaces. Yahoo archive is active, so this filter is real.
   const leagues = await storage.getYahooLeagues(userId, false);
 
   return c.json({ leagues }, 200);
@@ -1150,7 +1165,20 @@ api.delete('/leagues/yahoo/:id', async (c) => {
   await storage.deleteYahooLeague(userId, leagueId);
   const leagues = await storage.getYahooLeagues(userId);
 
-  return c.json({ success: true, leagues }, 200);
+  // Annotate the returned list (feeds the UI) with `archived`, fail-open.
+  let archivedSet: Set<string>;
+  try {
+    archivedSet = await ArchiveStorage.fromEnvironment(c.env).getArchivedSet(userId, 'yahoo');
+  } catch (error) {
+    console.error('[index-hono] getArchivedSet (yahoo) failed; annotating none (fail-open):', error);
+    archivedSet = new Set();
+  }
+  const annotated = leagues.map((league) => ({
+    ...league,
+    archived: archivedSet.has(archivedKey(league.sport, league.recurringLeagueId ?? league.leagueKey)),
+  }));
+
+  return c.json({ success: true, leagues: annotated }, 200);
 });
 
 // =============================================================================
@@ -1235,7 +1263,7 @@ api.delete('/leagues/sleeper/:id', async (c) => {
 // LEAGUE ARCHIVE ROUTES (FLA-124)
 // =============================================================================
 
-const ARCHIVE_PLATFORMS: ArchivePlatform[] = ['espn', 'sleeper'];
+const ARCHIVE_PLATFORMS: ArchivePlatform[] = ['espn', 'sleeper', 'yahoo'];
 const ARCHIVE_SPORTS: ArchiveSport[] = ['football', 'baseball', 'basketball', 'hockey'];
 
 // recurringLeagueId allowlist: numeric ESPN/Sleeper ids plus dotted Yahoo-style
@@ -1258,7 +1286,6 @@ export function parseArchiveBody(body: ArchiveRequestBody):
   if (!platform || !sport || !recurringLeagueId) {
     return { ok: false, error: 'platform, sport, and recurringLeagueId are required' };
   }
-  // Yahoo archive is deferred to a later phase: no stable stored recurring id yet.
   if (!ARCHIVE_PLATFORMS.includes(platform as ArchivePlatform)) {
     return { ok: false, error: `Archive is not supported for platform '${platform}'` };
   }
@@ -1293,7 +1320,7 @@ api.get('/leagues/archive', async (c) => {
   return c.json({ leagues }, 200);
 });
 
-// Archive a league (hide it from the AI; survives re-sync). ESPN + Sleeper only (Yahoo deferred to a later phase).
+// Archive a league (hide it from the AI; survives re-sync). ESPN + Yahoo + Sleeper.
 api.post('/leagues/archive', async (c) => {
   const { userId, error: authError } = await getClerkUserId(c.req.raw, c.env);
   if (!userId) {
@@ -1323,6 +1350,13 @@ api.post('/leagues/archive', async (c) => {
     leagueName = target.leagueName;
     // Clear defaults per per-season league_id of the recurring group.
     seasonLeagueIds = target.seasonLeagueIds.length > 0 ? target.seasonLeagueIds : [recurringLeagueId];
+  } else if (platform === 'yahoo') {
+    // Resolve the canonical renew-chain root fresh, then clear defaults per
+    // per-season league_key (Yahoo defaults store league_key as leagueId).
+    const target = await resolveYahooArchiveTarget(c.env as YahooConnectEnv, userId, recurringLeagueId);
+    recurringLeagueId = target.recurringLeagueId;
+    leagueName = target.leagueName;
+    seasonLeagueIds = target.seasonLeagueKeys.length > 0 ? target.seasonLeagueKeys : [recurringLeagueId];
   }
 
   const archived = await archiveStorage.archiveLeague(userId, platform, sport, recurringLeagueId, leagueName);

--- a/workers/auth-worker/src/index-hono.ts
+++ b/workers/auth-worker/src/index-hono.ts
@@ -59,7 +59,7 @@ import {
   resolveYahooArchiveTarget,
   YahooConnectEnv,
 } from './yahoo-connect-handlers';
-import { YahooStorage } from './yahoo-storage';
+import { YahooStorage, type YahooLeague } from './yahoo-storage';
 import { ArchiveStorage, archivedKey, type ArchivePlatform, type ArchiveSport } from './archive-storage';
 import { logSetupSignal, type SetupSignalEvent } from '@flaim/worker-shared';
 import {
@@ -1098,6 +1098,29 @@ api.post('/connect/yahoo/discover', async (c) => {
   );
 });
 
+// Annotate Yahoo league rows with an `archived` boolean so the public (UI)
+// endpoints can bucket them. Fail-open on an archive-set error — a transient DB
+// error just drops the flag rather than failing the whole list (mirrors Sleeper).
+// The archive key uses the canonical recurring root (recurringLeagueId) when set,
+// falling back to the per-season leagueKey.
+async function annotateYahooLeaguesArchived(
+  env: Env,
+  userId: string,
+  leagues: YahooLeague[]
+): Promise<Array<YahooLeague & { archived: boolean }>> {
+  let archivedSet: Set<string>;
+  try {
+    archivedSet = await ArchiveStorage.fromEnvironment(env).getArchivedSet(userId, 'yahoo');
+  } catch (error) {
+    console.error('[index-hono] getArchivedSet (yahoo) failed; annotating none (fail-open):', error);
+    archivedSet = new Set();
+  }
+  return leagues.map((league) => ({
+    ...league,
+    archived: archivedSet.has(archivedKey(league.sport, league.recurringLeagueId ?? league.leagueKey)),
+  }));
+}
+
 // List Yahoo leagues (requires auth)
 api.get('/leagues/yahoo', async (c) => {
   const { userId, error: authError } = await getClerkUserId(c.req.raw, c.env);
@@ -1110,21 +1133,7 @@ api.get('/leagues/yahoo', async (c) => {
 
   const storage = YahooStorage.fromEnvironment(c.env);
   const leagues = await storage.getYahooLeagues(userId);
-
-  // Public (UI) endpoint: return all rows annotated with an `archived` boolean so
-  // the UI can bucket them. Fail-open on an archive-set error — a transient DB
-  // error just drops the flag rather than failing the whole list (mirrors Sleeper).
-  let archivedSet: Set<string>;
-  try {
-    archivedSet = await ArchiveStorage.fromEnvironment(c.env).getArchivedSet(userId, 'yahoo');
-  } catch (error) {
-    console.error('[index-hono] getArchivedSet (yahoo) failed; annotating none (fail-open):', error);
-    archivedSet = new Set();
-  }
-  const annotated = leagues.map((league) => ({
-    ...league,
-    archived: archivedSet.has(archivedKey(league.sport, league.recurringLeagueId ?? league.leagueKey)),
-  }));
+  const annotated = await annotateYahooLeaguesArchived(c.env, userId, leagues);
 
   return c.json({ leagues: annotated }, 200);
 });
@@ -1164,19 +1173,7 @@ api.delete('/leagues/yahoo/:id', async (c) => {
   const storage = YahooStorage.fromEnvironment(c.env);
   await storage.deleteYahooLeague(userId, leagueId);
   const leagues = await storage.getYahooLeagues(userId);
-
-  // Annotate the returned list (feeds the UI) with `archived`, fail-open.
-  let archivedSet: Set<string>;
-  try {
-    archivedSet = await ArchiveStorage.fromEnvironment(c.env).getArchivedSet(userId, 'yahoo');
-  } catch (error) {
-    console.error('[index-hono] getArchivedSet (yahoo) failed; annotating none (fail-open):', error);
-    archivedSet = new Set();
-  }
-  const annotated = leagues.map((league) => ({
-    ...league,
-    archived: archivedSet.has(archivedKey(league.sport, league.recurringLeagueId ?? league.leagueKey)),
-  }));
+  const annotated = await annotateYahooLeaguesArchived(c.env, userId, leagues);
 
   return c.json({ success: true, leagues: annotated }, 200);
 });

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -1966,8 +1966,10 @@ async function refreshAccessToken(
 const YAHOO_FANTASY_API_URL = 'https://fantasysports.yahooapis.com/fantasy/v2';
 
 // Cap the renew-chain walk so a malformed/looping pointer set can't fetch
-// unbounded league metas. Yahoo Fantasy predates the era any real chain would
-// exceed; matches Sleeper's MAX_HISTORY_YEARS intent.
+// unbounded league metas. Yahoo Fantasy Sports has run since ~2001 (~25 NFL
+// seasons), so a real renew chain — one league renewed every year since launch —
+// won't exceed this. The cap only guards against malformed/cyclic pointer data;
+// matches Sleeper's MAX_HISTORY_YEARS intent.
 const MAX_YAHOO_CHAIN_DEPTH = 25;
 
 /**
@@ -2030,6 +2032,10 @@ async function getYahooLeagueMeta(
   const cached = metaCache.get(leagueKey);
   if (cached) return cached;
 
+  // The promise is cached before it settles, so a rejected (non-OK) meta fetch
+  // caches a rejected promise. This is intentional: a second reference to the same
+  // league_key within the same chain walk re-throws consistently instead of
+  // re-fetching, and callers (tryResolveYahooRecurringId) catch it.
   const request = (async (): Promise<YahooLeagueMeta | null> => {
     const url = `${YAHOO_FANTASY_API_URL}/league/${leagueKey}?format=json`;
     const res = await fetch(url, { headers: { Authorization: `Bearer ${accessToken}` } });

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -22,6 +22,7 @@ import {
   YahooStorage,
   type YahooCredentialHealth,
   type YahooCredentials,
+  type YahooLeague,
 } from './yahoo-storage';
 import { getFrontendUrl, resolvePreviewOrigin } from './preview-url';
 import {
@@ -1863,8 +1864,8 @@ export async function handleYahooStatus(
     // Public status exposes only coarse, non-secret health for the web UI.
     const [credentials, leagues] = await Promise.all([
       storage.getYahooCredentialHealth(userId),
-      // Exclude archived to match the visible active-list count semantics (inert
-      // for now since Yahoo has no archived set, correct once Yahoo archive ships).
+      // Exclude archived to match the visible active-list count semantics; Yahoo
+      // now has a real archived set, so this excludes archived recurring groups.
       storage.getYahooLeagues(userId, false),
     ]);
     const checkedAtNowMs = Date.now();
@@ -1964,6 +1965,11 @@ async function refreshAccessToken(
 
 const YAHOO_FANTASY_API_URL = 'https://fantasysports.yahooapis.com/fantasy/v2';
 
+// Cap the renew-chain walk so a malformed/looping pointer set can't fetch
+// unbounded league metas. Yahoo Fantasy predates the era any real chain would
+// exceed; matches Sleeper's MAX_HISTORY_YEARS intent.
+const MAX_YAHOO_CHAIN_DEPTH = 25;
+
 /**
  * Map Yahoo sport codes to our internal sport names
  */
@@ -1982,6 +1988,273 @@ interface DiscoveredYahooLeague {
   teamId: string;
   teamKey: string;
   teamName: string;
+  // Yahoo's prior-season renew pointer (league meta resource) in
+  // `{game_key}_{league_id}` form (empty string at the oldest league). Seeds the
+  // chain walk's first hop. May be absent in some responses.
+  renew?: string;
+}
+
+/**
+ * A renew pointer in Yahoo's `{game_key}_{league_id}` form (e.g. "308_51222").
+ * Reconstruct the prior season's league_key as `{game_key}.l.{league_id}`.
+ * Returns null when the pointer is empty (chain terminator) or malformed.
+ */
+function leagueKeyFromRenew(renew: string | undefined | null): string | null {
+  if (!renew || typeof renew !== 'string') return null;
+  const trimmed = renew.trim();
+  if (!trimmed) return null;
+  const underscore = trimmed.indexOf('_');
+  if (underscore <= 0 || underscore >= trimmed.length - 1) return null;
+  const gameKey = trimmed.slice(0, underscore);
+  const leagueId = trimmed.slice(underscore + 1);
+  if (!gameKey || !leagueId) return null;
+  return `${gameKey}.l.${leagueId}`;
+}
+
+interface YahooLeagueMeta {
+  leagueKey: string;
+  renew?: string;
+}
+
+/**
+ * Fetch a single Yahoo league's meta resource (`/league/{league_key}`) and
+ * extract its `league_key` + `renew` pointer. Cached per chain walk so a shared
+ * season is not re-fetched. Returns null on a non-OK response or unparseable body
+ * (treated as an unresolvable link by the caller).
+ */
+async function getYahooLeagueMeta(
+  leagueKey: string,
+  accessToken: string,
+  metaCache: Map<string, Promise<YahooLeagueMeta | null>>
+): Promise<YahooLeagueMeta | null> {
+  const cached = metaCache.get(leagueKey);
+  if (cached) return cached;
+
+  const request = (async (): Promise<YahooLeagueMeta | null> => {
+    const url = `${YAHOO_FANTASY_API_URL}/league/${leagueKey}?format=json`;
+    const res = await fetch(url, { headers: { Authorization: `Bearer ${accessToken}` } });
+    if (!res.ok) {
+      throw new Error(`Yahoo API ${res.status} while resolving ${leagueKey}`);
+    }
+    const data = await res.json();
+    return parseYahooLeagueMeta(data, leagueKey);
+  })();
+
+  metaCache.set(leagueKey, request);
+  return request;
+}
+
+/**
+ * Parse the renew pointer (and confirm the league_key) out of Yahoo's nested
+ * single-league meta response. Defensive: `renew` may be absent.
+ *
+ * Shape: { fantasy_content: { league: [ { league_key, renew, renewed, ... } ] } }
+ */
+function parseYahooLeagueMeta(data: unknown, fallbackLeagueKey: string): YahooLeagueMeta | null {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const leagueArray = (data as any)?.fantasy_content?.league;
+    if (!Array.isArray(leagueArray) || leagueArray.length < 1) {
+      return { leagueKey: fallbackLeagueKey };
+    }
+    const info = leagueArray[0];
+    const leagueKey = typeof info?.league_key === 'string' ? info.league_key : fallbackLeagueKey;
+    const renew = typeof info?.renew === 'string' ? info.renew : undefined;
+    return { leagueKey, renew };
+  } catch {
+    return { leagueKey: fallbackLeagueKey };
+  }
+}
+
+interface YahooRecurringResolutionResult {
+  recurringLeagueId?: string;
+  failureReason?: string;
+}
+
+/**
+ * Walk Yahoo's renew chain to the oldest reachable league (the recurring root),
+ * mirroring Sleeper's tryResolveRecurringLeagueId. Starting from `leagueKey`:
+ * read its `renew` pointer → reconstruct the prior `league_key` → fetch its meta →
+ * repeat until `renew` is empty. The root = oldest reachable `league_key`.
+ *
+ * Includes a fetch cache, a `visited` cycle guard, and a depth cap. When the first
+ * league's `renew` is already known (from the bulk discovery response), `seedRenew`
+ * skips the initial extra meta fetch.
+ */
+async function tryResolveYahooRecurringId(
+  leagueKey: string,
+  accessToken: string,
+  cache: Map<string, string | null>,
+  metaCache: Map<string, Promise<YahooLeagueMeta | null>>,
+  seedRenew?: string
+): Promise<YahooRecurringResolutionResult> {
+  const path: string[] = [];
+  const visited = new Set<string>();
+  let currentLeagueKey: string | null = leagueKey;
+  let pendingRenew: string | undefined = seedRenew;
+  let usedSeed = seedRenew !== undefined;
+
+  while (currentLeagueKey) {
+    if (cache.has(currentLeagueKey)) {
+      const cached = cache.get(currentLeagueKey) ?? null;
+      for (const pathKey of path) cache.set(pathKey, cached);
+      return cached
+        ? { recurringLeagueId: cached }
+        : { failureReason: `unresolved recurring chain at ${currentLeagueKey}` };
+    }
+
+    if (visited.has(currentLeagueKey)) {
+      for (const pathKey of path) cache.set(pathKey, null);
+      return { failureReason: `detected recurring league cycle at ${currentLeagueKey}` };
+    }
+
+    if (path.length >= MAX_YAHOO_CHAIN_DEPTH) {
+      for (const pathKey of path) cache.set(pathKey, null);
+      return { failureReason: `recurring chain exceeded depth cap at ${currentLeagueKey}` };
+    }
+
+    visited.add(currentLeagueKey);
+    path.push(currentLeagueKey);
+
+    try {
+      // Use the seeded renew for the first hop when available; otherwise fetch meta.
+      let renew: string | undefined;
+      if (usedSeed) {
+        renew = pendingRenew;
+        usedSeed = false;
+      } else {
+        const meta = await getYahooLeagueMeta(currentLeagueKey, accessToken, metaCache);
+        if (!meta) {
+          for (const pathKey of path) cache.set(pathKey, null);
+          return { failureReason: `Yahoo returned no meta while resolving ${currentLeagueKey}` };
+        }
+        renew = meta.renew;
+      }
+
+      const priorKey = leagueKeyFromRenew(renew);
+      if (!priorKey) {
+        // Empty/absent renew → this is the oldest reachable league (the root).
+        for (const pathKey of path) cache.set(pathKey, currentLeagueKey);
+        return { recurringLeagueId: currentLeagueKey };
+      }
+
+      currentLeagueKey = priorKey;
+      pendingRenew = undefined;
+    } catch {
+      // Mid-walk meta fetch failed: use the oldest league we actually reached as
+      // the root rather than collapsing to the season-scoped start key. A season
+      // that is consistently unreachable (e.g. token can't read deep history) then
+      // yields a stable root year-over-year, so an archived league does not
+      // resurface on the next re-sync (§8.5 #2). At the first hop currentLeagueKey
+      // is still the season-scoped start, so this is never worse than the old
+      // fallback. (Cycle/depth-cap below remain hard fallbacks.)
+      for (const pathKey of path) cache.set(pathKey, currentLeagueKey);
+      return { recurringLeagueId: currentLeagueKey };
+    }
+  }
+
+  return { failureReason: `unresolved recurring chain at ${leagueKey}` };
+}
+
+/**
+ * Resolve the Yahoo recurring root for `leagueKey`, falling back to the
+ * season-scoped `league_key` when the renew chain can't resolve (mirrors
+ * Sleeper's resolveRecurringLeagueId safety net). Never throws.
+ */
+async function resolveYahooRecurringId(
+  leagueKey: string,
+  accessToken: string,
+  cache: Map<string, string | null>,
+  metaCache: Map<string, Promise<YahooLeagueMeta | null>>,
+  seedRenew?: string
+): Promise<string> {
+  const resolution = await tryResolveYahooRecurringId(leagueKey, accessToken, cache, metaCache, seedRenew);
+  if (resolution.recurringLeagueId) return resolution.recurringLeagueId;
+
+  console.warn(
+    `[yahoo-connect] Falling back to season-scoped league_key ${leagueKey} for recurring grouping: ${resolution.failureReason ?? 'unresolved recurring chain'}`
+  );
+  return leagueKey;
+}
+
+/**
+ * Resolve the canonical recurring root for a Yahoo archive write, fresh from the
+ * renew chain — never persisting a season-scoped fallback as the archive key when
+ * the real root is resolvable. Also returns the group's per-season `league_key`s
+ * (for default-clear) and persists the resolved root onto those rows so the
+ * read-filter's stored key (`recurring_league_id ?? league_key`) equals the
+ * archive key. Mirrors resolveSleeperArchiveTarget.
+ *
+ * `requestedRecurringId` is the id the UI sent (the displayed recurring id or a
+ * season-scoped league_key). Used to locate the group's stored rows; the canonical
+ * root is re-resolved from the freshest (most-recent season) row's league_key.
+ */
+export async function resolveYahooArchiveTarget(
+  env: YahooConnectEnv,
+  userId: string,
+  requestedRecurringId: string
+): Promise<{ recurringLeagueId: string; leagueName?: string; seasonLeagueKeys: string[] }> {
+  const storage = YahooStorage.fromEnvironment(env);
+  const allLeagues = await storage.getYahooLeagues(userId, true);
+
+  // Rows in this recurring group: stored recurring id matches, or (fallback) the
+  // season-scoped league_key equals the requested id.
+  const groupRows = allLeagues.filter((l) => {
+    const stored = l.recurringLeagueId ?? l.leagueKey;
+    return stored === requestedRecurringId || l.leagueKey === requestedRecurringId;
+  });
+
+  const seasonLeagueKeys = Array.from(new Set(groupRows.map((l) => l.leagueKey)));
+
+  // Re-resolve the canonical root fresh from the most-recent season's league_key.
+  const freshest = groupRows.reduce<YahooLeague | undefined>((best, cur) => {
+    if (!best) return cur;
+    return cur.seasonYear > best.seasonYear ? cur : best;
+  }, undefined);
+
+  let recurringLeagueId = requestedRecurringId;
+  if (freshest) {
+    // Re-resolution needs the user's access token; resolve it fresh (with refresh).
+    const accessToken = await getYahooAccessTokenForResolution(storage, env, userId);
+    if (accessToken) {
+      const cache = new Map<string, string | null>();
+      const metaCache = new Map<string, Promise<YahooLeagueMeta | null>>();
+      recurringLeagueId = await resolveYahooRecurringId(freshest.leagueKey, accessToken, cache, metaCache);
+    } else {
+      // No usable token → fall back to the freshest row's stored id (or league_key).
+      recurringLeagueId = freshest.recurringLeagueId ?? freshest.leagueKey;
+    }
+  }
+
+  // Persist the resolved root onto every row in the group so the read-filter's
+  // stored key equals the archive key (tolerates the pre-migration missing column).
+  if (seasonLeagueKeys.length > 0) {
+    await storage.persistYahooRecurringRoot(userId, seasonLeagueKeys, recurringLeagueId);
+  }
+
+  return { recurringLeagueId, leagueName: freshest?.leagueName, seasonLeagueKeys };
+}
+
+/**
+ * Resolve a usable Yahoo access token for recurring-id resolution, refreshing if
+ * needed. Returns null when no credentials exist or the refresh fails — callers
+ * fall back to the stored/season-scoped id rather than throwing.
+ */
+async function getYahooAccessTokenForResolution(
+  storage: YahooStorage,
+  env: YahooConnectEnv,
+  userId: string
+): Promise<string | null> {
+  const credentials = await storage.getYahooCredentials(userId);
+  if (!credentials) return null;
+  if (!credentials.needsRefresh) return credentials.accessToken;
+
+  const tokenResult = await getValidYahooAccessToken(storage, userId, env, credentials, undefined, 'clerk');
+  if ('error' in tokenResult) {
+    console.warn(`[yahoo-connect] Could not refresh token for recurring-id resolution (user ${maskUserId(userId)}): ${tokenResult.error}`);
+    return null;
+  }
+  return tokenResult.accessToken;
 }
 
 /**
@@ -2082,8 +2355,32 @@ export async function handleYahooDiscover(
 
     console.log(`[yahoo-connect] Discovered ${leagues.length} leagues for user ${maskUserId(userId)}`);
 
+    // Resolve each league's recurring root (renew-chain walk) and persist it onto
+    // the row, tolerating a missing column (pre-migration) exactly like Sleeper.
+    // A shared cache de-dupes meta fetches across leagues that share a chain.
+    const recurringIdCache = new Map<string, string | null>();
+    const metaCache = new Map<string, Promise<YahooLeagueMeta | null>>();
+
     // Save leagues to storage
     for (const league of leagues) {
+      let recurringLeagueId: string | undefined;
+      try {
+        recurringLeagueId = await resolveYahooRecurringId(
+          league.leagueKey,
+          accessToken,
+          recurringIdCache,
+          metaCache,
+          league.renew
+        );
+      } catch (error) {
+        // resolveYahooRecurringId never throws, but guard discovery regardless:
+        // persist without a recurring id rather than failing the whole sync.
+        console.warn(
+          `[yahoo-connect] Recurring-id resolution failed for ${league.leagueKey}; saving without it:`,
+          error
+        );
+      }
+
       await storage.upsertYahooLeague({
         clerkUserId: userId,
         sport: league.sport,
@@ -2093,6 +2390,7 @@ export async function handleYahooDiscover(
         teamId: league.teamId,
         teamKey: league.teamKey,
         teamName: league.teamName,
+        recurringLeagueId,
       });
     }
 
@@ -2214,6 +2512,11 @@ function parseYahooLeaguesResponse(data: unknown): DiscoveredYahooLeague[] {
 
           if (!leagueKey || !leagueName) continue;
 
+          // Capture Yahoo's prior-season renew pointer when present in the bulk
+          // response. `renew` lets the chain walk skip the first per-league meta
+          // fetch; it's defensive (absent in some payloads).
+          const renew = typeof leagueInfo?.renew === 'string' ? leagueInfo.renew : undefined;
+
           // Extract team ID and team name from the league data
           // Yahoo API includes the user's team in the league response
           let teamId = '';
@@ -2258,6 +2561,7 @@ function parseYahooLeaguesResponse(data: unknown): DiscoveredYahooLeague[] {
             teamId,
             teamKey: resolvedTeamKey,
             teamName,
+            renew,
           });
         }
       }

--- a/workers/auth-worker/src/yahoo-storage.ts
+++ b/workers/auth-worker/src/yahoo-storage.ts
@@ -15,6 +15,7 @@
 
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { clearDefaultsForLeague as _clearDefaultsForLeague, clearDefaultsForPlatform as _clearDefaultsForPlatform } from './preference-defaults';
+import { ArchiveStorage, archivedKey } from './archive-storage';
 
 export const REFRESH_COOLDOWN_OWNER_PREFIX = 'cooldown:';
 
@@ -85,6 +86,7 @@ export interface YahooLeague {
   teamId?: string;
   teamKey?: string;
   teamName?: string;
+  recurringLeagueId?: string;
 }
 
 export interface SaveLeagueParams {
@@ -96,6 +98,23 @@ export interface SaveLeagueParams {
   teamId?: string;
   teamKey?: string;
   teamName?: string;
+  recurringLeagueId?: string;
+}
+
+interface SupabaseErrorLike {
+  code?: string;
+  message?: string;
+  details?: string;
+  hint?: string;
+}
+
+/**
+ * Treat a missing `recurring_league_id` column (pre-migration) or a stale
+ * PostgREST schema cache as tolerable: discovery/archive writes fall back to a
+ * payload without the column, exactly like Sleeper.
+ */
+function isMissingRecurringLeagueIdColumnError(error: SupabaseErrorLike | null | undefined): boolean {
+  return error?.code === '42703' || error?.code === 'PGRST204';
 }
 
 // =============================================================================
@@ -136,9 +155,12 @@ function yahooCredentialUpdateData(params: UpdateCredentialsParams): Record<stri
 
 export class YahooStorage {
   private supabase: SupabaseClient;
+  private archive: ArchiveStorage;
+  private recurringLeagueIdColumnStatus: 'unknown' | 'available' | 'missing' = 'unknown';
 
   constructor(supabaseUrl: string, supabaseKey: string) {
     this.supabase = createClient(supabaseUrl, supabaseKey);
+    this.archive = new ArchiveStorage(supabaseUrl, supabaseKey);
   }
 
   // ---------------------------------------------------------------------------
@@ -496,46 +518,112 @@ export class YahooStorage {
    * Returns the league ID
    */
   async upsertYahooLeague(params: SaveLeagueParams): Promise<string> {
+    const basePayload = {
+      clerk_user_id: params.clerkUserId,
+      sport: params.sport,
+      season_year: params.seasonYear,
+      league_key: params.leagueKey,
+      league_name: params.leagueName,
+      team_id: params.teamId || null,
+      team_key: params.teamKey || null,
+      team_name: params.teamName || null,
+      updated_at: new Date().toISOString(),
+    };
+
+    // Persist recurring_league_id when present and the column is available.
+    // Tolerates a missing column (pre-migration) by retrying without it — mirrors
+    // Sleeper's saveSleeperLeague so a NULL-recurring row keys the read-filter on
+    // its season-scoped league_key until backfill/archive resolves the real root.
+    if (params.recurringLeagueId && this.recurringLeagueIdColumnStatus !== 'missing') {
+      const result = await this.upsertYahooLeagueRow({
+        ...basePayload,
+        recurring_league_id: params.recurringLeagueId,
+      });
+
+      if (!result.error) {
+        this.recurringLeagueIdColumnStatus = 'available';
+        return result.id;
+      }
+
+      if (!isMissingRecurringLeagueIdColumnError(result.error)) {
+        console.error('[yahoo-storage] Failed to upsert Yahoo league:', result.error);
+        throw new Error('Failed to upsert Yahoo league');
+      }
+
+      console.warn(
+        `[yahoo-storage] recurring_league_id column unavailable for user ${maskUserId(params.clerkUserId)} league ${params.leagueKey}; retrying without it (code=${result.error.code ?? 'unknown'})`
+      );
+      this.recurringLeagueIdColumnStatus = 'missing';
+    }
+
+    const legacy = await this.upsertYahooLeagueRow(basePayload);
+    if (legacy.error) {
+      console.error('[yahoo-storage] Failed to upsert Yahoo league:', legacy.error);
+      throw new Error('Failed to upsert Yahoo league');
+    }
+    return legacy.id;
+  }
+
+  private async upsertYahooLeagueRow(
+    payload: Record<string, unknown>
+  ): Promise<{ id: string; error: null } | { id: ''; error: SupabaseErrorLike }> {
     const { data, error } = await this.supabase
       .from('yahoo_leagues')
-      .upsert(
-        {
-          clerk_user_id: params.clerkUserId,
-          sport: params.sport,
-          season_year: params.seasonYear,
-          league_key: params.leagueKey,
-          league_name: params.leagueName,
-          team_id: params.teamId || null,
-          team_key: params.teamKey || null,
-          team_name: params.teamName || null,
-          updated_at: new Date().toISOString(),
-        },
-        { onConflict: 'clerk_user_id,league_key,season_year' }
-      )
+      .upsert(payload, { onConflict: 'clerk_user_id,league_key,season_year' })
       .select('id')
       .single();
 
     if (error) {
-      console.error('[yahoo-storage] Failed to upsert Yahoo league:', error);
-      throw new Error('Failed to upsert Yahoo league');
+      return { id: '', error: error as SupabaseErrorLike };
+    }
+    return { id: data.id, error: null };
+  }
+
+  /**
+   * Persist the canonical recurring root onto every Yahoo row in a group.
+   * After an archive write resolves the renew-chain root, this writes that root
+   * into `recurring_league_id` for the given season-scoped `league_key`s, so the
+   * STORED column the read-filter keys on (`recurring_league_id ?? league_key`)
+   * equals the archive-table key (mirrors Sleeper's persistRecurringRoot).
+   * Tolerates the pre-migration missing-column case as a no-op.
+   */
+  async persistYahooRecurringRoot(clerkUserId: string, leagueKeys: string[], recurringRoot: string): Promise<void> {
+    if (!clerkUserId || leagueKeys.length === 0 || this.recurringLeagueIdColumnStatus === 'missing') return;
+
+    const { error } = await this.supabase
+      .from('yahoo_leagues')
+      .update({ recurring_league_id: recurringRoot, updated_at: new Date().toISOString() })
+      .eq('clerk_user_id', clerkUserId)
+      .in('league_key', leagueKeys);
+
+    if (!error) {
+      this.recurringLeagueIdColumnStatus = 'available';
+      return;
     }
 
-    return data.id;
+    if (!isMissingRecurringLeagueIdColumnError(error as SupabaseErrorLike)) {
+      throw new Error(`Failed to persist Yahoo recurring root: ${(error as SupabaseErrorLike).message}`);
+    }
+
+    console.warn(
+      `[yahoo-storage] recurring_league_id column unavailable for user ${maskUserId(clerkUserId)}; skipping recurring-root persist (code=${(error as SupabaseErrorLike).code ?? 'unknown'})`
+    );
+    this.recurringLeagueIdColumnStatus = 'missing';
   }
 
   /**
    * Get all Yahoo leagues for a user.
    *
-   * The `includeArchived` parameter exists for read-path parity with ESPN/Sleeper,
-   * but Yahoo archive is deferred to a later phase: no `recurring_league_id` is
-   * stored yet, so the archived set is always empty and this method returns all
-   * rows regardless of the flag. A later phase will resolve the Yahoo recurring id
-   * and apply the same column-comparison filter.
+   * When `includeArchived` is false, rows whose recurring identity
+   * (`recurring_league_id ?? league_key`) is in the user's archived set are
+   * excluded. The default (`true`) keeps dedupe/discovery readers unfiltered.
+   * Mirrors getSleeperLeagues; the season-scoped `league_key` is the fallback key
+   * (Yahoo's analogue of Sleeper's per-season `league_id`).
    */
-  async getYahooLeagues(clerkUserId: string, _includeArchived: boolean = true): Promise<YahooLeague[]> {
+  async getYahooLeagues(clerkUserId: string, includeArchived: boolean = true): Promise<YahooLeague[]> {
     const { data, error } = await this.supabase
       .from('yahoo_leagues')
-      .select('id, clerk_user_id, sport, season_year, league_key, league_name, team_id, team_key, team_name')
+      .select('*')
       .eq('clerk_user_id', clerkUserId);
 
     if (error) {
@@ -543,7 +631,17 @@ export class YahooStorage {
       throw new Error('Failed to get Yahoo leagues');
     }
 
-    return (data || []).map((row) => ({
+    const archivedSet = includeArchived
+      ? null
+      : await this.archive.getArchivedSet(clerkUserId, 'yahoo');
+
+    const rows = (data || []).filter((row) => {
+      if (!archivedSet) return true;
+      const recurringId = row.recurring_league_id ?? row.league_key;
+      return !archivedSet.has(archivedKey(row.sport, recurringId));
+    });
+
+    return rows.map((row) => ({
       id: row.id,
       clerkUserId: row.clerk_user_id,
       sport: row.sport as Sport,
@@ -553,6 +651,7 @@ export class YahooStorage {
       teamId: row.team_id || undefined,
       teamKey: row.team_key || undefined,
       teamName: row.team_name || undefined,
+      recurringLeagueId: row.recurring_league_id ?? undefined,
     }));
   }
 
@@ -562,16 +661,32 @@ export class YahooStorage {
    * matching sport default in user_preferences can be cleared correctly.
    */
   async deleteYahooLeague(clerkUserId: string, leagueId: string): Promise<void> {
-    // Resolve platform identifiers before deleting (route arg is DB row UUID)
+    // Resolve platform identifiers before deleting (route arg is DB row UUID).
+    // Single read serves both the default-clear (league_key + season_year) and the
+    // archive cleanup (sport + recurring archive key). Tolerates a missing
+    // recurring_league_id column (pre-migration) by selecting '*' and reading it
+    // off the row if present.
     const { data: row, error: lookupError } = await this.supabase
       .from('yahoo_leagues')
-      .select('league_key, season_year')
+      .select('*')
       .eq('clerk_user_id', clerkUserId)
       .eq('id', leagueId)
       .maybeSingle();
 
     if (lookupError) {
       console.warn(`[yahoo-storage] Failed to look up Yahoo league ${leagueId} before delete:`, lookupError);
+    }
+
+    // Resolve the recurring archive key before the row is gone. Falls back to the
+    // season-scoped league_key when recurring_league_id is absent/NULL.
+    let archiveRecurringId: { sport: string; recurringLeagueId: string } | null = null;
+    if (row) {
+      const recurringId =
+        (row as { recurring_league_id?: string | null }).recurring_league_id ?? row.league_key;
+      const sport = (row as { sport?: string }).sport;
+      if (sport) {
+        archiveRecurringId = { sport, recurringLeagueId: recurringId };
+      }
     }
 
     const { error } = await this.supabase
@@ -590,6 +705,17 @@ export class YahooStorage {
     // Clear any sport default pointing to this league (keyed by platform league_key + season)
     if (row) {
       await this._clearDefaultsForLeague(clerkUserId, 'yahoo', row.league_key, row.season_year);
+    }
+
+    // A true delete also removes the league's archive entry (D8): "delete" forgets,
+    // while "archive" survives re-sync. A later re-add returns un-archived.
+    if (archiveRecurringId) {
+      await this.archive.unarchiveLeague(
+        clerkUserId,
+        'yahoo',
+        archiveRecurringId.sport as Sport,
+        archiveRecurringId.recurringLeagueId
+      );
     }
   }
 


### PR DESCRIPTION
## What & why

Phase 1b of manual league archive ([FLA-124](https://linear.app/flaim/issue/FLA-124)) — extends archive to **Yahoo**, completing the feature across all three platforms. Mirrors the shipped Sleeper surface (filter / CRUD / default-clear / delete-cleanup) and adds the one genuinely-new piece: Yahoo recurring-league identity via the `renew` chain.

## How it works

- **Recurring identity:** Yahoo's `league_key` (`{game_key}.l.{id}`) is season-scoped, so a recurring league has no stable raw id. We walk Yahoo's `renew` pointer chain (per-league meta fetch, with cache + cycle guard + depth cap) to the oldest reachable `league_key` and persist it as `recurring_league_id`. On a mid-walk meta failure we use the oldest league actually reached (not the season-scoped start), so a consistently-unreachable deep season yields a stable root year-over-year and an archived league doesn't resurface on re-sync (§8.5 #2). Falls back to the season-scoped key only when the chain can't start.
- **Storage/endpoints:** real `includeArchived` filter on `getYahooLeagues` keyed on `recurring_league_id ?? league_key` (sport-scoped); `yahoo` added to the archive-route platform gate; archive write re-resolves the canonical root fresh + persists it onto the rows (key parity); default-clear per per-season `league_key`; delete-clears-archive; public `/leagues/yahoo` annotates `archived`.
- **Web:** Archive button + Archived-section handling enabled for Yahoo (mirrors ESPN/Sleeper).

## Migration (NOT yet applied)

`flaim-docs/migrations/024_yahoo_recurring_league_id.sql` (mirrors `023`) — additive/idempotent, apply before the worker deploy.

## Verification

- auth-worker: **397/397 tests**, `tsc` clean
- web: `tsc` / lint / `ui:check` clean
- Reviewed via an independent backend audit (leak/key-parity/resolver/default-clear/delete-cleanup all PASS).

## Needs live verification

The exact shape of Yahoo's `renew` field in the bulk discovery + per-league meta responses is inferred from the API docs, not a captured live payload. The resolver is defensive (falls back safely), but the real shape will be **verified on preview with a real Yahoo account** before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
