### PR TITLE
Bump football season rollover from July 1 to June 1 (FLA-148)

### DIFF
--- a/workers/fantasy-mcp/tests/integration/index.integration.test.ts
+++ b/workers/fantasy-mcp/tests/integration/index.integration.test.ts
@@ -605,8 +605,7 @@ describe('fantasy-mcp gateway integration', () => {
   });
 
   it('routes get_user_session and returns leagues from all platforms', async () => {
-    // Use the live current football season so the fixture tracks the rollover
-    // logic rather than a hardcoded year that silently rots each season.
+    // Tracks the rollover automatically instead of hardcoding a year that rots each season.
     const currentFootballSeason = getDefaultSeasonYear('football');
     const espnLeague = {
       platform: 'espn',

--- a/workers/fantasy-mcp/tests/integration/index.integration.test.ts
+++ b/workers/fantasy-mcp/tests/integration/index.integration.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import app from '../../src/index';
 import type { Env } from '../../src/types';
 import { getUnifiedTools } from '../../src/mcp/tools';
-import { INTERNAL_SERVICE_TOKEN_HEADER } from '@flaim/worker-shared';
+import { INTERNAL_SERVICE_TOKEN_HEADER, getDefaultSeasonYear } from '@flaim/worker-shared';
 
 function buildMcpRequest(pathname: '/mcp' | '/fantasy/mcp'): Request {
   return buildMcpJsonRpcRequest(pathname, 'tools/list');
@@ -605,6 +605,9 @@ describe('fantasy-mcp gateway integration', () => {
   });
 
   it('routes get_user_session and returns leagues from all platforms', async () => {
+    // Use the live current football season so the fixture tracks the rollover
+    // logic rather than a hardcoded year that silently rots each season.
+    const currentFootballSeason = getDefaultSeasonYear('football');
     const espnLeague = {
       platform: 'espn',
       sport: 'football',
@@ -612,7 +615,7 @@ describe('fantasy-mcp gateway integration', () => {
       leagueName: 'Test ESPN League',
       teamId: '1',
       teamName: 'My Team',
-      seasonYear: 2025,
+      seasonYear: currentFootballSeason,
     };
     const yahooLeague = {
       sport: 'football',
@@ -620,7 +623,7 @@ describe('fantasy-mcp gateway integration', () => {
       leagueName: 'Test Yahoo League',
       teamId: '1',
       teamName: 'My Yahoo Team',
-      seasonYear: 2025,
+      seasonYear: currentFootballSeason,
     };
     const sleeperLeague = {
       platform: 'sleeper',
@@ -629,7 +632,7 @@ describe('fantasy-mcp gateway integration', () => {
       leagueName: 'Test Sleeper League',
       teamId: 'sl-1',
       teamName: 'My Sleeper Team',
-      seasonYear: 2025,
+      seasonYear: currentFootballSeason,
     };
 
     const authFetch = vi.fn(async (request: Request) => {

--- a/workers/fantasy-mcp/tests/integration/index.integration.test.ts
+++ b/workers/fantasy-mcp/tests/integration/index.integration.test.ts
@@ -605,7 +605,6 @@ describe('fantasy-mcp gateway integration', () => {
   });
 
   it('routes get_user_session and returns leagues from all platforms', async () => {
-    // Tracks the rollover automatically instead of hardcoding a year that rots each season.
     const currentFootballSeason = getDefaultSeasonYear('football');
     const espnLeague = {
       platform: 'espn',

--- a/workers/shared/src/__tests__/season.test.ts
+++ b/workers/shared/src/__tests__/season.test.ts
@@ -17,12 +17,12 @@ describe('season helpers', () => {
       expect(getDefaultSeasonYear('baseball', new Date('2026-02-01T00:00:00-05:00'))).toBe(2026);
     });
 
-    it('returns the previous football season before Jul 1', () => {
-      expect(getDefaultSeasonYear('football', new Date('2026-06-15T12:00:00-04:00'))).toBe(2025);
+    it('returns the previous football season before Jun 1', () => {
+      expect(getDefaultSeasonYear('football', new Date('2026-05-15T12:00:00-04:00'))).toBe(2025);
     });
 
-    it('returns the current football season on Jul 1', () => {
-      expect(getDefaultSeasonYear('football', new Date('2026-07-01T00:00:00-04:00'))).toBe(2026);
+    it('returns the current football season on Jun 1', () => {
+      expect(getDefaultSeasonYear('football', new Date('2026-06-01T00:00:00-04:00'))).toBe(2026);
     });
 
     it('returns the previous basketball season before Aug 1', () => {

--- a/workers/shared/src/__tests__/season.test.ts
+++ b/workers/shared/src/__tests__/season.test.ts
@@ -21,6 +21,10 @@ describe('season helpers', () => {
       expect(getDefaultSeasonYear('football', new Date('2026-05-15T12:00:00-04:00'))).toBe(2025);
     });
 
+    it('returns the previous football season at the last instant before Jun 1', () => {
+      expect(getDefaultSeasonYear('football', new Date('2026-05-31T23:59:59-04:00'))).toBe(2025);
+    });
+
     it('returns the current football season on Jun 1', () => {
       expect(getDefaultSeasonYear('football', new Date('2026-06-01T00:00:00-04:00'))).toBe(2026);
     });

--- a/workers/shared/src/__tests__/season.test.ts
+++ b/workers/shared/src/__tests__/season.test.ts
@@ -29,6 +29,10 @@ describe('season helpers', () => {
       expect(getDefaultSeasonYear('football', new Date('2026-06-01T00:00:00-04:00'))).toBe(2026);
     });
 
+    it('returns the current football season on June 15 (regression: previously bucketed as historical)', () => {
+      expect(getDefaultSeasonYear('football', new Date('2026-06-15T12:00:00-04:00'))).toBe(2026);
+    });
+
     it('returns the previous basketball season before Aug 1', () => {
       expect(getDefaultSeasonYear('basketball', new Date('2026-07-15T12:00:00-04:00'))).toBe(2025);
     });

--- a/workers/shared/src/season.ts
+++ b/workers/shared/src/season.ts
@@ -10,7 +10,7 @@ export type SeasonSport = 'baseball' | 'football' | 'basketball' | 'hockey';
 
 const ROLLOVER_MONTHS: Record<SeasonSport, number> = {
   baseball: 2, // Feb 1
-  football: 7, // Jul 1
+  football: 6, // Jun 1
   basketball: 8, // Aug 1
   hockey: 8, // Aug 1
 };


### PR DESCRIPTION
## What

Changes football's current-season rollover month from **July 1** to **June 1** — a single constant in `workers/shared/src/season.ts` (`ROLLOVER_MONTHS.football: 7 → 6`).

## Why

The canonical "current season" for each sport rolls over on a per-sport month. Football's was July 1, so from February through June a user has **no active football leagues** — the upcoming season's league-seasons sit in `get_ancient_history` instead of the active `get_user_session` view. Surfaced when 2026 football leagues showed under historical in mid-June.

Moving the rollover to June 1 surfaces the upcoming football season as active a month earlier, giving a longer pre-draft window (drafts are late August).

## Scope / blast radius

- Single source of truth: all workers and the web layer import the shared `getDefaultSeasonYear`/`isCurrentSeason`, so one constant change propagates everywhere.
- **No data migration** — current-season bucketing is computed from the date at read time on every call. The change takes effect immediately and is fully reversible.
- Other sports' rollovers unchanged (baseball Feb 1, basketball/hockey Aug 1).

## Tests

- Updated the football June/July boundary assertions in `shared/src/__tests__/season.test.ts`.
- Made the fantasy-mcp integration `get_user_session` fixture compute the current football season via `getDefaultSeasonYear` instead of hardcoding 2025, so it tracks the rollover instead of silently rotting each season.

Local: shared (33), espn-client (171), auth-worker (398), fantasy-mcp unit (66) + integration (17) all green.

## Trade-off

Between June 1 and draft day (~late Aug) the "active" football league may have sparse data (no draft yet). Acceptable — it's correctly the upcoming season, and pre-draft strategy is a primary use case.

Closes FLA-148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)