### PR TITLE
Three-state league visibility: Active / Archived / Hidden (FLA-150)

### DIFF
--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -100,7 +100,9 @@ Notes:
 - During rollout, auth-worker retries writes without `recurring_league_id` if the live schema does not have the column yet; those legacy or unresolved rows still rely on read-time fallback until they are rediscovered.
 
 ### archived_leagues
-Manual league archive (FLA-124). One row per archived recurring league. Archived leagues are hidden from the AI's MCP tools (`get_user_session`, `get_ancient_history`) but remain visible and restorable in `/leagues`.
+Manual league suppression (FLA-124; three-state model FLA-150). One row per suppressed recurring league, across ESPN, Yahoo, and Sleeper. The `mode` column places a league in one of two suppressed states; both remain visible and restorable in `/leagues`:
+- `historical` (Archive) — hidden from `get_user_session` but browsable in `get_ancient_history`.
+- `hidden` (Hide) — hidden from both AI tools.
 
 | Column | Type | Notes |
 |---|---|---|
@@ -108,18 +110,18 @@ Manual league archive (FLA-124). One row per archived recurring league. Archived
 | clerk_user_id | text | User owner |
 | platform | text | `espn`, `yahoo`, or `sleeper` |
 | sport | text | football/baseball/basketball/hockey |
-| recurring_league_id | text | Stable recurring-league identity (ESPN: `league_id`; Sleeper: `recurring_league_id ?? league_id`; Yahoo reserved for a later phase) |
-| league_name | text | Denormalized name for the Archived UI list (optional) |
-| archived_at | timestamptz | When the league was archived |
+| recurring_league_id | text | Stable recurring-league identity (ESPN: `league_id`; Sleeper: `recurring_league_id ?? league_id`; Yahoo: `recurring_league_id ?? league_key`) |
+| league_name | text | Denormalized name for the UI list (optional) |
+| archived_at | timestamptz | When the league was suppressed |
+| mode | text | `historical` or `hidden` (default `historical`; migration 025 backfilled existing rows to `hidden`). NOT part of the unique key. |
 
 Constraints/Indexes:
-- Unique per archived league: `(clerk_user_id, platform, sport, recurring_league_id)`.
+- Unique per league: `(clerk_user_id, platform, sport, recurring_league_id)` — `mode` is a mutable attribute, so re-archiving overwrites it (moves the league between Archived/Hidden).
 - Index on `clerk_user_id`.
 
 Notes:
-- Keyed on a recurring identity (not a season-scoped row) so an archived league stays archived across annual re-syncs — discovery upserts new season rows without touching this table.
-- Read paths: internal/AI-facing league reads exclude archived rows (fail-closed on a lookup error); public/UI league reads annotate an `archived` flag instead.
-- Phase 1a covers ESPN and Sleeper; Yahoo archive is deferred to a later phase.
+- Keyed on a recurring identity (not a season-scoped row) so suppression survives annual re-syncs — discovery upserts new season rows without touching this table.
+- Read paths: internal/AI-facing reads take a tri-state filter — `exclude-archived` (both modes, for `get_user_session`) or `exclude-hidden` (drops only `hidden`, for `get_ancient_history`); fail-closed on a lookup error. Public/UI reads annotate `archived` + `archiveMode`. The read tolerates a pre-migration schema (treats rows as `hidden` if `mode` is absent).
 
 ### platform_oauth_states
 Short-lived OAuth state values for platform-connect flows (separate from MCP OAuth state table).

--- a/web/app/(site)/leagues/page.tsx
+++ b/web/app/(site)/leagues/page.tsx
@@ -20,6 +20,7 @@ import {
   RefreshCw,
   Archive,
   ArchiveRestore,
+  EyeOff,
 } from 'lucide-react';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { useEspnCredentials } from '@/lib/use-espn-credentials';
@@ -50,6 +51,7 @@ interface League {
   teamName?: string;
   seasonYear?: number;
   archived?: boolean;
+  archiveMode?: 'historical' | 'hidden';
 }
 
 interface YahooLeague {
@@ -63,6 +65,7 @@ interface YahooLeague {
   teamName?: string;
   recurringLeagueId?: string;
   archived?: boolean;
+  archiveMode?: 'historical' | 'hidden';
 }
 
 interface SleeperLeague {
@@ -74,6 +77,7 @@ interface SleeperLeague {
   rosterId: number | null;
   recurringLeagueId?: string;
   archived?: boolean;
+  archiveMode?: 'historical' | 'hidden';
 }
 
 interface LeagueDefault {
@@ -109,8 +113,11 @@ interface UnifiedLeague {
   // Sleeper-specific
   sleeperId?: string;    // DB UUID for deletion (Sleeper only)
   recurringLeagueId?: string;
-  // Archive state (annotated by the public /leagues* endpoints, ESPN + Yahoo + Sleeper)
+  // Archive state (annotated by the public /leagues* endpoints, ESPN + Yahoo + Sleeper).
+  // `archiveMode` is only meaningful when `archived` is true: 'historical' (still
+  // browsable for past seasons) vs 'hidden' (completely hidden from the AI).
   archived?: boolean;
+  archiveMode?: 'historical' | 'hidden';
 }
 
 interface UnifiedLeagueGroup {
@@ -121,7 +128,8 @@ interface UnifiedLeagueGroup {
   leagueName: string;
   teamId?: string;
   seasons: UnifiedLeague[];
-  archived: boolean;     // true when this recurring league is archived (hidden from the AI)
+  archived: boolean;     // true when this recurring league is suppressed (archived or hidden)
+  archiveMode?: 'historical' | 'hidden'; // mode of the suppression when archived is true
 }
 
 const SPORT_OPTIONS: { value: Sport; label: string; emoji: string }[] = [
@@ -213,6 +221,7 @@ function espnToUnified(leagues: League[], preferences: UserPreferencesState): Un
       leagueId: l.leagueId,
       teamId: l.teamId,
       archived: l.archived ?? false,
+      archiveMode: l.archiveMode,
     };
   });
 }
@@ -237,6 +246,7 @@ function yahooToUnified(leagues: YahooLeague[], preferences: UserPreferencesStat
       yahooId: l.id,
       recurringLeagueId: l.recurringLeagueId,
       archived: l.archived ?? false,
+      archiveMode: l.archiveMode,
     };
   });
 }
@@ -265,6 +275,7 @@ function sleeperToUnified(
       sleeperId: sl.id,
       recurringLeagueId: sl.recurringLeagueId,
       archived: sl.archived ?? false,
+      archiveMode: sl.archiveMode,
     };
   });
 }
@@ -280,33 +291,54 @@ function getArchiveRecurringId(group: UnifiedLeagueGroup): string {
   return group.leagueId;
 }
 
