### PR TITLE
Surface archived leagues in get_ancient_history (FLA-149)

### DIFF
--- a/workers/auth-worker/README.md
+++ b/workers/auth-worker/README.md
@@ -104,15 +104,15 @@ Refresh diagnostics are emitted as structured, non-secret `yahoo-connect` log ev
 
 ### League Archive
 
-Cross-platform manual archive (ESPN + Sleeper; Yahoo deferred to a later phase). Archive state lives in the `archived_leagues` table, keyed on a stable recurring-league identity so it survives re-sync. Archived leagues are **excluded** from the AI-facing `/internal/leagues*` reads and **annotated** with an `archived` flag on the public `/leagues*` reads.
+Cross-platform manual archive (ESPN, Yahoo, Sleeper). Archive state lives in the `archived_leagues` table, keyed on a stable recurring-league identity so it survives re-sync. Archived leagues are **excluded** from the active `get_user_session` view — the `/internal/leagues*` reads default to excluding them — but remain **browsable** in `get_ancient_history`, which opts in by requesting `?includeArchived=true`. The public `/leagues*` reads **annotate** each league with an `archived` flag for the UI.
 
 | Endpoint | Auth | Purpose |
 |----------|------|---------|
-| `POST /leagues/archive` | Clerk JWT | Archive a league `{ platform, sport, recurringLeagueId }` (ESPN/Sleeper) |
+| `POST /leagues/archive` | Clerk JWT | Archive a league `{ platform, sport, recurringLeagueId }` (ESPN/Yahoo/Sleeper) |
 | `DELETE /leagues/archive` | Clerk JWT | Unarchive a league (same body) |
 | `GET /leagues/archive` | Clerk JWT | List the user's archived leagues |
 
-The internal (AI-facing) league reads fail closed: if the archive lookup errors, the read fails rather than returning archived leagues unfiltered. The public/UI reads fail open (they just lose the `archived` flag).
+The exclude path (`get_user_session`) fails closed: if the archive lookup errors, the read fails rather than returning archived leagues unfiltered. The history path (`?includeArchived=true`) skips the archive lookup entirely. The public/UI reads fail open (they just lose the `archived` flag).
 
 ### Extension APIs
 

--- a/workers/auth-worker/src/__tests__/eval-api-key.test.ts
+++ b/workers/auth-worker/src/__tests__/eval-api-key.test.ts
@@ -205,6 +205,39 @@ describe('eval API key auth', () => {
     expect(body.leagues).toEqual([]);
   });
 
