### PR TITLE
docs(changelog): three-state league visibility + season rollover

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,8 +4,12 @@ Follow Keep a Changelog; stamp a version when submitting to directories.
 
 ## [Unreleased]
 
-### League Archive (FLA-124)
-- **Added**: Manual league archive for ESPN and Sleeper. Users can hide a league from the AI's MCP tools (`get_user_session`, `get_ancient_history`) and restore it from a new Archived section in `/leagues`. Archives are keyed on a stable recurring-league identity (`archived_leagues` table) so they survive annual re-syncs; the AI-facing read path fails closed, so a lookup error never leaks an archived league. Yahoo archive is deferred to a later phase.
+### League Visibility — Active / Inactive / Hidden (FLA-124, FLA-150, FLA-151, FLA-152)
+- **Added**: Three-state league visibility across ESPN, Yahoo, and Sleeper. From `/leagues`, users can **Archive** a recurring league (dropped from the active `get_user_session` view but still browsable via `get_ancient_history`) or **Hide** it (suppressed from both AI tools), and Restore at any time. Keyed on a stable recurring-league identity (`archived_leagues` table with a `mode` column) so it survives annual re-syncs; the AI-facing read fails closed (a lookup error never leaks a suppressed league) and tolerates the pre-migration schema. Migration 025 adds `mode`, backfilling existing archived rows to `hidden`.
+- **Changed**: `/leagues` now groups leagues into **Active**, **Inactive** (auto-aged-out + manually archived), and **Hidden**, replacing the earlier separate Old Leagues / Archived sections.
+
+### Season Rollover (FLA-148)
+- **Changed**: Football's current-season rollover moved from July 1 to June 1, so the upcoming season surfaces as active a month earlier (a longer pre-draft window). Other sports unchanged (baseball Feb 1, basketball/hockey Aug 1).
 
 ## [8.1.0] - 2026-06-10
 


### PR DESCRIPTION
Docs-only. Updates `docs/CHANGELOG.md` `[Unreleased]`:

- Replaces the stale "League Archive (FLA-124)" entry (ESPN+Sleeper only, "Yahoo deferred", binary hide) with the shipped **three-state visibility** model across ESPN/Yahoo/Sleeper (Active / Archived / Hidden), incl. migration 025 + fail-closed notes.
- Adds the **FLA-148** football season-rollover change (Jul 1 → Jun 1).

Documents work already merged + live (FLA-124/148/150/151/152). No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)