### PR TITLE
Merge Old Leagues + Archived into one "Inactive" section (FLA-152)

### DIFF
--- a/web/app/(site)/leagues/page.tsx
+++ b/web/app/(site)/leagues/page.tsx
@@ -401,8 +401,7 @@ function LeaguesPageContent() {
   const displaySleeperLeagues = isAccountStateCurrent ? sleeperLeagues : EMPTY_SLEEPER_LEAGUES;
   const displayPreferences = isAccountStateCurrent ? preferences : EMPTY_USER_PREFERENCES;
   const defaultSport = displayPreferences.defaultSport;
-  const [showOldLeagues, setShowOldLeagues] = useState(false);
-  const [showArchivedLeagues, setShowArchivedLeagues] = useState(false);
+  const [showInactiveLeagues, setShowInactiveLeagues] = useState(false);
   const [showHiddenLeagues, setShowHiddenLeagues] = useState(false);
   // Keyed by `${platform}:${recurringLeagueId}` while an archive/unarchive request is in flight.
   const [archivingLeagueKey, setArchivingLeagueKey] = useState<string | null>(null);
@@ -1735,27 +1734,28 @@ function LeaguesPageContent() {
                   </div>
                 ))}
 
-                    {/* Old Leagues Section */}
-                    {leaguesBySport.old.length > 0 && (
+                    {/* Inactive Leagues Section (aged-out + manually archived) */}
+                    {(leaguesBySport.old.length + leaguesBySport.archived.length) > 0 && (
                       <div className="space-y-3 pt-3 border-t">
                         <button
                           type="button"
                           className="flex items-center gap-2 font-medium text-muted-foreground hover:text-foreground transition-colors w-full"
-                          onClick={() => setShowOldLeagues(!showOldLeagues)}
+                          onClick={() => setShowInactiveLeagues(!showInactiveLeagues)}
                         >
-                          <span className="text-lg">🗄️</span>
-                          <span className="text-base">Old Leagues ({leaguesBySport.old.length})</span>
-                          <ChevronDown className={`h-4 w-4 ml-auto transition-transform ${showOldLeagues ? 'rotate-180' : ''}`} />
+                          <Archive className="h-4 w-4" />
+                          <span className="text-base">Inactive ({leaguesBySport.old.length + leaguesBySport.archived.length})</span>
+                          <ChevronDown className={`h-4 w-4 ml-auto transition-transform ${showInactiveLeagues ? 'rotate-180' : ''}`} />
                         </button>
 
-                        {showOldLeagues && (
+                        {showInactiveLeagues && (
                           <div className="space-y-3">
                             <p className="text-sm text-muted-foreground">
-                              Leagues that are no longer active. Your AI can still pull their results when you ask about past seasons.
+                              Leagues that are old or that you&apos;ve manually archived. These are still available to your AI when you ask about past seasons.
                             </p>
                             {leaguesBySport.old.map((group) => {
                               const baseKey = `${group.leagueId}-${group.sport}`;
                               const isDeleting = deletingLeagueKey === baseKey;
+                              const isArchiving = archivingLeagueKey === `${group.platform}:${getArchiveRecurringId(group)}`;
                               const mostRecentYear = group.seasons[0]?.seasonYear;
 
                               return (
@@ -1772,13 +1772,16 @@ function LeaguesPageContent() {
                                       </div>
                                     </div>
                                     <div className="flex items-center gap-1 shrink-0">
-                                      {/* Visibility controls: all three platforms (ESPN, Yahoo, Sleeper). */}
-                                      <ArchiveButtons
-                                        group={group}
-                                        archivingLeagueKey={archivingLeagueKey}
-                                        onArchive={(g) => performArchiveAction(g, 'archive', 'historical')}
-                                        onHide={(g) => performArchiveAction(g, 'archive', 'hidden')}
-                                      />
+                                      <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                                        onClick={() => performArchiveAction(group, 'archive', 'hidden')}
+                                        disabled={isArchiving}
+                                        title="Hide (completely hidden from the AI)"
+                                      >
+                                        {isArchiving ? <Loader2 className="h-4 w-4 animate-spin" /> : <EyeOff className="h-4 w-4" />}
+                                      </Button>
                                       <Button
                                         variant="ghost"
                                         size="icon"
@@ -1814,29 +1817,6 @@ function LeaguesPageContent() {
                                 </div>
                               );
                             })}
-                          </div>
-                        )}
-                      </div>
-                    )}
-
-                    {/* Archived Leagues Section (mode: 'historical') */}
-                    {leaguesBySport.archived.length > 0 && (
-                      <div className="space-y-3 pt-3 border-t">
-                        <button
-                          type="button"
-                          className="flex items-center gap-2 font-medium text-muted-foreground hover:text-foreground transition-colors w-full"
-                          onClick={() => setShowArchivedLeagues(!showArchivedLeagues)}
-                        >
-                          <Archive className="h-4 w-4" />
-                          <span className="text-base">Archived ({leaguesBySport.archived.length})</span>
-                          <ChevronDown className={`h-4 w-4 ml-auto transition-transform ${showArchivedLeagues ? 'rotate-180' : ''}`} />
-                        </button>
-
-                        {showArchivedLeagues && (
-                          <div className="space-y-3">
-                            <p className="text-sm text-muted-foreground">
-                              Leagues you&apos;ve set aside. Your AI won&apos;t bring these up on its own, but it can still pull their history when you ask about past seasons.
-                            </p>
                             {leaguesBySport.archived.map((group) => {
                               const baseKey = `${group.leagueId}-${group.sport}`;
                               const isDeleting =

--- a/web/app/(site)/leagues/page.tsx
+++ b/web/app/(site)/leagues/page.tsx
@@ -509,9 +509,9 @@ function LeaguesPageContent() {
       group.teamId = group.seasons.find((s) => s.teamId)?.teamId;
     }
 
-    // Separate suppressed groups, then active vs old. Suppressed leagues are pulled
-    // out of both the active and old buckets into their own sections: 'historical'
-    // (Archived — still browsable for past seasons) and 'hidden' (completely hidden).
+    // Separate suppressed groups, then active vs old. The data split stays four-way
+    // (active/old/archived/hidden); the UI renders old + archived together in the
+    // merged "Inactive" section, while 'hidden' gets its own "Hidden" section.
     const activeLeagues: UnifiedLeagueGroup[] = [];
     const oldLeagueGroups: UnifiedLeagueGroup[] = [];
     const archivedLeagueGroups: UnifiedLeagueGroup[] = [];

--- a/web/app/api/leagues/archive/route.ts
+++ b/web/app/api/leagues/archive/route.ts
@@ -3,7 +3,7 @@
  * ---------------------------------------------------------------------------
  * Proxies the manual league archive endpoints to the Auth-Worker (FLA-124).
  *
- * - GET    → list the user's archived leagues (feeds the Archived UI section)
+ * - GET    → list the user's suppressed leagues (feeds the Inactive/Hidden UI sections)
  * - POST   → set a league's archive mode (hide it from the AI's active view; survives re-sync)
  * - DELETE → unarchive a league (restore it to the visible/AI surfaces)
  *

--- a/workers/auth-worker/src/__tests__/archive-route.test.ts
+++ b/workers/auth-worker/src/__tests__/archive-route.test.ts
@@ -71,8 +71,8 @@ describe('parseArchiveBody', () => {
   });
 
   it('accepts a valid dotted Yahoo-style id (e.g. 449.l.123) for a supported platform', () => {
-    // Yahoo as a platform is deferred, but the dotted-id charset must pass so the
-    // charset rule never becomes the reason a future Yahoo id is rejected.
+    // The dotted-id charset (e.g. a Yahoo league_key like 449.l.123) must pass so
+    // the charset rule never becomes the reason such an id is rejected.
     const result = parseArchiveBody({ platform: 'sleeper', sport: 'football', recurringLeagueId: '449.l.123' });
     expect(result).toEqual({ ok: true, platform: 'sleeper', sport: 'football', recurringLeagueId: '449.l.123', mode: 'historical' });
   });


### PR DESCRIPTION
## What

Collapses the separate **Old Leagues** and **Archived** sections on `/leagues` into a single **Inactive** section, returning to a clean three-bucket model: **Active / Inactive / Hidden**.

## Why

Old Leagues (auto-aged-out) and Archived (manually set aside, mode `historical`) behave **identically** to the AI — both are excluded from `get_user_session` but available in `get_ancient_history`. The only difference is *origin* (aged out vs. you chose), which is plumbing, not user-meaningful. Two sections meaning the same thing was genuinely confusing.

## Changes (display-only — `web/app/(site)/leagues/page.tsx`)

- `showOldLeagues` + `showArchivedLeagues` → one `showInactiveLeagues`.
- One collapsible **Inactive (N)** section (N = old + archived), subtitle: *"Leagues that are old or that you've manually archived. These are still available to your AI when you ask about past seasons."*
- **Aged-out rows:** Hide + Delete (dropped the redundant Archive button — they're already inactive).
- **Manually-archived rows:** Hide + Restore + Delete (unchanged). The only visible difference between the two row types is the Restore button.
- `leaguesBySport` bucketing and the **Hidden** section unchanged. No backend change.

## Verification

web `tsc` + `ui:check` clean. Built via subagent + reviewed diff.

Closes FLA-152. Follow-up on FLA-150 / FLA-151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)