+  it('GET /auth/internal/leagues?includeArchived=true forwards the flag to storage', async () => {
+    const { EspnSupabaseStorage } = await import('../supabase-storage');
+    await appFetch(
+      makeRequest('/auth/internal/leagues?includeArchived=true', {
+        headers: internalHeaders(EVAL_API_KEY),
+      })
+    );
+    const storage = EspnSupabaseStorage.fromEnvironment(baseEnv as never);
+    expect(storage.getLeagues).toHaveBeenCalledWith(EVAL_USER_ID, true);
+  });
+
+  it('GET /auth/internal/leagues excludes archived by default (no query param)', async () => {
+    const { EspnSupabaseStorage } = await import('../supabase-storage');
+    await appFetch(
+      makeRequest('/auth/internal/leagues', {
+        headers: internalHeaders(EVAL_API_KEY),
+      })
+    );
+    const storage = EspnSupabaseStorage.fromEnvironment(baseEnv as never);
+    expect(storage.getLeagues).toHaveBeenCalledWith(EVAL_USER_ID, false);
+  });
+
+  it('GET /auth/internal/leagues/yahoo?includeArchived=true forwards the flag to storage', async () => {
+    const { YahooStorage } = await import('../yahoo-storage');
+    await appFetch(
+      makeRequest('/auth/internal/leagues/yahoo?includeArchived=true', {
+        headers: internalHeaders(EVAL_API_KEY),
+      })
+    );
+    const storage = YahooStorage.fromEnvironment(baseEnv as never);
+    expect(storage.getYahooLeagues).toHaveBeenCalledWith(EVAL_USER_ID, true);
+  });
+
   it('GET /auth/internal/connect/yahoo/credentials with valid API key succeeds', async () => {
     const res = await appFetch(
       makeRequest('/auth/internal/connect/yahoo/credentials', {

--- a/workers/auth-worker/src/index-hono.ts
+++ b/workers/auth-worker/src/index-hono.ts
@@ -1148,9 +1148,10 @@ api.get('/internal/leagues/yahoo', async (c) => {
   }
 
   const storage = YahooStorage.fromEnvironment(c.env);
-  // Internal (gateway-facing) endpoint excludes archived leagues so they vanish
-  // from the AI surfaces. Yahoo archive is active, so this filter is real.
-  const leagues = await storage.getYahooLeagues(userId, false);
+  // Excludes archived leagues by default (get_user_session); get_ancient_history opts in
+  // via ?includeArchived=true so archived leagues stay browsable in history.
+  const includeArchived = c.req.query('includeArchived') === 'true';
+  const leagues = await storage.getYahooLeagues(userId, includeArchived);
 
   return c.json({ leagues }, 200);
 });
@@ -1238,8 +1239,10 @@ api.get('/internal/leagues/sleeper', async (c) => {
       error_description: authError || 'Authentication required',
     }, authStatus ?? 401);
   }
-  // Internal (gateway-facing) endpoint excludes archived leagues from the AI.
-  return handleSleeperLeagues(c.env as SleeperConnectEnv, userId, getCorsHeaders(c.req.raw), { includeArchived: false });
+  // Excludes archived leagues by default (get_user_session); get_ancient_history opts in
+  // via ?includeArchived=true so archived leagues stay browsable in history.
+  const includeArchived = c.req.query('includeArchived') === 'true';
+  return handleSleeperLeagues(c.env as SleeperConnectEnv, userId, getCorsHeaders(c.req.raw), { includeArchived });
 });
 
 // Delete Sleeper league (requires auth)
@@ -1732,9 +1735,10 @@ api.get('/internal/leagues', async (c) => {
   }
 
   const storage = EspnSupabaseStorage.fromEnvironment(c.env);
-  // Internal (gateway-facing) endpoint excludes archived leagues so they vanish
-  // from get_user_session and get_ancient_history automatically.
-  const leagues = await storage.getLeagues(clerkUserId, false);
+  // Excludes archived leagues by default (get_user_session); get_ancient_history opts in
+  // via ?includeArchived=true so archived leagues stay browsable in history.
+  const includeArchived = c.req.query('includeArchived') === 'true';
+  const leagues = await storage.getLeagues(clerkUserId, includeArchived);
   const leaguesWithPlatform = leagues.map(league => ({
     ...league,
     platform: 'espn' as const

--- a/workers/fantasy-mcp/src/__tests__/tools.test.ts
+++ b/workers/fantasy-mcp/src/__tests__/tools.test.ts
@@ -235,6 +235,65 @@ describe('fantasy-mcp tools', () => {
     expect(bbOld?.seasonYear).toBe(2025);
   });
 
+  it('archived leagues surface in get_ancient_history but stay hidden from get_user_session', async () => {
+    const sessionTool = getUnifiedTools().find((t) => t.name === 'get_user_session');
+    const historyTool = getUnifiedTools().find((t) => t.name === 'get_ancient_history');
+
+    // Baseball current season is 2026 regardless of the football rollover or real date.
+    const activeLeagues = [
+      { platform: 'espn', sport: 'baseball', leagueId: 'active1', leagueName: 'Active', teamId: 't1', seasonYear: 2026 },
+      { platform: 'espn', sport: 'baseball', leagueId: 'active1', leagueName: 'Active', teamId: 't1', seasonYear: 2025 },
+    ];
+    const archivedSeasons = [
+      { platform: 'espn', sport: 'baseball', leagueId: 'zombie1', leagueName: 'Zombie', teamId: 't9', seasonYear: 2026 },
+      { platform: 'espn', sport: 'baseball', leagueId: 'zombie1', leagueName: 'Zombie', teamId: 't9', seasonYear: 2025 },
+      { platform: 'espn', sport: 'baseball', leagueId: 'zombie1', leagueName: 'Zombie', teamId: 't9', seasonYear: 2024 },
+    ];
+
+    // Mirrors the auth-worker internal endpoint: archived rows are returned only when
+    // ?includeArchived=true (the history path), and excluded otherwise (the session path).
+    const env = {
+      INTERNAL_SERVICE_TOKEN: 'internal-secret',
+      AUTH_WORKER: {
+        fetch: async (req: Request) => {
+          const url = new URL(req.url);
+          if (url.pathname === '/internal/leagues') {
+            const includeArchived = url.searchParams.get('includeArchived') === 'true';
+            const leagues = includeArchived ? [...activeLeagues, ...archivedSeasons] : activeLeagues;
+            return new Response(JSON.stringify({ leagues }), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          }
+          return new Response(JSON.stringify({ leagues: [] }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        },
+      },
+    } as unknown as Env;
+
+    // Session view excludes the archived league entirely (current season stays hidden).
+    const sessionResult = await sessionTool!.handler({}, env, 'Bearer test-token');
+    const sessionPayload = JSON.parse(sessionResult.content[0].text) as {
+      allLeagues: Array<{ leagueId: string }>;
+    };
+    expect(sessionPayload.allLeagues.some((l) => l.leagueId === 'zombie1')).toBe(false);
+    expect(sessionPayload.allLeagues.some((l) => l.leagueId === 'active1')).toBe(true);
+
+    // History view keeps the archived league's past seasons browsable.
+    const historyResult = await historyTool!.handler({}, env, 'Bearer test-token');
+    const historyPayload = JSON.parse(historyResult.content[0].text) as {
+      oldSeasonsFromActiveLeagues: Record<string, Array<{ leagueId: string; seasonYear: number }>>;
+    };
+    const zombieOld = Object.values(historyPayload.oldSeasonsFromActiveLeagues)
+      .flat()
+      .filter((s) => s.leagueId === 'zombie1')
+      .map((s) => s.seasonYear)
+      .sort();
+    expect(zombieOld).toEqual([2024, 2025]);
+  });
+
   it('get_ancient_history keeps recurring Yahoo seasons under active leagues', async () => {
     const tool = getUnifiedTools().find((t) => t.name === 'get_ancient_history');
     expect(tool).toBeTruthy();

--- a/workers/fantasy-mcp/src/mcp/tools.ts
+++ b/workers/fantasy-mcp/src/mcp/tools.ts
@@ -145,7 +145,8 @@ async function fetchUserLeagues(
   authHeader?: string,
   correlationId?: string,
   evalRunId?: string,
-  evalTraceId?: string
+  evalTraceId?: string,
+  includeArchived: boolean = false
 ): Promise<{ leagues: UserLeague[]; error?: string; status?: number }> {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), 5000);
@@ -162,8 +163,9 @@ async function fetchUserLeagues(
     const withInternal = withInternalServiceToken(withCorrelation, env, 'auth-worker /internal/leagues');
     const headers = withEvalHeaders(withInternal, evalRunId, evalTraceId);
 
+    const url = `https://internal/internal/leagues${includeArchived ? '?includeArchived=true' : ''}`;
     const response = await env.AUTH_WORKER.fetch(
-      new Request('https://internal/internal/leagues', {
+      new Request(url, {
         method: 'GET',
         headers,
         signal: controller.signal,
@@ -217,7 +219,8 @@ async function fetchYahooLeagues(
   authHeader?: string,
   correlationId?: string,
   evalRunId?: string,
-  evalTraceId?: string
+  evalTraceId?: string,
+  includeArchived: boolean = false
 ): Promise<{ leagues: UserLeague[]; error?: string }> {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), 5000);
@@ -234,8 +237,9 @@ async function fetchYahooLeagues(
     const withInternal = withInternalServiceToken(withCorrelation, env, 'auth-worker /internal/leagues/yahoo');
     const headers = withEvalHeaders(withInternal, evalRunId, evalTraceId);
 
+    const url = `https://internal/internal/leagues/yahoo${includeArchived ? '?includeArchived=true' : ''}`;
     const response = await env.AUTH_WORKER.fetch(
-      new Request('https://internal/internal/leagues/yahoo', {
+      new Request(url, {
         headers,
         signal: controller.signal,
       })
@@ -294,7 +298,8 @@ async function fetchSleeperLeagues(
   authHeader?: string,
   correlationId?: string,
   evalRunId?: string,
-  evalTraceId?: string
+  evalTraceId?: string,
+  includeArchived: boolean = false
 ): Promise<{ leagues: UserLeague[]; error?: string }> {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), 5000);
@@ -311,8 +316,9 @@ async function fetchSleeperLeagues(
     const withInternal = withInternalServiceToken(withCorrelation, env, 'auth-worker /internal/leagues/sleeper');
     const headers = withEvalHeaders(withInternal, evalRunId, evalTraceId);
 
+    const url = `https://internal/internal/leagues/sleeper${includeArchived ? '?includeArchived=true' : ''}`;
     const response = await env.AUTH_WORKER.fetch(
-      new Request('https://internal/internal/leagues/sleeper', {
+      new Request(url, {
         headers,
         signal: controller.signal,
       })
@@ -796,12 +802,14 @@ export function getUnifiedTools(): UnifiedTool[] {
         const { platform } = args as { platform?: 'espn' | 'yahoo' | 'sleeper' };
         return withToolLogging(correlationId, 'get_ancient_history', `ancient platform=${platform || 'all'}`, async () => {
         try {
-          // Fetch platform leagues in parallel (only requested platforms)
+          // Fetch platform leagues in parallel (only requested platforms).
+          // includeArchived=true keeps archived leagues browsable in history, unlike
+          // get_user_session which excludes them.
           const fetchArgs = [env, authHeader, correlationId, evalRunId, evalTraceId] as const;
           const promises: Promise<{ leagues: UserLeague[]; error?: string }>[] = [];
-          if (!platform || platform === 'espn') promises.push(fetchUserLeagues(...fetchArgs));
-          if (!platform || platform === 'yahoo') promises.push(fetchYahooLeagues(...fetchArgs));
-          if (!platform || platform === 'sleeper') promises.push(fetchSleeperLeagues(...fetchArgs));
+          if (!platform || platform === 'espn') promises.push(fetchUserLeagues(...fetchArgs, true));
+          if (!platform || platform === 'yahoo') promises.push(fetchYahooLeagues(...fetchArgs, true));
+          if (!platform || platform === 'sleeper') promises.push(fetchSleeperLeagues(...fetchArgs, true));
 
           const results = await Promise.allSettled(promises);
           const allLeagues: UserLeague[] = [];


### PR DESCRIPTION
## What

Make manually-archived leagues **browsable in `get_ancient_history`** while keeping them **excluded from `get_user_session`**. Follow-on to the manual archive feature (FLA-124), which hid archived leagues from *both* AI tools.

Decision: "declutter the active view, don't erase." An archived recurring league's *current* season stays hidden; its *past* seasons become reachable when the user explicitly asks about old seasons.

## Why this is safe

`get_ancient_history` is opt-in — it only fires when the user explicitly asks about past seasons, so surfacing archived leagues there does not reintroduce the token-clutter problem that motivated the archive feature. The archived league's current season never appears (excluded from `get_user_session`; ancient-history filters to non-current seasons anyway).

## How

Both AI tools fetch through the same three internal endpoints, which passed `includeArchived: false`. Thread an opt-in flag through the history path only:

- **auth-worker** (`index-hono.ts`): the three `/internal/leagues*` endpoints read `?includeArchived=true` and forward it to storage. Storage already supports the flag and **skips the archived-set lookup entirely when true**, so there's no fail-closed concern on the history path. Default stays `false`.
- **fantasy-mcp** (`tools.ts`): `fetchUserLeagues` / `fetchYahooLeagues` / `fetchSleeperLeagues` take a trailing `includeArchived` param that appends the query string; `get_ancient_history` passes `true`, `get_user_session` keeps the default.

`get_user_session` behavior and the public `/leagues*` (UI) reads are unchanged. Also refreshes the auth-worker README archive section (Yahoo is shipped, not "deferred").

## Tests

- **fantasy-mcp**: an archived league surfaces in `get_ancient_history` but stays hidden from `get_user_session` (single test exercising both tools against one mock that mirrors the endpoint's `?includeArchived` behavior).
- **auth-worker**: `/internal/leagues` and `/internal/leagues/yahoo` forward `includeArchived` to storage; default excludes.

Local: auth-worker 401, fantasy-mcp 67 unit + 17 integration, both typecheck clean.

Closes FLA-149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)