-// Archive icon-button shared by the active and old league sections.
-// Rendered for all three platforms (ESPN, Yahoo, Sleeper).
-function ArchiveButton({
+// Visibility controls shared by the active and old league sections. Renders two
+// icon-buttons for all three platforms (ESPN, Yahoo, Sleeper):
+//   - Archive → mode 'historical' (still browsable when asked about past seasons)
+//   - Hide    → mode 'hidden' (completely hidden from the AI)
+// While either request is in flight both buttons are disabled.
+function ArchiveButtons({
   group,
   archivingLeagueKey,
   onArchive,
+  onHide,
 }: {
   group: UnifiedLeagueGroup;
   archivingLeagueKey: string | null;
   onArchive: (group: UnifiedLeagueGroup) => void;
+  onHide: (group: UnifiedLeagueGroup) => void;
 }) {
   const isArchiving = archivingLeagueKey === `${group.platform}:${getArchiveRecurringId(group)}`;
   return (
-    <Button
-      variant="ghost"
-      size="icon"
-      className="h-8 w-8 text-muted-foreground hover:text-foreground"
-      onClick={() => onArchive(group)}
-      disabled={isArchiving}
-      title="Archive (hide from your AI)"
-    >
-      {isArchiving ? (
-        <Loader2 className="h-4 w-4 animate-spin" />
-      ) : (
-        <Archive className="h-4 w-4" />
-      )}
-    </Button>
+    <>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-8 w-8 text-muted-foreground hover:text-foreground"
+        onClick={() => onArchive(group)}
+        disabled={isArchiving}
+        title="Archive (still browsable for past seasons)"
+      >
+        {isArchiving ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : (
+          <Archive className="h-4 w-4" />
+        )}
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-8 w-8 text-muted-foreground hover:text-foreground"
+        onClick={() => onHide(group)}
+        disabled={isArchiving}
+        title="Hide (completely hidden from the AI)"
+      >
+        {isArchiving ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : (
+          <EyeOff className="h-4 w-4" />
+        )}
+      </Button>
+    </>
   );
 }
 
@@ -371,6 +403,7 @@ function LeaguesPageContent() {
   const defaultSport = displayPreferences.defaultSport;
   const [showOldLeagues, setShowOldLeagues] = useState(false);
   const [showArchivedLeagues, setShowArchivedLeagues] = useState(false);
+  const [showHiddenLeagues, setShowHiddenLeagues] = useState(false);
   // Keyed by `${platform}:${recurringLeagueId}` while an archive/unarchive request is in flight.
   const [archivingLeagueKey, setArchivingLeagueKey] = useState<string | null>(null);
 
@@ -461,8 +494,12 @@ function LeaguesPageContent() {
       }
       const group = grouped.get(groupKey)!;
       group.seasons.push(league);
-      // Seasons of a recurring league share an archive state; any flagged season archives the group.
-      if (league.archived) group.archived = true;
+      // Seasons of a recurring league share an archive state; any flagged season
+      // suppresses the group and carries its mode (default 'historical' when absent).
+      if (league.archived) {
+        group.archived = true;
+        group.archiveMode = league.archiveMode ?? 'historical';
+      }
     }
 
     // Sort seasons desc within each group
@@ -473,15 +510,21 @@ function LeaguesPageContent() {
       group.teamId = group.seasons.find((s) => s.teamId)?.teamId;
     }
 
-    // Separate archived, then active vs old. Archived leagues are pulled out of
-    // both the active and old buckets into their own section (hidden from the AI).
+    // Separate suppressed groups, then active vs old. Suppressed leagues are pulled
+    // out of both the active and old buckets into their own sections: 'historical'
+    // (Archived — still browsable for past seasons) and 'hidden' (completely hidden).
     const activeLeagues: UnifiedLeagueGroup[] = [];
     const oldLeagueGroups: UnifiedLeagueGroup[] = [];
     const archivedLeagueGroups: UnifiedLeagueGroup[] = [];
+    const hiddenLeagueGroups: UnifiedLeagueGroup[] = [];
 
     for (const group of grouped.values()) {
       if (group.archived) {
-        archivedLeagueGroups.push(group);
+        if (group.archiveMode === 'hidden') {
+          hiddenLeagueGroups.push(group);
+        } else {
+          archivedLeagueGroups.push(group);
+        }
       } else if (isOldLeague(group.sport as Sport, group.seasons)) {
         oldLeagueGroups.push(group);
       } else {
@@ -489,8 +532,11 @@ function LeaguesPageContent() {
       }
     }
 
-    // Sort archived by most recent season desc for a stable list order.
-    archivedLeagueGroups.sort((a, b) => (b.seasons[0]?.seasonYear ?? 0) - (a.seasons[0]?.seasonYear ?? 0));
+    // Sort suppressed groups by most recent season desc for a stable list order.
+    const bySeasonDesc = (a: UnifiedLeagueGroup, b: UnifiedLeagueGroup) =>
+      (b.seasons[0]?.seasonYear ?? 0) - (a.seasons[0]?.seasonYear ?? 0);
+    archivedLeagueGroups.sort(bySeasonDesc);
+    hiddenLeagueGroups.sort(bySeasonDesc);
 
     // Group active leagues by sport
     const bySportActive = new Map<string, UnifiedLeagueGroup[]>();
@@ -516,7 +562,7 @@ function LeaguesPageContent() {
       return sportOrder.indexOf(a[0]) - sportOrder.indexOf(b[0]);
     });
 
-    return { active: sortedActive, old: oldLeagueGroups, archived: archivedLeagueGroups };
+    return { active: sortedActive, old: oldLeagueGroups, archived: archivedLeagueGroups, hidden: hiddenLeagueGroups };
   }, [displayLeagues, displayYahooLeagues, displaySleeperLeagues, displayPreferences]);
 
   const loadLeagues = useCallback(async (options?: { showSpinner?: boolean; shouldApply?: () => boolean }) => {
@@ -1173,11 +1219,16 @@ function LeaguesPageContent() {
     }
   };
 
-  // Archive/unarchive a league group (ESPN, Yahoo, Sleeper). Both directions share the
-  // flow: resolve key → set loading → fetch → refresh the affected platform so the
-  // `archived` flag re-buckets the group. POST archives (hides from the AI); DELETE
-  // unarchives (restores to the visible/AI surfaces).
-  const performArchiveAction = async (group: UnifiedLeagueGroup, action: 'archive' | 'unarchive') => {
+  // Set or clear a league group's visibility (ESPN, Yahoo, Sleeper). All directions
+  // share the flow: resolve key → set loading → fetch → refresh the affected platform
+  // so the `archived`/`archiveMode` flags re-bucket the group. POST sets the archive
+  // mode ('historical' = Archive, 'hidden' = Hide); DELETE restores it to the visible/
+  // AI surfaces. `mode` is only used for the 'archive' action.
+  const performArchiveAction = async (
+    group: UnifiedLeagueGroup,
+    action: 'archive' | 'unarchive',
+    mode: 'historical' | 'hidden' = 'historical'
+  ) => {
     const recurringLeagueId = getArchiveRecurringId(group);
     const actionKey = `${group.platform}:${recurringLeagueId}`;
     const shouldApply = createAccountGuard();
@@ -1189,7 +1240,11 @@ function LeaguesPageContent() {
       const res = await fetch('/api/leagues/archive', {
         method: action === 'archive' ? 'POST' : 'DELETE',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ platform: group.platform, sport: group.sport, recurringLeagueId }),
+        body: JSON.stringify(
+          action === 'archive'
+            ? { platform: group.platform, sport: group.sport, recurringLeagueId, mode }
+            : { platform: group.platform, sport: group.sport, recurringLeagueId }
+        ),
       });
       if (!res.ok) {
         const data = await res.json() as { error?: string };
@@ -1219,7 +1274,8 @@ function LeaguesPageContent() {
   const hasAnyLeagueGroups =
     leaguesBySport.active.length > 0 ||
     leaguesBySport.old.length > 0 ||
-    leaguesBySport.archived.length > 0;
+    leaguesBySport.archived.length > 0 ||
+    leaguesBySport.hidden.length > 0;
   const displayLeagueError = isAccountStateCurrent ? leagueError : null;
   const displayLeagueNotice = isAccountStateCurrent ? leagueNotice : null;
   const displayEspnConnected = isAccountStateCurrent && hasCredentials;
@@ -1598,14 +1654,13 @@ function LeaguesPageContent() {
                                 </div>
                               </div>
                               <div className="flex items-center gap-1 shrink-0">
-                                {/* Archive: all three platforms (ESPN, Yahoo, Sleeper). */}
-                                {(group.platform === 'espn' || group.platform === 'yahoo' || group.platform === 'sleeper') && (
-                                  <ArchiveButton
-                                    group={group}
-                                    archivingLeagueKey={archivingLeagueKey}
-                                    onArchive={(g) => performArchiveAction(g, 'archive')}
-                                  />
-                                )}
+                                {/* Visibility controls: all three platforms (ESPN, Yahoo, Sleeper). */}
+                                <ArchiveButtons
+                                  group={group}
+                                  archivingLeagueKey={archivingLeagueKey}
+                                  onArchive={(g) => performArchiveAction(g, 'archive', 'historical')}
+                                  onHide={(g) => performArchiveAction(g, 'archive', 'hidden')}
+                                />
                                 <Button
                                   variant="ghost"
                                   size="icon"
@@ -1714,14 +1769,13 @@ function LeaguesPageContent() {
                                       </div>
                                     </div>
                                     <div className="flex items-center gap-1 shrink-0">
-                                      {/* Archive: all three platforms (ESPN, Yahoo, Sleeper). */}
-                                      {(group.platform === 'espn' || group.platform === 'yahoo' || group.platform === 'sleeper') && (
-                                        <ArchiveButton
-                                          group={group}
-                                          archivingLeagueKey={archivingLeagueKey}
-                                          onArchive={(g) => performArchiveAction(g, 'archive')}
-                                        />
-                                      )}
+                                      {/* Visibility controls: all three platforms (ESPN, Yahoo, Sleeper). */}
+                                      <ArchiveButtons
+                                        group={group}
+                                        archivingLeagueKey={archivingLeagueKey}
+                                        onArchive={(g) => performArchiveAction(g, 'archive', 'historical')}
+                                        onHide={(g) => performArchiveAction(g, 'archive', 'hidden')}
+                                      />
                                       <Button
                                         variant="ghost"
                                         size="icon"
@@ -1762,7 +1816,7 @@ function LeaguesPageContent() {
                       </div>
                     )}
 
-                    {/* Archived Leagues Section */}
+                    {/* Archived Leagues Section (mode: 'historical') */}
                     {leaguesBySport.archived.length > 0 && (
                       <div className="space-y-3 pt-3 border-t">
                         <button
@@ -1778,7 +1832,7 @@ function LeaguesPageContent() {
                         {showArchivedLeagues && (
                           <div className="space-y-3">
                             <p className="text-sm text-muted-foreground">
-                              Hidden from your AI entirely. Unarchive to bring it back.
+                              Still browsable when you ask about past seasons
                             </p>
                             {leaguesBySport.archived.map((group) => {
                               const baseKey = `${group.leagueId}-${group.sport}`;
@@ -1807,9 +1861,124 @@ function LeaguesPageContent() {
                                         variant="ghost"
                                         size="icon"
                                         className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                                        onClick={() => performArchiveAction(group, 'archive', 'hidden')}
+                                        disabled={isArchiving}
+                                        title="Hide (completely hidden from the AI)"
+                                      >
+                                        {isArchiving ? (
+                                          <Loader2 className="h-4 w-4 animate-spin" />
+                                        ) : (
+                                          <EyeOff className="h-4 w-4" />
+                                        )}
+                                      </Button>
+                                      <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        className="h-8 w-8 text-muted-foreground hover:text-foreground"
                                         onClick={() => performArchiveAction(group, 'unarchive')}
                                         disabled={isArchiving}
-                                        title="Unarchive (show to your AI again)"
+                                        title="Restore (show to your AI again)"
+                                      >
+                                        {isArchiving ? (
+                                          <Loader2 className="h-4 w-4 animate-spin" />
+                                        ) : (
+                                          <ArchiveRestore className="h-4 w-4" />
+                                        )}
+                                      </Button>
+                                      <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        className="h-8 w-8 text-muted-foreground hover:text-destructive"
+                                        onClick={() => {
+                                          if (group.platform === 'espn') {
+                                            handleDeleteLeague(group.leagueId, group.sport);
+                                          } else if (group.platform === 'yahoo') {
+                                            handleDeleteYahooLeagueGroup(group.seasons);
+                                          } else {
+                                            handleDeleteSleeperLeagueGroup(group.seasons, group.leagueId);
+                                          }
+                                        }}
+                                        disabled={isDeleting}
+                                        title="Delete league"
+                                      >
+                                        {isDeleting ? (
+                                          <Loader2 className="h-4 w-4 animate-spin" />
+                                        ) : (
+                                          <Trash2 className="h-4 w-4" />
+                                        )}
+                                      </Button>
+                                    </div>
+                                  </div>
+                                </div>
+                              );
+                            })}
+                          </div>
+                        )}
+                      </div>
+                    )}
+
+                    {/* Hidden Leagues Section (mode: 'hidden') */}
+                    {leaguesBySport.hidden.length > 0 && (
+                      <div className="space-y-3 pt-3 border-t">
+                        <button
+                          type="button"
+                          className="flex items-center gap-2 font-medium text-muted-foreground hover:text-foreground transition-colors w-full"
+                          onClick={() => setShowHiddenLeagues(!showHiddenLeagues)}
+                        >
+                          <EyeOff className="h-4 w-4" />
+                          <span className="text-base">Hidden ({leaguesBySport.hidden.length})</span>
+                          <ChevronDown className={`h-4 w-4 ml-auto transition-transform ${showHiddenLeagues ? 'rotate-180' : ''}`} />
+                        </button>
+
+                        {showHiddenLeagues && (
+                          <div className="space-y-3">
+                            <p className="text-sm text-muted-foreground">
+                              Completely hidden from the AI
+                            </p>
+                            {leaguesBySport.hidden.map((group) => {
+                              const baseKey = `${group.leagueId}-${group.sport}`;
+                              const isDeleting =
+                                (group.platform === 'espn' && deletingLeagueKey === baseKey)
+                                || (group.platform === 'sleeper' && deletingSleeperKey === `sleeper:${group.leagueId}`)
+                                || (group.platform === 'yahoo' && deletingLeagueKey === `yahoo:${group.seasons[0]?.yahooId}`);
+                              const isArchiving = archivingLeagueKey === `${group.platform}:${getArchiveRecurringId(group)}`;
+                              const mostRecentYear = group.seasons[0]?.seasonYear;
+
+                              return (
+                                <div key={group.key} className="rounded-lg border bg-muted/30">
+                                  {/* Hidden League Header */}
+                                  <div className="flex items-center justify-between gap-3 p-3">
+                                    <div className="min-w-0">
+                                      <div className="font-medium break-words text-muted-foreground">
+                                        {group.leagueName || `League ${group.leagueId}`}
+                                      </div>
+                                      <div className="text-xs text-muted-foreground/70 break-words">
+                                        {group.platform === 'espn' ? 'ESPN' : group.platform === 'yahoo' ? 'Yahoo' : 'Sleeper'}
+                                        {mostRecentYear ? ` • Last active: ${mostRecentYear}` : ''}
+                                      </div>
+                                    </div>
+                                    <div className="flex items-center gap-1 shrink-0">
+                                      <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                                        onClick={() => performArchiveAction(group, 'archive', 'historical')}
+                                        disabled={isArchiving}
+                                        title="Archive (still browsable for past seasons)"
+                                      >
+                                        {isArchiving ? (
+                                          <Loader2 className="h-4 w-4 animate-spin" />
+                                        ) : (
+                                          <Archive className="h-4 w-4" />
+                                        )}
+                                      </Button>
+                                      <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                                        onClick={() => performArchiveAction(group, 'unarchive')}
+                                        disabled={isArchiving}
+                                        title="Restore (show to your AI again)"
                                       >
                                         {isArchiving ? (
                                           <Loader2 className="h-4 w-4 animate-spin" />

--- a/web/app/api/espn/leagues/route.ts
+++ b/web/app/api/espn/leagues/route.ts
@@ -19,6 +19,8 @@ interface WorkerLeaguesResponse extends WorkerErrorResponse {
     leagueName?: string;
     teamId?: string;
     seasonYear?: number;
+    archived?: boolean;
+    archiveMode?: 'historical' | 'hidden';
   }>;
   deleted?: boolean;
 }

--- a/web/app/api/leagues/archive/route.ts
+++ b/web/app/api/leagues/archive/route.ts
@@ -4,20 +4,26 @@
  * Proxies the manual league archive endpoints to the Auth-Worker (FLA-124).
  *
  * - GET    → list the user's archived leagues (feeds the Archived UI section)
- * - POST   → archive a league (hide it from the AI; survives re-sync)
+ * - POST   → set a league's archive mode (hide it from the AI's active view; survives re-sync)
  * - DELETE → unarchive a league (restore it to the visible/AI surfaces)
  *
- * Body for POST/DELETE: { platform, sport, recurringLeagueId }. ESPN + Sleeper
- * only — Yahoo archive is deferred to a later phase, enforced by the Auth-Worker.
+ * Body for POST: { platform, sport, recurringLeagueId, mode }, where `mode` is
+ * 'historical' (Archive — still browsable for past seasons) or 'hidden' (Hide —
+ * completely hidden from the AI); it defaults to 'historical' when omitted.
+ * Body for DELETE: { platform, sport, recurringLeagueId }. All three platforms
+ * (ESPN, Yahoo, Sleeper) support the three-state visibility flow.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@clerk/nextjs/server';
 
+type ArchiveMode = 'historical' | 'hidden';
+
 interface ArchiveRequestBody {
   platform?: string;
   sport?: string;
   recurringLeagueId?: string;
+  mode?: ArchiveMode;
 }
 
 // Shared auth/url/token resolution for the GET/POST/DELETE handlers. Returns the
@@ -88,6 +94,13 @@ export async function POST(request: NextRequest) {
         error: 'platform, sport, and recurringLeagueId are required',
       }, { status: 400 });
     }
+    // `mode` is optional; the Auth-Worker defaults it to 'historical'. Validate it
+    // when present so only the two supported modes are forwarded.
+    if (body.mode !== undefined && body.mode !== 'historical' && body.mode !== 'hidden') {
+      return NextResponse.json({
+        error: "mode must be 'historical' or 'hidden'",
+      }, { status: 400 });
+    }
 
     const workerResponse = await fetch(`${workerUrl}/leagues/archive`, {
       method: 'POST',
@@ -99,6 +112,7 @@ export async function POST(request: NextRequest) {
         platform: body.platform,
         sport: body.sport,
         recurringLeagueId: body.recurringLeagueId,
+        ...(body.mode !== undefined ? { mode: body.mode } : {}),
       }),
     });
 

--- a/workers/auth-worker/README.md
+++ b/workers/auth-worker/README.md
@@ -104,15 +104,20 @@ Refresh diagnostics are emitted as structured, non-secret `yahoo-connect` log ev
 
 ### League Archive
 
-Cross-platform manual archive (ESPN + Sleeper; Yahoo deferred to a later phase). Archive state lives in the `archived_leagues` table, keyed on a stable recurring-league identity so it survives re-sync. Archived leagues are **excluded** from the AI-facing `/internal/leagues*` reads and **annotated** with an `archived` flag on the public `/leagues*` reads.
+Cross-platform manual suppression (ESPN, Yahoo, Sleeper). State lives in the `archived_leagues` table, keyed on a stable recurring-league identity so it survives re-sync. Each row has a **`mode`** that places the league in one of two suppressed states:
+
+- **`historical`** (Archive) — excluded from the active `get_user_session` view but still browsable in `get_ancient_history` (so "when did I win / my record" stays answerable).
+- **`hidden`** (Hide) — excluded from **both** AI tools.
+
+The internal `/internal/leagues*` reads take a `?archived` query param: default `exclude-archived` (drops both modes, for `get_user_session`); `?archived=exclude-hidden` drops only `hidden` (for `get_ancient_history`). The public `/leagues*` reads **annotate** each league with `archived` (suppressed at all) + `archiveMode`.
 
 | Endpoint | Auth | Purpose |
 |----------|------|---------|
-| `POST /leagues/archive` | Clerk JWT | Archive a league `{ platform, sport, recurringLeagueId }` (ESPN/Sleeper) |
-| `DELETE /leagues/archive` | Clerk JWT | Unarchive a league (same body) |
-| `GET /leagues/archive` | Clerk JWT | List the user's archived leagues |
+| `POST /leagues/archive` | Clerk JWT | Suppress a league `{ platform, sport, recurringLeagueId, mode? }` (`mode` defaults to `historical`). Re-posting with a different `mode` moves it between Archived/Hidden. ESPN/Yahoo/Sleeper. |
+| `DELETE /leagues/archive` | Clerk JWT | Restore a league (`{ platform, sport, recurringLeagueId }`) |
+| `GET /leagues/archive` | Clerk JWT | List the user's suppressed leagues (incl. `mode`) |
 
-The internal (AI-facing) league reads fail closed: if the archive lookup errors, the read fails rather than returning archived leagues unfiltered. The public/UI reads fail open (they just lose the `archived` flag).
+The internal (AI-facing) league reads fail closed: if the archive lookup errors, the read fails rather than returning suppressed leagues unfiltered. The public/UI reads fail open (they just lose the `archived`/`archiveMode` flags). The mode-aware read tolerates the pre-migration schema (treats rows as `hidden` if the `mode` column is absent).
 
 ### Extension APIs
 

--- a/workers/auth-worker/src/__tests__/archive-route.test.ts
+++ b/workers/auth-worker/src/__tests__/archive-route.test.ts
@@ -4,17 +4,17 @@ import { parseArchiveBody } from '../index-hono';
 describe('parseArchiveBody', () => {
   it('accepts a valid espn body', () => {
     const result = parseArchiveBody({ platform: 'espn', sport: 'football', recurringLeagueId: '123456' });
-    expect(result).toEqual({ ok: true, platform: 'espn', sport: 'football', recurringLeagueId: '123456' });
+    expect(result).toEqual({ ok: true, platform: 'espn', sport: 'football', recurringLeagueId: '123456', mode: 'historical' });
   });
 
   it('accepts a valid sleeper body', () => {
     const result = parseArchiveBody({ platform: 'sleeper', sport: 'basketball', recurringLeagueId: '987654321098765432' });
-    expect(result).toEqual({ ok: true, platform: 'sleeper', sport: 'basketball', recurringLeagueId: '987654321098765432' });
+    expect(result).toEqual({ ok: true, platform: 'sleeper', sport: 'basketball', recurringLeagueId: '987654321098765432', mode: 'historical' });
   });
 
   it('accepts a valid yahoo body (Phase 1b — recurring id now resolved)', () => {
     const result = parseArchiveBody({ platform: 'yahoo', sport: 'football', recurringLeagueId: '449.l.123' });
-    expect(result).toEqual({ ok: true, platform: 'yahoo', sport: 'football', recurringLeagueId: '449.l.123' });
+    expect(result).toEqual({ ok: true, platform: 'yahoo', sport: 'football', recurringLeagueId: '449.l.123', mode: 'historical' });
   });
 
   it('rejects an unsupported platform', () => {
@@ -74,6 +74,42 @@ describe('parseArchiveBody', () => {
     // Yahoo as a platform is deferred, but the dotted-id charset must pass so the
     // charset rule never becomes the reason a future Yahoo id is rejected.
     const result = parseArchiveBody({ platform: 'sleeper', sport: 'football', recurringLeagueId: '449.l.123' });
-    expect(result).toEqual({ ok: true, platform: 'sleeper', sport: 'football', recurringLeagueId: '449.l.123' });
+    expect(result).toEqual({ ok: true, platform: 'sleeper', sport: 'football', recurringLeagueId: '449.l.123', mode: 'historical' });
+  });
+
+  // ===========================================================================
+  // mode (FLA-150 three-state visibility)
+  // ===========================================================================
+
+  it('defaults mode to historical when omitted', () => {
+    const result = parseArchiveBody({ platform: 'espn', sport: 'football', recurringLeagueId: '123' });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.mode).toBe('historical');
+    }
+  });
+
+  it('accepts an explicit historical mode', () => {
+    const result = parseArchiveBody({ platform: 'espn', sport: 'football', recurringLeagueId: '123', mode: 'historical' });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.mode).toBe('historical');
+    }
+  });
+
+  it('accepts an explicit hidden mode', () => {
+    const result = parseArchiveBody({ platform: 'espn', sport: 'football', recurringLeagueId: '123', mode: 'hidden' });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.mode).toBe('hidden');
+    }
+  });
+
+  it('rejects an invalid mode', () => {
+    const result = parseArchiveBody({ platform: 'espn', sport: 'football', recurringLeagueId: '123', mode: 'bogus' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('Invalid mode');
+    }
   });
 });

--- a/workers/auth-worker/src/__tests__/archive-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/archive-storage.test.ts
@@ -41,6 +41,28 @@ describe('ArchiveStorage', () => {
       expect(options).toEqual({ onConflict: 'clerk_user_id,platform,sport,recurring_league_id' });
     });
 
+    it('defaults the upsert mode to historical when not specified', async () => {
+      const mockUpsert = vi.fn().mockResolvedValue({ error: null });
+      mockFrom.mockReturnValue({ upsert: mockUpsert });
+
+      await storage.archiveLeague('user_123', 'espn', 'football', 'league-9', 'Zombie League');
+
+      expect(mockUpsert.mock.calls[0][0]).toMatchObject({ mode: 'historical' });
+    });
+
+    it('writes the given mode into the upsert payload', async () => {
+      const mockUpsert = vi.fn().mockResolvedValue({ error: null });
+      mockFrom.mockReturnValue({ upsert: mockUpsert });
+
+      const ok = await storage.archiveLeague('user_123', 'espn', 'football', 'league-9', 'Zombie League', 'hidden');
+
+      expect(ok).toBe(true);
+      expect(mockUpsert.mock.calls[0][0]).toMatchObject({
+        recurring_league_id: 'league-9',
+        mode: 'hidden',
+      });
+    });
+
     it('returns false when the recurring id is missing', async () => {
       const mockUpsert = vi.fn();
       mockFrom.mockReturnValue({ upsert: mockUpsert });
@@ -87,8 +109,8 @@ describe('ArchiveStorage', () => {
     it('returns the set keyed by sport:recurringId for a platform', async () => {
       const eqPlatform = vi.fn().mockResolvedValue({
         data: [
-          { sport: 'football', recurring_league_id: 'a' },
-          { sport: 'basketball', recurring_league_id: 'b' },
+          { sport: 'football', recurring_league_id: 'a', mode: 'historical' },
+          { sport: 'basketball', recurring_league_id: 'b', mode: 'hidden' },
         ],
         error: null,
       });
@@ -98,7 +120,8 @@ describe('ArchiveStorage', () => {
 
       const set = await storage.getArchivedSet('user_123', 'espn');
 
-      expect(select).toHaveBeenCalledWith('sport, recurring_league_id');
+      // getArchivedSet now delegates to getArchivedMap, which selects the mode column too.
+      expect(select).toHaveBeenCalledWith('sport, recurring_league_id, mode');
       expect(set.has(archivedKey('football', 'a'))).toBe(true);
       expect(set.has(archivedKey('basketball', 'b'))).toBe(true);
       expect(set.size).toBe(2);
@@ -129,7 +152,62 @@ describe('ArchiveStorage', () => {
       const select = vi.fn().mockReturnValue({ eq: eqUser });
       mockFrom.mockReturnValue({ select });
 
-      await expect(storage.getArchivedSet('user_123', 'sleeper')).rejects.toThrow('Failed to get archived set');
+      await expect(storage.getArchivedSet('user_123', 'sleeper')).rejects.toThrow('Failed to get archived map');
+    });
+  });
+
+  describe('getArchivedMap', () => {
+    it('returns a mode-tagged map keyed by sport:recurringId', async () => {
+      const eqPlatform = vi.fn().mockResolvedValue({
+        data: [
+          { sport: 'football', recurring_league_id: 'a', mode: 'historical' },
+          { sport: 'basketball', recurring_league_id: 'b', mode: 'hidden' },
+        ],
+        error: null,
+      });
+      const eqUser = vi.fn().mockReturnValue({ eq: eqPlatform });
+      const select = vi.fn().mockReturnValue({ eq: eqUser });
+      mockFrom.mockReturnValue({ select });
+
+      const map = await storage.getArchivedMap('user_123', 'espn');
+
+      expect(select).toHaveBeenCalledWith('sport, recurring_league_id, mode');
+      expect(map.get(archivedKey('football', 'a'))).toBe('historical');
+      expect(map.get(archivedKey('basketball', 'b'))).toBe('hidden');
+      expect(map.size).toBe(2);
+    });
+
+    it('falls back to a mode-less select and treats all rows as hidden when the mode column is missing', async () => {
+      // First select (with mode) errors with Postgres undefined_column (42703); the
+      // code retries without the mode column and tags every legacy row as 'hidden'.
+      const eqPlatformWithMode = vi.fn().mockResolvedValue({
+        data: null,
+        error: { code: '42703', message: 'column archived_leagues.mode does not exist' },
+      });
+      const eqPlatformLegacy = vi.fn().mockResolvedValue({
+        data: [
+          { sport: 'football', recurring_league_id: 'a' },
+          { sport: 'basketball', recurring_league_id: 'b' },
+        ],
+        error: null,
+      });
+      let call = 0;
+      const select = vi.fn().mockImplementation((columns: string) => {
+        call += 1;
+        const eqPlatform = columns.includes('mode') ? eqPlatformWithMode : eqPlatformLegacy;
+        const eqUser = vi.fn().mockReturnValue({ eq: eqPlatform });
+        return { eq: eqUser };
+      });
+      mockFrom.mockReturnValue({ select });
+
+      const map = await storage.getArchivedMap('user_123', 'espn');
+
+      expect(call).toBe(2);
+      expect(select).toHaveBeenNthCalledWith(1, 'sport, recurring_league_id, mode');
+      expect(select).toHaveBeenNthCalledWith(2, 'sport, recurring_league_id');
+      expect(map.get(archivedKey('football', 'a'))).toBe('hidden');
+      expect(map.get(archivedKey('basketball', 'b'))).toBe('hidden');
+      expect(map.size).toBe(2);
     });
   });
 
@@ -159,8 +237,32 @@ describe('ArchiveStorage', () => {
           recurringLeagueId: 'root-1',
           leagueName: 'Dynasty',
           archivedAt: '2026-06-20T00:00:00.000Z',
+          // Row has no `mode` (pre-migration); normalizeArchiveMode maps missing → 'hidden'.
+          mode: 'hidden',
         },
       ]);
+    });
+
+    it('maps an explicit historical mode through to the ArchivedLeague', async () => {
+      const eqUser = vi.fn().mockResolvedValue({
+        data: [
+          {
+            platform: 'espn',
+            sport: 'football',
+            recurring_league_id: '123',
+            league_name: 'Keepers',
+            archived_at: '2026-06-20T00:00:00.000Z',
+            mode: 'historical',
+          },
+        ],
+        error: null,
+      });
+      const select = vi.fn().mockReturnValue({ eq: eqUser });
+      mockFrom.mockReturnValue({ select });
+
+      const result = await storage.listArchived('user_123');
+
+      expect(result[0].mode).toBe('historical');
     });
   });
 });

--- a/workers/auth-worker/src/__tests__/eval-api-key.test.ts
+++ b/workers/auth-worker/src/__tests__/eval-api-key.test.ts
@@ -214,6 +214,17 @@ describe('eval API key auth', () => {
     expect(mockGetLeagues).toHaveBeenCalledWith(EVAL_USER_ID, 'exclude-hidden');
   });
 
+  it('GET /auth/internal/leagues with a malformed archived param falls back to exclude-archived (fail-safe)', async () => {
+    // A garbled or hostile value must NOT widen the AI view — strict equality means
+    // anything other than 'exclude-hidden' resolves to the most-suppressive default.
+    await appFetch(
+      makeRequest('/auth/internal/leagues?archived=include-all', {
+        headers: internalHeaders(EVAL_API_KEY),
+      })
+    );
+    expect(mockGetLeagues).toHaveBeenCalledWith(EVAL_USER_ID, 'exclude-archived');
+  });
+
   it('GET /auth/internal/leagues/yahoo with valid API key returns leagues', async () => {
     const res = await appFetch(
       makeRequest('/auth/internal/leagues/yahoo', {

--- a/workers/auth-worker/src/__tests__/eval-api-key.test.ts
+++ b/workers/auth-worker/src/__tests__/eval-api-key.test.ts
@@ -11,9 +11,10 @@ const DEMO_USER_ID = 'user_demo_test_54321';
 const INTERNAL_SERVICE_TOKEN = 'internal-service-secret';
 
 const mockRateLimiter = { limit: async () => ({ success: true }) };
-const { mockClearDefaultLeague, mockClearStaleDefaultForLeague } = vi.hoisted(() => ({
+const { mockClearDefaultLeague, mockClearStaleDefaultForLeague, mockGetLeagues } = vi.hoisted(() => ({
   mockClearDefaultLeague: vi.fn().mockResolvedValue({ success: true }),
   mockClearStaleDefaultForLeague: vi.fn().mockResolvedValue(undefined),
+  mockGetLeagues: vi.fn().mockResolvedValue([]),
 }));
 
 const baseEnv = {
@@ -55,7 +56,7 @@ async function appFetch(req: Request, env = baseEnv): Promise<Response> {
 vi.mock('../supabase-storage', () => {
   const mockStorage = {
     getCredentials: vi.fn().mockResolvedValue({ swid: 'test-swid', s2: 'test-s2' }),
-    getLeagues: vi.fn().mockResolvedValue([]),
+    getLeagues: mockGetLeagues,
     getCurrentSeasonLeagues: vi.fn().mockResolvedValue([]),
     hasCredentials: vi.fn().mockResolvedValue(true),
     getSetupStatus: vi.fn().mockResolvedValue({ hasCredentials: true, hasLeagues: false, hasDefaultTeam: false }),
@@ -131,6 +132,7 @@ describe('eval API key auth', () => {
     vi.clearAllMocks();
     mockClearDefaultLeague.mockResolvedValue({ success: true });
     mockClearStaleDefaultForLeague.mockResolvedValue(undefined);
+    mockGetLeagues.mockResolvedValue([]);
   });
 
   // =========================================================================
@@ -192,6 +194,24 @@ describe('eval API key auth', () => {
     expect(res.status).toBe(200);
     const body = await res.json() as { success: boolean };
     expect(body.success).toBe(true);
+  });
+
+  it('GET /auth/internal/leagues with no archived param forwards exclude-archived (get_user_session view)', async () => {
+    await appFetch(
+      makeRequest('/auth/internal/leagues', {
+        headers: internalHeaders(EVAL_API_KEY),
+      })
+    );
+    expect(mockGetLeagues).toHaveBeenCalledWith(EVAL_USER_ID, 'exclude-archived');
+  });
+
+  it('GET /auth/internal/leagues?archived=exclude-hidden forwards exclude-hidden (get_ancient_history view)', async () => {
+    await appFetch(
+      makeRequest('/auth/internal/leagues?archived=exclude-hidden', {
+        headers: internalHeaders(EVAL_API_KEY),
+      })
+    );
+    expect(mockGetLeagues).toHaveBeenCalledWith(EVAL_USER_ID, 'exclude-hidden');
   });
 
   it('GET /auth/internal/leagues/yahoo with valid API key returns leagues', async () => {

--- a/workers/auth-worker/src/__tests__/sleeper-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/sleeper-connect-handlers.test.ts
@@ -20,13 +20,15 @@ vi.mock('../sleeper-storage', () => ({
 // ArchiveStorage is constructed inside the public/internal Sleeper league handlers
 // (annotate / exclude). Mock it so no real Supabase client is created and the
 // archived set is controllable per test (defaults to empty).
-const mockGetArchivedSet = vi.fn(async () => new Set<string>());
+// The public annotate path now reads getArchivedMap (mode-tagged) rather than the
+// flat getArchivedSet, so stub the map. Default: nothing archived (empty map).
+const mockGetArchivedMap = vi.fn(async () => new Map<string, 'historical' | 'hidden'>());
 // Keep the real archivedKey so the handler's composite-key membership check
 // (sport:recurringId) uses the production key format.
 const archivedKey = (sport: string, recurringLeagueId: string) => `${sport}:${recurringLeagueId}`;
 vi.mock('../archive-storage', () => ({
   ArchiveStorage: {
-    fromEnvironment: vi.fn(() => ({ getArchivedSet: mockGetArchivedSet })),
+    fromEnvironment: vi.fn(() => ({ getArchivedMap: mockGetArchivedMap })),
   },
   archivedKey: (sport: string, recurringLeagueId: string) => `${sport}:${recurringLeagueId}`,
 }));
@@ -67,7 +69,7 @@ describe('sleeper-connect-handlers', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockFetch.mockReset();
-    mockGetArchivedSet.mockImplementation(async () => new Set<string>());
+    mockGetArchivedMap.mockImplementation(async () => new Map<string, 'historical' | 'hidden'>());
 
     mockStorage = {
       saveSleeperConnection: vi.fn().mockResolvedValue(undefined),
@@ -767,7 +769,7 @@ describe('sleeper-connect-handlers', () => {
         sleeperUsername: 'demo_user',
         updatedAt: '2026-01-25T12:00:00.000Z',
       });
-      // Status passes includeArchived:false; the storage mock here returns the
+      // Status excludes archived (both modes); the storage mock here returns the
       // already-filtered set, so assert the count reflects what the handler got.
       mockStorage.getSleeperLeagues.mockResolvedValue([]);
 
@@ -775,7 +777,7 @@ describe('sleeper-connect-handlers', () => {
       const body = (await response.json()) as Record<string, unknown>;
 
       expect(body.leagueCount).toBe(0);
-      expect(mockStorage.getSleeperLeagues).toHaveBeenCalledWith('user_1', false);
+      expect(mockStorage.getSleeperLeagues).toHaveBeenCalledWith('user_1', 'exclude-archived');
     });
   });
 
@@ -800,42 +802,56 @@ describe('sleeper-connect-handlers', () => {
 
     it('public path annotates archived=true when the recurring id is archived', async () => {
       mockStorage.getSleeperLeagues.mockResolvedValue(stored);
-      // Composite key: the archived set is keyed by sport:recurringId.
-      mockGetArchivedSet.mockResolvedValue(new Set([archivedKey('football', 'sleeper-root')]));
+      // Composite key: the archived map is keyed by sport:recurringId.
+      mockGetArchivedMap.mockResolvedValue(new Map([[archivedKey('football', 'sleeper-root'), 'historical']]));
 
       const response = await handleSleeperLeagues(env, 'user_1', corsHeaders);
-      const body = (await response.json()) as { leagues: Array<{ archived?: boolean }> };
+      const body = (await response.json()) as { leagues: Array<{ archived?: boolean; archiveMode?: string }> };
 
-      expect(mockStorage.getSleeperLeagues).toHaveBeenCalledWith('user_1', true);
+      expect(mockStorage.getSleeperLeagues).toHaveBeenCalledWith('user_1', 'include-all');
       expect(body.leagues[0].archived).toBe(true);
+      // Public annotate now also surfaces the mode so the UI can bucket historical vs hidden.
+      expect(body.leagues[0].archiveMode).toBe('historical');
+    });
+
+    it('public path annotates archiveMode=hidden for a hidden league', async () => {
+      mockStorage.getSleeperLeagues.mockResolvedValue(stored);
+      mockGetArchivedMap.mockResolvedValue(new Map([[archivedKey('football', 'sleeper-root'), 'hidden']]));
+
+      const response = await handleSleeperLeagues(env, 'user_1', corsHeaders);
+      const body = (await response.json()) as { leagues: Array<{ archived?: boolean; archiveMode?: string }> };
+
+      expect(body.leagues[0].archived).toBe(true);
+      expect(body.leagues[0].archiveMode).toBe('hidden');
     });
 
     it('public path does NOT annotate archived for a same recurring id in a different sport', async () => {
       // Stored league is football; archiving basketball:sleeper-root must not flag it.
       mockStorage.getSleeperLeagues.mockResolvedValue(stored);
-      mockGetArchivedSet.mockResolvedValue(new Set([archivedKey('basketball', 'sleeper-root')]));
+      mockGetArchivedMap.mockResolvedValue(new Map([[archivedKey('basketball', 'sleeper-root'), 'historical']]));
 
       const response = await handleSleeperLeagues(env, 'user_1', corsHeaders);
-      const body = (await response.json()) as { leagues: Array<{ archived?: boolean }> };
+      const body = (await response.json()) as { leagues: Array<{ archived?: boolean; archiveMode?: string }> };
 
       expect(body.leagues[0].archived).toBe(false);
+      expect(body.leagues[0].archiveMode).toBeUndefined();
     });
 
     it('internal path excludes archived rows and omits the flag', async () => {
       mockStorage.getSleeperLeagues.mockResolvedValue(stored);
 
-      const response = await handleSleeperLeagues(env, 'user_1', corsHeaders, { includeArchived: false });
+      const response = await handleSleeperLeagues(env, 'user_1', corsHeaders, { archived: 'exclude-archived' });
       const body = (await response.json()) as { leagues: Array<{ archived?: boolean }> };
 
-      // Storage was asked to exclude archived; archive set is not consulted for annotation.
-      expect(mockStorage.getSleeperLeagues).toHaveBeenCalledWith('user_1', false);
-      expect(mockGetArchivedSet).not.toHaveBeenCalled();
+      // Storage was asked to exclude archived; archive map is not consulted for annotation.
+      expect(mockStorage.getSleeperLeagues).toHaveBeenCalledWith('user_1', 'exclude-archived');
+      expect(mockGetArchivedMap).not.toHaveBeenCalled();
       expect(body.leagues[0].archived).toBeUndefined();
     });
 
-    it('public path fails OPEN on an archive-set error — returns leagues unflagged', async () => {
+    it('public path fails OPEN on an archive-map error — returns leagues unflagged', async () => {
       mockStorage.getSleeperLeagues.mockResolvedValue(stored);
-      mockGetArchivedSet.mockRejectedValue(new Error('Failed to get archived set: boom'));
+      mockGetArchivedMap.mockRejectedValue(new Error('Failed to get archived map: boom'));
 
       const response = await handleSleeperLeagues(env, 'user_1', corsHeaders);
       const body = (await response.json()) as { leagues: Array<{ archived?: boolean }> };

--- a/workers/auth-worker/src/__tests__/sleeper-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/sleeper-storage.test.ts
@@ -493,7 +493,7 @@ describe('SleeperStorage', () => {
         return {};
       });
 
-      const result = await storage.getSleeperLeagues('u', false);
+      const result = await storage.getSleeperLeagues('u', 'exclude-archived');
       expect(result.map((l) => l.leagueId)).toEqual(['K2025']);
     });
 
@@ -511,7 +511,7 @@ describe('SleeperStorage', () => {
         return {};
       });
 
-      const result = await storage.getSleeperLeagues('u', false);
+      const result = await storage.getSleeperLeagues('u', 'exclude-archived');
       // Only the football ROOT is hidden; the basketball ROOT survives.
       expect(result.map((l) => ({ leagueId: l.leagueId, sport: l.sport }))).toEqual([
         { leagueId: 'B2025', sport: 'basketball' },
@@ -531,7 +531,7 @@ describe('SleeperStorage', () => {
         return {};
       });
 
-      const result = await storage.getSleeperLeagues('u', false);
+      const result = await storage.getSleeperLeagues('u', 'exclude-archived');
       expect(result.map((l) => l.leagueId)).toEqual(['K2025']);
     });
 
@@ -553,7 +553,77 @@ describe('SleeperStorage', () => {
         return {};
       });
 
-      await expect(storage.getSleeperLeagues('u', false)).rejects.toThrow('Failed to get archived set');
+      await expect(storage.getSleeperLeagues('u', 'exclude-archived')).rejects.toThrow('Failed to get archived map');
+    });
+
+    // archived_leagues read with explicit modes: pass [sport, id, mode] tuples.
+    function mockArchiveReadModes(rows: [string, string, 'historical' | 'hidden'][]) {
+      const eqPlatform = vi.fn().mockResolvedValue({
+        data: rows.map(([sport, recurring_league_id, mode]) => ({ sport, recurring_league_id, mode })),
+        error: null,
+      });
+      const eqUser = vi.fn().mockReturnValue({ eq: eqPlatform });
+      return { select: vi.fn().mockReturnValue({ eq: eqUser }) };
+    }
+
+    it('exclude-hidden keeps a historical row, drops a hidden one, and keeps non-archived', async () => {
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'sleeper_leagues') {
+          return mockLeaguesRead([
+            { id: 'a', clerk_user_id: 'u', league_id: 'ACT', sport: 'football', season_year: 2025, league_name: 'Active', roster_id: 1, recurring_league_id: 'ACTROOT', sleeper_user_id: 's' },
+            { id: 'b', clerk_user_id: 'u', league_id: 'HIST', sport: 'football', season_year: 2025, league_name: 'Historical', roster_id: 2, recurring_league_id: 'HISTROOT', sleeper_user_id: 's' },
+            { id: 'c', clerk_user_id: 'u', league_id: 'HID', sport: 'football', season_year: 2025, league_name: 'Hidden', roster_id: 3, recurring_league_id: 'HIDROOT', sleeper_user_id: 's' },
+          ]);
+        }
+        if (table === 'archived_leagues') return mockArchiveReadModes([
+          ['football', 'HISTROOT', 'historical'],
+          ['football', 'HIDROOT', 'hidden'],
+        ]);
+        return {};
+      });
+
+      const result = await storage.getSleeperLeagues('u', 'exclude-hidden');
+      expect(result.map((l) => l.leagueId)).toEqual(['ACT', 'HIST']);
+    });
+
+    it('exclude-archived drops BOTH historical and hidden rows', async () => {
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'sleeper_leagues') {
+          return mockLeaguesRead([
+            { id: 'a', clerk_user_id: 'u', league_id: 'ACT', sport: 'football', season_year: 2025, league_name: 'Active', roster_id: 1, recurring_league_id: 'ACTROOT', sleeper_user_id: 's' },
+            { id: 'b', clerk_user_id: 'u', league_id: 'HIST', sport: 'football', season_year: 2025, league_name: 'Historical', roster_id: 2, recurring_league_id: 'HISTROOT', sleeper_user_id: 's' },
+            { id: 'c', clerk_user_id: 'u', league_id: 'HID', sport: 'football', season_year: 2025, league_name: 'Hidden', roster_id: 3, recurring_league_id: 'HIDROOT', sleeper_user_id: 's' },
+          ]);
+        }
+        if (table === 'archived_leagues') return mockArchiveReadModes([
+          ['football', 'HISTROOT', 'historical'],
+          ['football', 'HIDROOT', 'hidden'],
+        ]);
+        return {};
+      });
+
+      const result = await storage.getSleeperLeagues('u', 'exclude-archived');
+      expect(result.map((l) => l.leagueId)).toEqual(['ACT']);
+    });
+
+    it('include-all returns everything regardless of mode', async () => {
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'sleeper_leagues') {
+          return mockLeaguesRead([
+            { id: 'a', clerk_user_id: 'u', league_id: 'ACT', sport: 'football', season_year: 2025, league_name: 'Active', roster_id: 1, recurring_league_id: 'ACTROOT', sleeper_user_id: 's' },
+            { id: 'b', clerk_user_id: 'u', league_id: 'HIST', sport: 'football', season_year: 2025, league_name: 'Historical', roster_id: 2, recurring_league_id: 'HISTROOT', sleeper_user_id: 's' },
+            { id: 'c', clerk_user_id: 'u', league_id: 'HID', sport: 'football', season_year: 2025, league_name: 'Hidden', roster_id: 3, recurring_league_id: 'HIDROOT', sleeper_user_id: 's' },
+          ]);
+        }
+        if (table === 'archived_leagues') return mockArchiveReadModes([
+          ['football', 'HISTROOT', 'historical'],
+          ['football', 'HIDROOT', 'hidden'],
+        ]);
+        return {};
+      });
+
+      const result = await storage.getSleeperLeagues('u', 'include-all');
+      expect(result.map((l) => l.leagueId)).toEqual(['ACT', 'HIST', 'HID']);
     });
 
     it('returns all rows and skips the archive read when includeArchived is true', async () => {
@@ -626,7 +696,7 @@ describe('SleeperStorage', () => {
       storedRecurring = 'ROOT2024';
 
       // (b) The exclude filter now keys on the stored root and drops the row.
-      const result = await storage.getSleeperLeagues('u', false);
+      const result = await storage.getSleeperLeagues('u', 'exclude-archived');
       expect(result.map((l) => l.leagueId)).toEqual([]);
     });
 

--- a/workers/auth-worker/src/__tests__/supabase-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/supabase-storage.test.ts
@@ -157,7 +157,7 @@ describe('EspnSupabaseStorage', () => {
       return {};
     });
 
-    const filtered = await storage.getLeagues('user_123', false);
+    const filtered = await storage.getLeagues('user_123', 'exclude-archived');
     expect(filtered.map(l => l.leagueId)).toEqual(['111']);
   });
 
@@ -183,7 +183,7 @@ describe('EspnSupabaseStorage', () => {
       return {};
     });
 
-    const filtered = await storage.getLeagues('user_123', false);
+    const filtered = await storage.getLeagues('user_123', 'exclude-archived');
     // Only the football `123` is hidden; the basketball `123` survives.
     expect(filtered.map(l => ({ leagueId: l.leagueId, sport: l.sport }))).toEqual([
       { leagueId: '123', sport: 'basketball' },
@@ -210,7 +210,70 @@ describe('EspnSupabaseStorage', () => {
       return {};
     });
 
-    await expect(storage.getLeagues('user_123', false)).rejects.toThrow('Failed to get archived set');
+    await expect(storage.getLeagues('user_123', 'exclude-archived')).rejects.toThrow('Failed to get archived map');
+  });
+
+  it('getLeagues exclude-hidden keeps historical archived rows, drops only hidden ones', async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'espn_leagues') {
+        const eq = vi.fn().mockResolvedValue({
+          data: [
+            { league_id: '111', sport: 'football', team_id: 't1', team_name: 'A', league_name: 'Active', season_year: 2025 },
+            { league_id: '222', sport: 'football', team_id: 't2', team_name: 'B', league_name: 'Historical', season_year: 2025 },
+            { league_id: '333', sport: 'football', team_id: 't3', team_name: 'C', league_name: 'Hidden', season_year: 2025 },
+          ],
+          error: null,
+        });
+        return { select: vi.fn().mockReturnValue({ eq }) };
+      }
+      if (table === 'archived_leagues') {
+        const eqPlatform = vi.fn().mockResolvedValue({
+          data: [
+            { sport: 'football', recurring_league_id: '222', mode: 'historical' },
+            { sport: 'football', recurring_league_id: '333', mode: 'hidden' },
+          ],
+          error: null,
+        });
+        const eqUser = vi.fn().mockReturnValue({ eq: eqPlatform });
+        return { select: vi.fn().mockReturnValue({ eq: eqUser }) };
+      }
+      return {};
+    });
+
+    const filtered = await storage.getLeagues('user_123', 'exclude-hidden');
+    // Active + historical survive (the get_ancient_history view); only 'hidden' drops.
+    expect(filtered.map(l => l.leagueId)).toEqual(['111', '222']);
+  });
+
+  it('getLeagues exclude-archived drops BOTH historical and hidden archived rows', async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'espn_leagues') {
+        const eq = vi.fn().mockResolvedValue({
+          data: [
+            { league_id: '111', sport: 'football', team_id: 't1', team_name: 'A', league_name: 'Active', season_year: 2025 },
+            { league_id: '222', sport: 'football', team_id: 't2', team_name: 'B', league_name: 'Historical', season_year: 2025 },
+            { league_id: '333', sport: 'football', team_id: 't3', team_name: 'C', league_name: 'Hidden', season_year: 2025 },
+          ],
+          error: null,
+        });
+        return { select: vi.fn().mockReturnValue({ eq }) };
+      }
+      if (table === 'archived_leagues') {
+        const eqPlatform = vi.fn().mockResolvedValue({
+          data: [
+            { sport: 'football', recurring_league_id: '222', mode: 'historical' },
+            { sport: 'football', recurring_league_id: '333', mode: 'hidden' },
+          ],
+          error: null,
+        });
+        const eqUser = vi.fn().mockReturnValue({ eq: eqPlatform });
+        return { select: vi.fn().mockReturnValue({ eq: eqUser }) };
+      }
+      return {};
+    });
+
+    const filtered = await storage.getLeagues('user_123', 'exclude-archived');
+    expect(filtered.map(l => l.leagueId)).toEqual(['111']);
   });
 
   it('setDefaultLeague fails OPEN on an archive-set error — allows the default', async () => {

--- a/workers/auth-worker/src/__tests__/yahoo-archive-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/yahoo-archive-storage.test.ts
@@ -54,7 +54,7 @@ describe('YahooStorage archive surface', () => {
         return {};
       });
 
-      const result = await storage.getYahooLeagues('u', false);
+      const result = await storage.getYahooLeagues('u', 'exclude-archived');
       expect(result.map((l) => l.leagueKey)).toEqual(['449.l.20']);
     });
 
@@ -71,7 +71,7 @@ describe('YahooStorage archive surface', () => {
         return {};
       });
 
-      const result = await storage.getYahooLeagues('u', false);
+      const result = await storage.getYahooLeagues('u', 'exclude-archived');
       expect(result.map((l) => l.leagueKey)).toEqual(['449.l.20']);
     });
 
@@ -87,7 +87,7 @@ describe('YahooStorage archive surface', () => {
         return {};
       });
 
-      const result = await storage.getYahooLeagues('u', false);
+      const result = await storage.getYahooLeagues('u', 'exclude-archived');
       expect(result.map((l) => ({ leagueKey: l.leagueKey, sport: l.sport }))).toEqual([
         { leagueKey: '454.l.10', sport: 'basketball' },
       ]);
@@ -109,7 +109,67 @@ describe('YahooStorage archive surface', () => {
         return {};
       });
 
-      await expect(storage.getYahooLeagues('u', false)).rejects.toThrow('Failed to get archived set');
+      await expect(storage.getYahooLeagues('u', 'exclude-archived')).rejects.toThrow('Failed to get archived map');
+    });
+
+    // archived_leagues read with explicit modes: pass [sport, id, mode] tuples.
+    function mockArchiveReadModes(rows: [string, string, 'historical' | 'hidden'][]) {
+      const eqPlatform = vi.fn().mockResolvedValue({
+        data: rows.map(([sport, recurring_league_id, mode]) => ({ sport, recurring_league_id, mode })),
+        error: null,
+      });
+      const eqUser = vi.fn().mockReturnValue({ eq: eqPlatform });
+      return { select: vi.fn().mockReturnValue({ eq: eqUser }) };
+    }
+
+    function threeRows() {
+      return [
+        { id: 'a', clerk_user_id: 'u', sport: 'football', season_year: 2025, league_key: '449.l.10', league_name: 'Active', team_id: null, team_key: null, team_name: null, recurring_league_id: 'ACTROOT' },
+        { id: 'b', clerk_user_id: 'u', sport: 'football', season_year: 2025, league_key: '449.l.20', league_name: 'Historical', team_id: null, team_key: null, team_name: null, recurring_league_id: 'HISTROOT' },
+        { id: 'c', clerk_user_id: 'u', sport: 'football', season_year: 2025, league_key: '449.l.30', league_name: 'Hidden', team_id: null, team_key: null, team_name: null, recurring_league_id: 'HIDROOT' },
+      ];
+    }
+
+    it('exclude-hidden keeps a historical row, drops a hidden one, and keeps non-archived', async () => {
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'yahoo_leagues') return mockLeaguesRead(threeRows());
+        if (table === 'archived_leagues') return mockArchiveReadModes([
+          ['football', 'HISTROOT', 'historical'],
+          ['football', 'HIDROOT', 'hidden'],
+        ]);
+        return {};
+      });
+
+      const result = await storage.getYahooLeagues('u', 'exclude-hidden');
+      expect(result.map((l) => l.leagueKey)).toEqual(['449.l.10', '449.l.20']);
+    });
+
+    it('exclude-archived drops BOTH historical and hidden rows', async () => {
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'yahoo_leagues') return mockLeaguesRead(threeRows());
+        if (table === 'archived_leagues') return mockArchiveReadModes([
+          ['football', 'HISTROOT', 'historical'],
+          ['football', 'HIDROOT', 'hidden'],
+        ]);
+        return {};
+      });
+
+      const result = await storage.getYahooLeagues('u', 'exclude-archived');
+      expect(result.map((l) => l.leagueKey)).toEqual(['449.l.10']);
+    });
+
+    it('include-all returns everything regardless of mode', async () => {
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'yahoo_leagues') return mockLeaguesRead(threeRows());
+        if (table === 'archived_leagues') return mockArchiveReadModes([
+          ['football', 'HISTROOT', 'historical'],
+          ['football', 'HIDROOT', 'hidden'],
+        ]);
+        return {};
+      });
+
+      const result = await storage.getYahooLeagues('u', 'include-all');
+      expect(result.map((l) => l.leagueKey)).toEqual(['449.l.10', '449.l.20', '449.l.30']);
     });
 
     it('returns all rows and skips the archive read when includeArchived is true', async () => {

--- a/workers/auth-worker/src/archive-storage.ts
+++ b/workers/auth-worker/src/archive-storage.ts
@@ -22,12 +22,28 @@ import { createClient, SupabaseClient } from '@supabase/supabase-js';
 export type ArchivePlatform = 'espn' | 'yahoo' | 'sleeper';
 export type ArchiveSport = 'football' | 'baseball' | 'basketball' | 'hockey';
 
+/**
+ * Suppression mode (FLA-150):
+ *   'historical' — hidden from get_user_session but browsable in get_ancient_history
+ *   'hidden'     — hidden from BOTH AI tools (the original binary-archive behavior)
+ */
+export type ArchiveMode = 'historical' | 'hidden';
+
+/**
+ * How a league read should treat archived leagues:
+ *   'include-all'      — return everything (dedupe / discovery / UI annotation)
+ *   'exclude-archived' — drop BOTH modes (the active get_user_session view)
+ *   'exclude-hidden'   — drop only 'hidden' (the get_ancient_history view)
+ */
+export type ArchivedFilter = 'include-all' | 'exclude-archived' | 'exclude-hidden';
+
 export interface ArchivedLeague {
   platform: ArchivePlatform;
   sport: ArchiveSport;
   recurringLeagueId: string;
   leagueName?: string;
   archivedAt?: string;
+  mode: ArchiveMode;
 }
 
 interface ArchivedLeagueRow {
@@ -36,6 +52,39 @@ interface ArchivedLeagueRow {
   recurring_league_id: string;
   league_name: string | null;
   archived_at: string | null;
+  mode?: string | null;
+}
+
+/** Normalize a raw `mode` value; anything unexpected (incl. null) → 'hidden' (the
+ * most-suppressive, no-leak default). Post-migration every row has a valid mode. */
+function normalizeArchiveMode(mode: string | null | undefined): ArchiveMode {
+  return mode === 'historical' ? 'historical' : 'hidden';
+}
+
+/** True when a DB error indicates the `mode` column doesn't exist yet (code runs
+ * before migration 025). Lets the read path fall back to legacy behavior instead
+ * of failing closed on a transient-looking error it can actually recover from. */
+function isMissingModeColumn(error: { code?: string; message?: string } | null): boolean {
+  if (!error) return false;
+  if (error.code === '42703') return true; // Postgres undefined_column
+  return /column\b.*\bmode\b.*does not exist/i.test(error.message ?? '');
+}
+
+/**
+ * Decide whether a league row should be dropped under a given filter, given the
+ * archived map (from getArchivedMap) and the row's archive key (archivedKey).
+ * Centralizes the tri-state semantics so the per-platform storage reads can't drift.
+ */
+export function isSuppressed(
+  filter: ArchivedFilter,
+  archived: Map<string, ArchiveMode>,
+  key: string
+): boolean {
+  if (filter === 'include-all') return false;
+  const mode = archived.get(key);
+  if (mode === undefined) return false; // not archived at all
+  if (filter === 'exclude-archived') return true; // active view drops both modes
+  return mode === 'hidden'; // exclude-hidden: history view drops only 'hidden'
 }
 
 function maskUserId(userId: string): string {
@@ -78,7 +127,8 @@ export class ArchiveStorage {
     platform: ArchivePlatform,
     sport: ArchiveSport,
     recurringLeagueId: string,
-    leagueName?: string
+    leagueName?: string,
+    mode: ArchiveMode = 'historical'
   ): Promise<boolean> {
     try {
       if (!clerkUserId || !recurringLeagueId) return false;
@@ -93,6 +143,7 @@ export class ArchiveStorage {
             recurring_league_id: recurringLeagueId,
             league_name: leagueName ?? null,
             archived_at: new Date().toISOString(),
+            mode,
           },
           { onConflict: 'clerk_user_id,platform,sport,recurring_league_id' }
         );
@@ -103,7 +154,7 @@ export class ArchiveStorage {
       }
 
       console.log(
-        `[archive-storage] archiveLeague: archived ${platform}:${sport}:${recurringLeagueId} for user ${maskUserId(clerkUserId)}`
+        `[archive-storage] archiveLeague: ${mode} ${platform}:${sport}:${recurringLeagueId} for user ${maskUserId(clerkUserId)}`
       );
       return true;
     } catch (error) {
@@ -154,9 +205,11 @@ export class ArchiveStorage {
     try {
       if (!clerkUserId) return [];
 
+      // select('*') so the read tolerates the `mode` column being present or absent
+      // (pre-migration); normalizeArchiveMode maps a missing/null mode to 'hidden'.
       const { data, error } = await this.supabase
         .from('archived_leagues')
-        .select('platform, sport, recurring_league_id, league_name, archived_at')
+        .select('*')
         .eq('clerk_user_id', clerkUserId);
 
       if (error || !data) {
@@ -170,6 +223,7 @@ export class ArchiveStorage {
         recurringLeagueId: row.recurring_league_id,
         leagueName: row.league_name ?? undefined,
         archivedAt: row.archived_at ?? undefined,
+        mode: normalizeArchiveMode(row.mode),
       }));
     } catch (error) {
       console.error('[archive-storage] Failed to list archived leagues:', error);
@@ -178,36 +232,68 @@ export class ArchiveStorage {
   }
 
   /**
-   * Return the set of archived leagues for a user + platform, keyed by
-   * `sport:recurringId` (see `archivedKey`). Used by the read-path filter as a
-   * plain composite-key comparison. The sport is part of the key because
-   * recurring ids are only unique within a sport.
+   * Return archived leagues for a user + platform as a `Map<archivedKey, mode>`,
+   * keyed by `sport:recurringId` (see `archivedKey`). The mode lets the read-path
+   * filter distinguish 'historical' (browsable in get_ancient_history) from
+   * 'hidden' (gone from both AI tools).
    *
-   * THROWS on a DB error (fail-closed). Exclude-path callers (internal
-   * `includeArchived:false`) let it propagate so a transient error fails the
-   * league read rather than silently un-hiding archived leagues from the AI —
-   * the gateway already tolerates a platform fetch failure. Annotate-path
-   * callers (public UI) catch it and fall back to an empty set (fail-open) so the
-   * UI just loses the archived flag.
+   * THROWS on a DB error (fail-closed). Exclude-path callers let it propagate so a
+   * transient error fails the league read rather than silently un-hiding archived
+   * leagues from the AI. Annotate-path callers (public UI) catch and fall back to
+   * an empty map (fail-open) so the UI just loses the archived flag.
+   *
+   * Tolerates the pre-migration schema: if the `mode` column doesn't exist yet,
+   * it falls back to reading without it and treats every archived league as
+   * 'hidden' (the original behavior) — so this is safe regardless of whether the
+   * migration or the code lands first. Any OTHER DB error still fails closed.
    */
-  async getArchivedSet(clerkUserId: string, platform: ArchivePlatform): Promise<Set<string>> {
-    if (!clerkUserId) return new Set();
+  async getArchivedMap(clerkUserId: string, platform: ArchivePlatform): Promise<Map<string, ArchiveMode>> {
+    if (!clerkUserId) return new Map();
 
     const { data, error } = await this.supabase
       .from('archived_leagues')
-      .select('sport, recurring_league_id')
+      .select('sport, recurring_league_id, mode')
       .eq('clerk_user_id', clerkUserId)
       .eq('platform', platform);
 
-    if (error || !data) {
-      console.error('[archive-storage] getArchivedSet error:', error);
-      throw new Error(`Failed to get archived set: ${error?.message ?? 'no data returned'}`);
+    if (!error && data) {
+      return new Map(
+        (data as { sport: string; recurring_league_id: string; mode: string | null }[]).map((row) => [
+          archivedKey(row.sport, row.recurring_league_id),
+          normalizeArchiveMode(row.mode),
+        ])
+      );
     }
 
-    return new Set(
-      (data as { sport: string; recurring_league_id: string }[]).map((row) =>
-        archivedKey(row.sport, row.recurring_league_id)
-      )
-    );
+    if (isMissingModeColumn(error)) {
+      const { data: legacyData, error: legacyError } = await this.supabase
+        .from('archived_leagues')
+        .select('sport, recurring_league_id')
+        .eq('clerk_user_id', clerkUserId)
+        .eq('platform', platform);
+
+      if (!legacyError && legacyData) {
+        return new Map(
+          (legacyData as { sport: string; recurring_league_id: string }[]).map((row) => [
+            archivedKey(row.sport, row.recurring_league_id),
+            'hidden' as ArchiveMode,
+          ])
+        );
+      }
+      console.error('[archive-storage] getArchivedMap legacy fallback error:', legacyError);
+      throw new Error(`Failed to get archived map: ${legacyError?.message ?? 'no data returned'}`);
+    }
+
+    console.error('[archive-storage] getArchivedMap error:', error);
+    throw new Error(`Failed to get archived map: ${error?.message ?? 'no data returned'}`);
+  }
+
+  /**
+   * Set of archived keys (both modes) for a user + platform. Back-compat wrapper
+   * over getArchivedMap for callers that only need "is this league suppressed at
+   * all" (the active-view exclude path). Fail-closed (throws) like getArchivedMap.
+   */
+  async getArchivedSet(clerkUserId: string, platform: ArchivePlatform): Promise<Set<string>> {
+    return new Set((await this.getArchivedMap(clerkUserId, platform)).keys());
   }
 }

--- a/workers/auth-worker/src/index-hono.ts
+++ b/workers/auth-worker/src/index-hono.ts
@@ -60,7 +60,7 @@ import {
   YahooConnectEnv,
 } from './yahoo-connect-handlers';
 import { YahooStorage, type YahooLeague } from './yahoo-storage';
-import { ArchiveStorage, archivedKey, type ArchivePlatform, type ArchiveSport } from './archive-storage';
+import { ArchiveStorage, archivedKey, type ArchivePlatform, type ArchiveSport, type ArchiveMode, type ArchivedFilter } from './archive-storage';
 import { logSetupSignal, type SetupSignalEvent } from '@flaim/worker-shared';
 import {
   handleSleeperDiscover,
@@ -1107,18 +1107,22 @@ async function annotateYahooLeaguesArchived(
   env: Env,
   userId: string,
   leagues: YahooLeague[]
-): Promise<Array<YahooLeague & { archived: boolean }>> {
-  let archivedSet: Set<string>;
+): Promise<Array<YahooLeague & { archived: boolean; archiveMode?: ArchiveMode }>> {
+  let archivedMap: Map<string, ArchiveMode>;
   try {
-    archivedSet = await ArchiveStorage.fromEnvironment(env).getArchivedSet(userId, 'yahoo');
+    archivedMap = await ArchiveStorage.fromEnvironment(env).getArchivedMap(userId, 'yahoo');
   } catch (error) {
-    console.error('[index-hono] getArchivedSet (yahoo) failed; annotating none (fail-open):', error);
-    archivedSet = new Set();
+    console.error('[index-hono] getArchivedMap (yahoo) failed; annotating none (fail-open):', error);
+    archivedMap = new Map();
   }
-  return leagues.map((league) => ({
-    ...league,
-    archived: archivedSet.has(archivedKey(league.sport, league.recurringLeagueId ?? league.leagueKey)),
-  }));
+  return leagues.map((league) => {
+    const key = archivedKey(league.sport, league.recurringLeagueId ?? league.leagueKey);
+    return {
+      ...league,
+      archived: archivedMap.has(key),
+      archiveMode: archivedMap.get(key),
+    };
+  });
 }
 
 // List Yahoo leagues (requires auth)
@@ -1148,9 +1152,11 @@ api.get('/internal/leagues/yahoo', async (c) => {
   }
 
   const storage = YahooStorage.fromEnvironment(c.env);
-  // Internal (gateway-facing) endpoint excludes archived leagues so they vanish
-  // from the AI surfaces. Yahoo archive is active, so this filter is real.
-  const leagues = await storage.getYahooLeagues(userId, false);
+  // Internal (gateway-facing) endpoint. Default excludes archived (both modes) for
+  // get_user_session; get_ancient_history passes ?archived=exclude-hidden to keep
+  // 'historical' leagues browsable while still hiding 'hidden' ones.
+  const archived: ArchivedFilter = c.req.query('archived') === 'exclude-hidden' ? 'exclude-hidden' : 'exclude-archived';
+  const leagues = await storage.getYahooLeagues(userId, archived);
 
   return c.json({ leagues }, 200);
 });
@@ -1238,8 +1244,11 @@ api.get('/internal/leagues/sleeper', async (c) => {
       error_description: authError || 'Authentication required',
     }, authStatus ?? 401);
   }
-  // Internal (gateway-facing) endpoint excludes archived leagues from the AI.
-  return handleSleeperLeagues(c.env as SleeperConnectEnv, userId, getCorsHeaders(c.req.raw), { includeArchived: false });
+  // Internal (gateway-facing) endpoint. Default excludes archived (both modes) for
+  // get_user_session; get_ancient_history passes ?archived=exclude-hidden to keep
+  // 'historical' leagues browsable while still hiding 'hidden' ones.
+  const archived: ArchivedFilter = c.req.query('archived') === 'exclude-hidden' ? 'exclude-hidden' : 'exclude-archived';
+  return handleSleeperLeagues(c.env as SleeperConnectEnv, userId, getCorsHeaders(c.req.raw), { archived });
 });
 
 // Delete Sleeper league (requires auth)
@@ -1262,6 +1271,7 @@ api.delete('/leagues/sleeper/:id', async (c) => {
 
 const ARCHIVE_PLATFORMS: ArchivePlatform[] = ['espn', 'sleeper', 'yahoo'];
 const ARCHIVE_SPORTS: ArchiveSport[] = ['football', 'baseball', 'basketball', 'hockey'];
+const ARCHIVE_MODES: ArchiveMode[] = ['historical', 'hidden'];
 
 // recurringLeagueId allowlist: numeric ESPN/Sleeper ids plus dotted Yahoo-style
 // league_keys (e.g. "449.l.123"). Dots, dashes, and underscores are permitted; no
@@ -1273,13 +1283,14 @@ interface ArchiveRequestBody {
   platform?: string;
   sport?: string;
   recurringLeagueId?: string;
+  mode?: string;
 }
 
 // Exported for unit tests — pure validation, no side effects.
 export function parseArchiveBody(body: ArchiveRequestBody):
-  | { ok: true; platform: ArchivePlatform; sport: ArchiveSport; recurringLeagueId: string }
+  | { ok: true; platform: ArchivePlatform; sport: ArchiveSport; recurringLeagueId: string; mode: ArchiveMode }
   | { ok: false; error: string } {
-  const { platform, sport, recurringLeagueId } = body;
+  const { platform, sport, recurringLeagueId, mode } = body;
   if (!platform || !sport || !recurringLeagueId) {
     return { ok: false, error: 'platform, sport, and recurringLeagueId are required' };
   }
@@ -1295,11 +1306,17 @@ export function parseArchiveBody(body: ArchiveRequestBody):
   if (!RECURRING_LEAGUE_ID_PATTERN.test(recurringLeagueId)) {
     return { ok: false, error: 'Invalid recurringLeagueId' };
   }
+  // mode is optional; defaults to 'historical' (the primary "Archive" action).
+  // 'hidden' is the stronger "Hide" action (suppressed from both AI tools).
+  if (mode !== undefined && !ARCHIVE_MODES.includes(mode as ArchiveMode)) {
+    return { ok: false, error: 'Invalid mode' };
+  }
   return {
     ok: true,
     platform: platform as ArchivePlatform,
     sport: sport as ArchiveSport,
     recurringLeagueId,
+    mode: (mode as ArchiveMode) ?? 'historical',
   };
 }
 
@@ -1328,7 +1345,7 @@ api.post('/leagues/archive', async (c) => {
   if (!parsed.ok) {
     return c.json({ error: parsed.error }, 400);
   }
-  const { platform, sport } = parsed;
+  const { platform, sport, mode } = parsed;
 
   const archiveStorage = ArchiveStorage.fromEnvironment(c.env);
   // clearStaleDefaultForLeague operates on user_preferences and is platform-agnostic,
@@ -1356,7 +1373,7 @@ api.post('/leagues/archive', async (c) => {
     seasonLeagueIds = target.seasonLeagueKeys.length > 0 ? target.seasonLeagueKeys : [recurringLeagueId];
   }
 
-  const archived = await archiveStorage.archiveLeague(userId, platform, sport, recurringLeagueId, leagueName);
+  const archived = await archiveStorage.archiveLeague(userId, platform, sport, recurringLeagueId, leagueName, mode);
   if (!archived) {
     return c.json({ error: 'Failed to archive league' }, 500);
   }
@@ -1367,7 +1384,7 @@ api.post('/leagues/archive', async (c) => {
     await sharedStorage.clearStaleDefaultForLeague(userId, platform, seasonLeagueId, undefined, sport);
   }
 
-  return c.json({ success: true, platform, sport, recurringLeagueId });
+  return c.json({ success: true, platform, sport, recurringLeagueId, mode });
 });
 
 // Unarchive a league (restore it to the visible/AI surfaces).
@@ -1732,9 +1749,11 @@ api.get('/internal/leagues', async (c) => {
   }
 
   const storage = EspnSupabaseStorage.fromEnvironment(c.env);
-  // Internal (gateway-facing) endpoint excludes archived leagues so they vanish
-  // from get_user_session and get_ancient_history automatically.
-  const leagues = await storage.getLeagues(clerkUserId, false);
+  // Internal (gateway-facing) endpoint. Default excludes archived (both modes) for
+  // get_user_session; get_ancient_history passes ?archived=exclude-hidden to keep
+  // 'historical' leagues browsable while still hiding 'hidden' ones.
+  const archived: ArchivedFilter = c.req.query('archived') === 'exclude-hidden' ? 'exclude-hidden' : 'exclude-archived';
+  const leagues = await storage.getLeagues(clerkUserId, archived);
   const leaguesWithPlatform = leagues.map(league => ({
     ...league,
     platform: 'espn' as const
@@ -1790,25 +1809,29 @@ async function handleLeagues(c: Context<{ Bindings: Env }>, method: string): Pro
     });
 
   } else if (method === 'GET') {
-    // Public (UI) endpoint returns ALL leagues with an `archived` boolean so the
-    // UI can bucket them into the Archived section. ESPN recurring id = league_id.
+    // Public (UI) endpoint returns ALL leagues with `archived` + `archiveMode` so
+    // the UI can bucket them into Archived/Hidden. ESPN recurring id = league_id.
     const leagues = await storage.getLeagues(clerkUserId);
     const archiveStorage = ArchiveStorage.fromEnvironment(env);
-    // Annotate path fails OPEN: a transient archive-set error just drops the flag
-    // (the UI loses bucketing) rather than failing the whole league list.
-    let archivedSet: Set<string>;
+    // Annotate path fails OPEN: a transient archive lookup error just drops the
+    // flags (the UI loses bucketing) rather than failing the whole league list.
+    let archivedMap: Map<string, ArchiveMode>;
     try {
-      archivedSet = await archiveStorage.getArchivedSet(clerkUserId, 'espn');
+      archivedMap = await archiveStorage.getArchivedMap(clerkUserId, 'espn');
     } catch (error) {
-      console.error('[auth-worker] /leagues archived-set lookup failed; annotating none:', error);
-      archivedSet = new Set();
+      console.error('[auth-worker] /leagues archived lookup failed; annotating none:', error);
+      archivedMap = new Map();
     }
 
-    const leaguesWithPlatform = leagues.map(league => ({
-      ...league,
-      platform: 'espn' as const,
-      archived: archivedSet.has(archivedKey(league.sport, league.leagueId)),
-    }));
+    const leaguesWithPlatform = leagues.map(league => {
+      const key = archivedKey(league.sport, league.leagueId);
+      return {
+        ...league,
+        platform: 'espn' as const,
+        archived: archivedMap.has(key),
+        archiveMode: archivedMap.get(key),
+      };
+    });
 
     return c.json({
       success: true,

--- a/workers/auth-worker/src/sleeper-connect-handlers.ts
+++ b/workers/auth-worker/src/sleeper-connect-handlers.ts
@@ -200,6 +200,7 @@ async function buildSleeperLeagueResponse(
   return Promise.all(leagues.map(async (league) => {
     const recurringLeagueId = league.recurringLeagueId
       ?? await resolveRecurringLeagueId(league.leagueId, recurringIdCache, leagueCache);
+    const key = archivedKey(league.sport, recurringLeagueId);
 
     return {
       id: league.id,
@@ -214,8 +215,8 @@ async function buildSleeperLeagueResponse(
       // `archived` = suppressed at all; `archiveMode` distinguishes historical/hidden.
       ...(archivedMap
         ? {
-            archived: archivedMap.has(archivedKey(league.sport, recurringLeagueId)),
-            archiveMode: archivedMap.get(archivedKey(league.sport, recurringLeagueId)),
+            archived: archivedMap.has(key),
+            archiveMode: archivedMap.get(key),
           }
         : {}),
     };

--- a/workers/auth-worker/src/sleeper-connect-handlers.ts
+++ b/workers/auth-worker/src/sleeper-connect-handlers.ts
@@ -1,5 +1,5 @@
 import { SleeperStorage, type SleeperLeague } from './sleeper-storage';
-import { ArchiveStorage, archivedKey } from './archive-storage';
+import { ArchiveStorage, archivedKey, type ArchivedFilter, type ArchiveMode } from './archive-storage';
 import { getDefaultSeasonYear } from './season-utils';
 
 const SLEEPER_API = 'https://api.sleeper.app/v1';
@@ -38,6 +38,7 @@ interface SleeperLeagueResponse {
   seasonYear: number;
   recurringLeagueId: string;
   archived?: boolean;
+  archiveMode?: ArchiveMode;
 }
 
 interface RecurringLeagueResolutionResult {
@@ -46,18 +47,18 @@ interface RecurringLeagueResolutionResult {
 }
 
 /**
- * Annotate-path archive-set lookup that fails OPEN: a transient DB error treats
- * nothing as archived (the UI just loses the `archived` flag) rather than failing
- * the whole league list. The exclude path keeps fail-closed via getSleeperLeagues
- * letting getArchivedSet's throw propagate — a DB error there fails the read
- * rather than leaking archived leagues to the AI.
+ * Annotate-path archive lookup that fails OPEN: a transient DB error treats
+ * nothing as archived (the UI just loses the `archived`/`archiveMode` flags) rather
+ * than failing the whole league list. The exclude path keeps fail-closed via
+ * getSleeperLeagues letting getArchivedMap's throw propagate — a DB error there
+ * fails the read rather than leaking archived leagues to the AI.
  */
-async function getArchivedSetFailOpen(env: SleeperConnectEnv, userId: string): Promise<Set<string>> {
+async function getArchivedMapFailOpen(env: SleeperConnectEnv, userId: string): Promise<Map<string, ArchiveMode>> {
   try {
-    return await ArchiveStorage.fromEnvironment(env).getArchivedSet(userId, 'sleeper');
+    return await ArchiveStorage.fromEnvironment(env).getArchivedMap(userId, 'sleeper');
   } catch (error) {
-    console.error('[sleeper-connect] getArchivedSet failed; annotating none (fail-open):', error);
-    return new Set();
+    console.error('[sleeper-connect] getArchivedMap failed; annotating none (fail-open):', error);
+    return new Map();
   }
 }
 
@@ -185,7 +186,7 @@ async function resolveRecurringLeagueId(
 
 async function buildSleeperLeagueResponse(
   leagues: SleeperLeague[],
-  archivedSet?: Set<string>
+  archivedMap?: Map<string, ArchiveMode>
 ): Promise<SleeperLeagueResponse[]> {
   const recurringIdCache = new Map<string, string | null>();
   const leagueCache = new Map<string, Promise<SleeperApiLeague | null>>();
@@ -209,8 +210,14 @@ async function buildSleeperLeagueResponse(
       seasonYear: league.seasonYear,
       recurringLeagueId,
       // Public (UI) responses annotate the archive state so the UI can bucket
-      // archived leagues; internal responses omit the flag and exclude the rows.
-      ...(archivedSet ? { archived: archivedSet.has(archivedKey(league.sport, recurringLeagueId)) } : {}),
+      // archived leagues; internal responses omit the flags and exclude the rows.
+      // `archived` = suppressed at all; `archiveMode` distinguishes historical/hidden.
+      ...(archivedMap
+        ? {
+            archived: archivedMap.has(archivedKey(league.sport, recurringLeagueId)),
+            archiveMode: archivedMap.get(archivedKey(league.sport, recurringLeagueId)),
+          }
+        : {}),
     };
   }));
 }
@@ -232,7 +239,7 @@ export async function backfillSleeperRecurringIds(
   userId: string
 ): Promise<{ processed: number; resolved: number }> {
   const storage = SleeperStorage.fromEnvironment(env);
-  const leagues = await storage.getSleeperLeagues(userId, true);
+  const leagues = await storage.getSleeperLeagues(userId, 'include-all');
 
   const recurringIdCache = new Map<string, string | null>();
   const leagueCache = new Map<string, Promise<SleeperApiLeague | null>>();
@@ -283,7 +290,7 @@ export async function resolveSleeperArchiveTarget(
   requestedRecurringId: string
 ): Promise<{ recurringLeagueId: string; leagueName?: string; seasonLeagueIds: string[] }> {
   const storage = SleeperStorage.fromEnvironment(env);
-  const allLeagues = await storage.getSleeperLeagues(userId, true);
+  const allLeagues = await storage.getSleeperLeagues(userId, 'include-all');
 
   // Rows belonging to this recurring group: either their stored recurring id
   // matches, or (fallback) their season-scoped league_id equals the requested id.
@@ -470,7 +477,7 @@ export async function handleSleeperStatus(
       });
     }
     // Status-card leagueCount excludes archived to match the visible active list.
-    const leagues = await storage.getSleeperLeagues(userId, false);
+    const leagues = await storage.getSleeperLeagues(userId, 'exclude-archived');
     return new Response(
       JSON.stringify({
         connected: true,
@@ -515,23 +522,23 @@ export async function handleSleeperLeagues(
   env: SleeperConnectEnv,
   userId: string,
   corsHeaders: Record<string, string>,
-  options: { includeArchived?: boolean } = {}
+  options: { archived?: ArchivedFilter } = {}
 ): Promise<Response> {
   try {
-    const includeArchived = options.includeArchived ?? true;
+    const archived = options.archived ?? 'include-all';
     const storage = SleeperStorage.fromEnvironment(env);
-    // Internal (gateway-facing) callers pass includeArchived:false so archived
-    // leagues are excluded from the AI surfaces. Public (UI) callers keep the
-    // default and annotate each league with an `archived` boolean instead.
-    const leagues = await storage.getSleeperLeagues(userId, includeArchived);
-    // Annotate path (includeArchived:true, public UI) fails OPEN: a transient
-    // archive-set error just drops the `archived` flag rather than 500-ing the
-    // list. The exclude path (includeArchived:false) lets getSleeperLeagues
-    // propagate the throw — fail-closed so archived leagues never leak to the AI.
-    const archivedSet = includeArchived
-      ? await getArchivedSetFailOpen(env, userId)
+    // Internal (gateway-facing) callers pass 'exclude-archived' (active view) or
+    // 'exclude-hidden' (history view) so archived leagues are filtered for the AI.
+    // Public (UI) callers keep 'include-all' and annotate each league instead.
+    const leagues = await storage.getSleeperLeagues(userId, archived);
+    // Annotate path ('include-all', public UI) fails OPEN: a transient archive
+    // error just drops the flags rather than 500-ing the list. The exclude paths
+    // let getSleeperLeagues propagate the throw — fail-closed so archived leagues
+    // never leak to the AI.
+    const archivedMap = archived === 'include-all'
+      ? await getArchivedMapFailOpen(env, userId)
       : undefined;
-    const responseLeagues = await buildSleeperLeagueResponse(leagues, archivedSet);
+    const responseLeagues = await buildSleeperLeagueResponse(leagues, archivedMap);
     return new Response(
       JSON.stringify({
         leagues: responseLeagues,
@@ -559,8 +566,8 @@ export async function handleSleeperLeagueDelete(
     // Return the public (annotated) list — this feeds the UI directly. Annotate
     // path fails open on an archive-set error (drops the flag rather than failing the list).
     const leagues = await storage.getSleeperLeagues(userId);
-    const archivedSet = await getArchivedSetFailOpen(env, userId);
-    const responseLeagues = await buildSleeperLeagueResponse(leagues, archivedSet);
+    const archivedMap = await getArchivedMapFailOpen(env, userId);
+    const responseLeagues = await buildSleeperLeagueResponse(leagues, archivedMap);
     return new Response(
       JSON.stringify({
         success: true,

--- a/workers/auth-worker/src/sleeper-storage.ts
+++ b/workers/auth-worker/src/sleeper-storage.ts
@@ -1,6 +1,6 @@
 import { createClient } from '@supabase/supabase-js';
 import { clearDefaultsForLeague as _clearDefaultsForLeague, clearDefaultsForPlatform as _clearDefaultsForPlatform } from './preference-defaults';
-import { ArchiveStorage, archivedKey } from './archive-storage';
+import { ArchiveStorage, archivedKey, isSuppressed, type ArchivedFilter } from './archive-storage';
 
 function maskUserId(userId: string): string {
   if (!userId || userId.length <= 8) return '***';
@@ -113,11 +113,13 @@ export class SleeperStorage {
 
   /**
    * Retrieve Sleeper leagues for a user.
-   * When `includeArchived` is false, rows whose recurring identity
-   * (`recurring_league_id ?? league_id`) is in the user's archived set are
-   * excluded. The default (`true`) keeps dedupe/discovery readers unfiltered.
+   * `archived` controls how suppressed leagues are treated; the recurring identity
+   * is `recurring_league_id ?? league_id`:
+   *   'include-all'      (default) — dedupe/discovery readers, unfiltered
+   *   'exclude-archived' — drop both archive modes (active get_user_session view)
+   *   'exclude-hidden'   — drop only 'hidden' (get_ancient_history view)
    */
-  async getSleeperLeagues(clerkUserId: string, includeArchived: boolean = true): Promise<SleeperLeague[]> {
+  async getSleeperLeagues(clerkUserId: string, archived: ArchivedFilter = 'include-all'): Promise<SleeperLeague[]> {
     const { data, error } = await this.supabase
       .from('sleeper_leagues')
       .select('*')
@@ -127,14 +129,14 @@ export class SleeperStorage {
     if (error) throw new Error(`Failed to get Sleeper leagues: ${error.message}`);
     if (!data) return [];
 
-    const archivedSet = includeArchived
+    const archivedMap = archived === 'include-all'
       ? null
-      : await this.archive.getArchivedSet(clerkUserId, 'sleeper');
+      : await this.archive.getArchivedMap(clerkUserId, 'sleeper');
 
     const rows = (data as SleeperLeagueRow[]).filter((row) => {
-      if (!archivedSet) return true;
+      if (!archivedMap) return true;
       const recurringId = row.recurring_league_id ?? row.league_id;
-      return !archivedSet.has(archivedKey(row.sport, recurringId));
+      return !isSuppressed(archived, archivedMap, archivedKey(row.sport, recurringId));
     });
 
     return rows.map((row) => ({

--- a/workers/auth-worker/src/supabase-storage.ts
+++ b/workers/auth-worker/src/supabase-storage.ts
@@ -689,10 +689,10 @@ export class EspnSupabaseStorage {
 
   /**
    * Annotate/validation-path wrapper around `getArchivedSet` (which throws on a DB
-   * error to fail-closed for the exclude path). Here we fail-OPEN: a transient
-   * archive-set error treats nothing as archived rather than blocking default
-   * validation. The exclude path (internal `includeArchived:false`) calls
-   * `getArchivedSet` directly and lets the throw propagate (fail-closed).
+   * error to fail-closed for the exclude paths). Here we fail-OPEN: a transient
+   * archive lookup error treats nothing as archived rather than blocking default
+   * validation. The AI-facing exclude paths (`exclude-archived` / `exclude-hidden`)
+   * call `getArchivedMap` directly and let the throw propagate (fail-closed).
    */
   private async getArchivedSetFailOpen(
     clerkUserId: string,

--- a/workers/auth-worker/src/supabase-storage.ts
+++ b/workers/auth-worker/src/supabase-storage.ts
@@ -16,7 +16,7 @@ import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { EspnCredentials, EspnCredentialsWithMetadata, EspnLeague, EspnUserData } from './espn-types';
 import { isCurrentSeason, type SeasonSport } from './season-utils';
 import { clearDefaultsForLeague as _clearDefaultsForLeague, clearDefaultsForPlatform as _clearDefaultsForPlatform } from './preference-defaults';
-import { ArchiveStorage, archivedKey } from './archive-storage';
+import { ArchiveStorage, archivedKey, isSuppressed, type ArchivedFilter } from './archive-storage';
 
 /**
  * Mask user ID for logging to avoid PII exposure
@@ -329,11 +329,13 @@ export class EspnSupabaseStorage {
 
   /**
    * Retrieve ESPN leagues for a user.
-   * When `includeArchived` is false, rows whose recurring identity (ESPN uses its
-   * stable `league_id`) is in the user's archived set are excluded. The default
-   * (`true`) keeps dedupe/onboarding/discovery readers unfiltered.
+   * `archived` controls how suppressed leagues are treated (ESPN's recurring
+   * identity is its stable `league_id`):
+   *   'include-all'      (default) — dedupe/onboarding/discovery readers, unfiltered
+   *   'exclude-archived' — drop both archive modes (active get_user_session view)
+   *   'exclude-hidden'   — drop only 'hidden' (get_ancient_history view)
    */
-  async getLeagues(clerkUserId: string, includeArchived: boolean = true): Promise<EspnLeague[]> {
+  async getLeagues(clerkUserId: string, archived: ArchivedFilter = 'include-all'): Promise<EspnLeague[]> {
     let rawRows: { league_id: string; sport: string; team_id: string | null; team_name: string | null; league_name: string | null; season_year: number | null }[] = [];
     try {
       if (!clerkUserId) return [];
@@ -350,16 +352,15 @@ export class EspnSupabaseStorage {
       return [];
     }
 
-    // Exclude path (includeArchived:false) fails CLOSED: getArchivedSet throws on a
-    // DB error and we let it propagate rather than leaking archived leagues
-    // unfiltered to the AI. Annotate/unfiltered callers (default true) skip this
-    // entirely.
-    const archivedSet = includeArchived
+    // Exclude paths fail CLOSED: getArchivedMap throws on a DB error and we let it
+    // propagate rather than leaking archived leagues unfiltered to the AI.
+    // 'include-all' skips the lookup entirely.
+    const archivedMap = archived === 'include-all'
       ? null
-      : await this.archive.getArchivedSet(clerkUserId, 'espn');
+      : await this.archive.getArchivedMap(clerkUserId, 'espn');
 
-    const rows = archivedSet
-      ? rawRows.filter(row => !archivedSet.has(archivedKey(row.sport, row.league_id)))
+    const rows = archivedMap
+      ? rawRows.filter(row => !isSuppressed(archived, archivedMap, archivedKey(row.sport, row.league_id)))
       : rawRows;
 
     return rows.map(row => ({
@@ -407,16 +408,16 @@ export class EspnSupabaseStorage {
    * Returns leagues where seasonYear matches the current season for their sport.
    * Uses sport-specific rollover logic (America/New_York timezone).
    *
-   * `includeArchived` defaults to false intentionally: the only callers are the
-   * post-discovery default-league dropdown, which must not surface a league the
-   * user has archived. A freshly discovered league is never archived, so this
-   * default does not hide anything the dropdown should show.
+   * `archived` defaults to 'exclude-archived' intentionally: the only callers are
+   * the post-discovery default-league dropdown, which must not surface a league the
+   * user has archived (either mode). A freshly discovered league is never archived,
+   * so this default does not hide anything the dropdown should show.
    */
-  async getCurrentSeasonLeagues(clerkUserId: string, includeArchived: boolean = false): Promise<EspnLeague[]> {
+  async getCurrentSeasonLeagues(clerkUserId: string, archived: ArchivedFilter = 'exclude-archived'): Promise<EspnLeague[]> {
     try {
       if (!clerkUserId) return [];
 
-      const allLeagues = await this.getLeagues(clerkUserId, includeArchived);
+      const allLeagues = await this.getLeagues(clerkUserId, archived);
 
       // Filter to current season leagues only using sport-specific rollover rules
       return allLeagues.filter(league => {

--- a/workers/auth-worker/src/yahoo-connect-handlers.ts
+++ b/workers/auth-worker/src/yahoo-connect-handlers.ts
@@ -1866,7 +1866,7 @@ export async function handleYahooStatus(
       storage.getYahooCredentialHealth(userId),
       // Exclude archived to match the visible active-list count semantics; Yahoo
       // now has a real archived set, so this excludes archived recurring groups.
-      storage.getYahooLeagues(userId, false),
+      storage.getYahooLeagues(userId, 'exclude-archived'),
     ]);
     const checkedAtNowMs = Date.now();
 
@@ -2201,7 +2201,7 @@ export async function resolveYahooArchiveTarget(
   requestedRecurringId: string
 ): Promise<{ recurringLeagueId: string; leagueName?: string; seasonLeagueKeys: string[] }> {
   const storage = YahooStorage.fromEnvironment(env);
-  const allLeagues = await storage.getYahooLeagues(userId, true);
+  const allLeagues = await storage.getYahooLeagues(userId, 'include-all');
 
   // Rows in this recurring group: stored recurring id matches, or (fallback) the
   // season-scoped league_key equals the requested id.

--- a/workers/auth-worker/src/yahoo-storage.ts
+++ b/workers/auth-worker/src/yahoo-storage.ts
@@ -15,7 +15,7 @@
 
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { clearDefaultsForLeague as _clearDefaultsForLeague, clearDefaultsForPlatform as _clearDefaultsForPlatform } from './preference-defaults';
-import { ArchiveStorage, archivedKey } from './archive-storage';
+import { ArchiveStorage, archivedKey, isSuppressed, type ArchivedFilter } from './archive-storage';
 
 export const REFRESH_COOLDOWN_OWNER_PREFIX = 'cooldown:';
 
@@ -614,13 +614,15 @@ export class YahooStorage {
   /**
    * Get all Yahoo leagues for a user.
    *
-   * When `includeArchived` is false, rows whose recurring identity
-   * (`recurring_league_id ?? league_key`) is in the user's archived set are
-   * excluded. The default (`true`) keeps dedupe/discovery readers unfiltered.
-   * Mirrors getSleeperLeagues; the season-scoped `league_key` is the fallback key
-   * (Yahoo's analogue of Sleeper's per-season `league_id`).
+   * `archived` controls how suppressed leagues are treated; the recurring identity
+   * is `recurring_league_id ?? league_key` (the season-scoped `league_key` is the
+   * fallback, Yahoo's analogue of Sleeper's per-season `league_id`):
+   *   'include-all'      (default) — dedupe/discovery readers, unfiltered
+   *   'exclude-archived' — drop both archive modes (active get_user_session view)
+   *   'exclude-hidden'   — drop only 'hidden' (get_ancient_history view)
+   * Mirrors getSleeperLeagues.
    */
-  async getYahooLeagues(clerkUserId: string, includeArchived: boolean = true): Promise<YahooLeague[]> {
+  async getYahooLeagues(clerkUserId: string, archived: ArchivedFilter = 'include-all'): Promise<YahooLeague[]> {
     const { data, error } = await this.supabase
       .from('yahoo_leagues')
       .select('*')
@@ -631,14 +633,14 @@ export class YahooStorage {
       throw new Error('Failed to get Yahoo leagues');
     }
 
-    const archivedSet = includeArchived
+    const archivedMap = archived === 'include-all'
       ? null
-      : await this.archive.getArchivedSet(clerkUserId, 'yahoo');
+      : await this.archive.getArchivedMap(clerkUserId, 'yahoo');
 
     const rows = (data || []).filter((row) => {
-      if (!archivedSet) return true;
+      if (!archivedMap) return true;
       const recurringId = row.recurring_league_id ?? row.league_key;
-      return !archivedSet.has(archivedKey(row.sport, recurringId));
+      return !isSuppressed(archived, archivedMap, archivedKey(row.sport, recurringId));
     });
 
     return rows.map((row) => ({

--- a/workers/fantasy-mcp/src/__tests__/tools.test.ts
+++ b/workers/fantasy-mcp/src/__tests__/tools.test.ts
@@ -282,6 +282,44 @@ describe('fantasy-mcp tools', () => {
     });
   });
 
+  it('get_ancient_history requests ?archived=exclude-hidden; get_user_session sends no archived param', async () => {
+    // Guards the leak-critical MCP->endpoint contract: get_user_session must drop
+    // ALL archived leagues (no param => endpoint default 'exclude-archived'), while
+    // get_ancient_history opts into 'exclude-hidden' so 'historical' leagues remain
+    // browsable but 'hidden' ones stay suppressed.
+    const sessionTool = getUnifiedTools().find((t) => t.name === 'get_user_session');
+    const historyTool = getUnifiedTools().find((t) => t.name === 'get_ancient_history');
+
+    const seenUrls: string[] = [];
+    const env = {
+      INTERNAL_SERVICE_TOKEN: 'internal-secret',
+      AUTH_WORKER: {
+        fetch: async (req: Request) => {
+          seenUrls.push(req.url);
+          return new Response(JSON.stringify({ leagues: [] }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        },
+      },
+    } as unknown as Env;
+
+    await sessionTool!.handler({}, env, 'Bearer test-token');
+    const sessionLeagueUrls = seenUrls.filter((u) => new URL(u).pathname.startsWith('/internal/leagues'));
+    expect(sessionLeagueUrls.length).toBeGreaterThanOrEqual(3); // espn + yahoo + sleeper
+    for (const u of sessionLeagueUrls) {
+      expect(new URL(u).searchParams.has('archived')).toBe(false);
+    }
+
+    seenUrls.length = 0;
+    await historyTool!.handler({}, env, 'Bearer test-token');
+    const historyLeagueUrls = seenUrls.filter((u) => new URL(u).pathname.startsWith('/internal/leagues'));
+    expect(historyLeagueUrls.length).toBeGreaterThanOrEqual(3);
+    for (const u of historyLeagueUrls) {
+      expect(new URL(u).searchParams.get('archived')).toBe('exclude-hidden');
+    }
+  });
+
   it('get_league_info routes to client and formats a success payload', async () => {
     const tool = getUnifiedTools().find((t) => t.name === 'get_league_info');
     expect(tool).toBeTruthy();

--- a/workers/fantasy-mcp/src/mcp/tools.ts
+++ b/workers/fantasy-mcp/src/mcp/tools.ts
@@ -140,12 +140,23 @@ function getActiveLeagueGroupKey(league: UserLeague): string {
   return `${league.platform}:${league.leagueId}`;
 }
 
+/**
+ * Query suffix for the internal leagues endpoints. When `includeHistorical` is set
+ * (get_ancient_history), request the 'exclude-hidden' filter so archived 'historical'
+ * leagues are returned while 'hidden' ones stay suppressed. Absent → the endpoint
+ * default 'exclude-archived' (the active get_user_session view, drops both modes).
+ */
+function archivedQuery(includeHistorical: boolean): string {
+  return includeHistorical ? '?archived=exclude-hidden' : '';
+}
+
 async function fetchUserLeagues(
   env: Env,
   authHeader?: string,
   correlationId?: string,
   evalRunId?: string,
-  evalTraceId?: string
+  evalTraceId?: string,
+  includeHistorical: boolean = false
 ): Promise<{ leagues: UserLeague[]; error?: string; status?: number }> {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), 5000);
@@ -163,7 +174,7 @@ async function fetchUserLeagues(
     const headers = withEvalHeaders(withInternal, evalRunId, evalTraceId);
 
     const response = await env.AUTH_WORKER.fetch(
-      new Request('https://internal/internal/leagues', {
+      new Request(`https://internal/internal/leagues${archivedQuery(includeHistorical)}`, {
         method: 'GET',
         headers,
         signal: controller.signal,
@@ -217,7 +228,8 @@ async function fetchYahooLeagues(
   authHeader?: string,
   correlationId?: string,
   evalRunId?: string,
-  evalTraceId?: string
+  evalTraceId?: string,
+  includeHistorical: boolean = false
 ): Promise<{ leagues: UserLeague[]; error?: string }> {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), 5000);
@@ -235,7 +247,7 @@ async function fetchYahooLeagues(
     const headers = withEvalHeaders(withInternal, evalRunId, evalTraceId);
 
     const response = await env.AUTH_WORKER.fetch(
-      new Request('https://internal/internal/leagues/yahoo', {
+      new Request(`https://internal/internal/leagues/yahoo${archivedQuery(includeHistorical)}`, {
         headers,
         signal: controller.signal,
       })
@@ -294,7 +306,8 @@ async function fetchSleeperLeagues(
   authHeader?: string,
   correlationId?: string,
   evalRunId?: string,
-  evalTraceId?: string
+  evalTraceId?: string,
+  includeHistorical: boolean = false
 ): Promise<{ leagues: UserLeague[]; error?: string }> {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), 5000);
@@ -312,7 +325,7 @@ async function fetchSleeperLeagues(
     const headers = withEvalHeaders(withInternal, evalRunId, evalTraceId);
 
     const response = await env.AUTH_WORKER.fetch(
-      new Request('https://internal/internal/leagues/sleeper', {
+      new Request(`https://internal/internal/leagues/sleeper${archivedQuery(includeHistorical)}`, {
         headers,
         signal: controller.signal,
       })
@@ -797,11 +810,14 @@ export function getUnifiedTools(): UnifiedTool[] {
         return withToolLogging(correlationId, 'get_ancient_history', `ancient platform=${platform || 'all'}`, async () => {
         try {
           // Fetch platform leagues in parallel (only requested platforms)
+          // includeHistorical=true → archived 'historical' leagues stay browsable in
+          // history (the 'exclude-hidden' filter), unlike get_user_session which drops
+          // all archived. 'hidden' leagues are still suppressed here.
           const fetchArgs = [env, authHeader, correlationId, evalRunId, evalTraceId] as const;
           const promises: Promise<{ leagues: UserLeague[]; error?: string }>[] = [];
-          if (!platform || platform === 'espn') promises.push(fetchUserLeagues(...fetchArgs));
-          if (!platform || platform === 'yahoo') promises.push(fetchYahooLeagues(...fetchArgs));
-          if (!platform || platform === 'sleeper') promises.push(fetchSleeperLeagues(...fetchArgs));
+          if (!platform || platform === 'espn') promises.push(fetchUserLeagues(...fetchArgs, true));
+          if (!platform || platform === 'yahoo') promises.push(fetchYahooLeagues(...fetchArgs, true));
+          if (!platform || platform === 'sleeper') promises.push(fetchSleeperLeagues(...fetchArgs, true));
 
           const results = await Promise.allSettled(promises);
           const allLeagues: UserLeague[] = [];


### PR DESCRIPTION
## What

Turns the binary league archive into a **single suppression dial with three positions**:

| State | `get_user_session` (active) | `get_ancient_history` | Meaning |
|---|:--:|:--:|---|
| **Active** | ✅ current season | ✅ past seasons | normal ongoing league |
| **Archived** (`mode: historical`) | ❌ | ✅ | "not ongoing, keep it browsable — *when did I win, my record*" |
| **Hidden** (`mode: hidden`) | ❌ | ❌ | "junk/zombie — never show me this in any form" |

All three survive re-sync (keyed on the recurring-league identity) and are reversible. None is a delete. Supersedes FLA-149 (its browsable-in-history behavior is the **Archived** tier here).

## How

- **Migration `025`** (`flaim-docs/migrations/`, applied separately): adds `archived_leagues.mode`. `ADD COLUMN ... DEFAULT 'hidden'` **backfills existing rows → `hidden`** (behavior-preserving — they meant "gone from both"), then sets the go-forward default to `historical`. `mode` is not in the unique key, so re-archiving moves a league between states.
- **Storage**: binary `includeArchived` → tri-state `ArchivedFilter` (`include-all` | `exclude-archived` | `exclude-hidden`). `getArchivedSet` → mode-aware `getArchivedMap` (`Map<key, mode>`), fail-closed, and **tolerant of the pre-migration schema** (treats rows as `hidden` if the column is absent) so deploy order is safe.
- **Internal endpoints** read `?archived=exclude-hidden`; a malformed/absent value falls back to `exclude-archived` (most-suppressive, fail-safe). Public `/leagues*` annotate `archived` + `archiveMode`.
- **MCP tools**: `get_ancient_history` requests `exclude-hidden`; `get_user_session` unchanged (drops both modes).
- **UI** (`/leagues`): two buttons per league — **Archive** (→ historical) and **Hide** (→ hidden) — and separate **Archived** / **Hidden** sections with helper text, each offering switch-mode + Restore.

## Behavior on deploy

The migration backfills existing archived rows to `hidden`, so currently-archived leagues stay **exactly as they are today** (gone from both tools). No behavior change until a user picks a mode via the new UI.

## Verification

- auth-worker **419** ✓ · fantasy-mcp **67 + 17** ✓ · web `tsc` ✓ · `ui:check` ✓ · all worker typechecks clean
- Implemented with subagents; a **separate audit subagent** reviewed the full diff — **no blockers**; verified no AI-leak path (hidden never reaches the AI; historical browsable only in history; fail-closed preserved). The two test-coverage gaps it flagged are closed (the leak-critical MCP query contract + a fail-safe param test).

## Deploy order

1. Apply migration `025` to flaim-prod (backfills existing archived → `hidden`).
2. Merge → prod. (Code is mode-tolerant, so a small lag either way is safe.)

Closes FLA-150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)