### PR TITLE
feat(analytics): ground-truth MCP usage events (FLA-156)

### DIFF
--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -278,6 +278,39 @@ Recommended indexes:
 - `demo_refresh_runs_sport_created_at_idx` on `(sport, created_at desc)` for runner health/scheduler reads
 - `demo_refresh_runs_preset_sport_created_at_idx` on `(preset_id, sport, created_at desc)` for website latest-failure lookups
 
+## Analytics Tables (MCP Usage)
+
+Added by migration 026. The fantasy-mcp gateway writes one best-effort, fire-and-forget row to `mcp_tool_events` per MCP tool call (via the auth-worker `/internal/usage-event` endpoint). The two `*_daily` tables are permanent rollups populated by `pg_cron`, not written by the worker.
+
+### mcp_tool_events
+Raw per-tool-call event log. One row per MCP tool invocation, including scope-denied and error cases.
+
+| Column | Type | Notes |
+|---|---|---|
+| id | uuid | Primary key |
+| ts | timestamptz | Event time; defaults to `now()` |
+| env | text | Deployment environment (`prod`, `preview`, `dev`, or `unknown`) |
+| user_id | text | Clerk user ID (rows with no user_id are not emitted) |
+| auth_type | text | `clerk`, `oauth`, `eval-api-key`, `demo-api-key`, or `unknown` |
+| client_name | text | MCP client name (e.g. Claude, ChatGPT); nullable |
+| tool_name | text | MCP tool invoked (e.g. `get_standings`) |
+| platform | text | Fantasy platform when present on the call; nullable |
+| sport | text | Sport when present on the call; nullable |
+| status | text | `ok`, `error`, or `denied` |
+| error_code | text | Structured error code from the tool result when available; nullable |
+| latency_ms | int | Tool-call duration; null on the scope-denied path (no handler run) |
+| league_hash | text | SHA-256 of `<platform>:<league_id>` (pseudonymized league identity); nullable |
+
+Notes:
+- `correlation_id` is intentionally NOT stored here — events are aggregate analytics, not request traces.
+- Raw events are pruned after 90 days via `pg_cron`; the rollup tables below retain the long-term history.
+
+### mcp_user_daily
+Permanent per-user daily rollup of MCP usage, populated by `pg_cron` from `mcp_tool_events`.
+
+### mcp_tool_daily
+Permanent per-tool daily rollup of MCP usage, populated by `pg_cron` from `mcp_tool_events`.
+
 ## Legacy/Deprecated Tables
 
 ### extension_pairing_codes (deprecated)

--- a/workers/auth-worker/src/__tests__/eval-api-key.test.ts
+++ b/workers/auth-worker/src/__tests__/eval-api-key.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import app from '../index-hono';
+import { validateOAuthToken } from '../oauth-handlers';
+import { UsageStorage } from '../usage-storage';
+
+const mockInsertEvent = vi.fn().mockResolvedValue({ error: null });
 
 // Mock Clerk JWKS fetch so JWT verification always fails (no real Clerk in tests)
 vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('no network in test')));
@@ -127,12 +131,20 @@ vi.mock('../oauth-handlers', () => ({
   OAuthEnv: {},
 }));
 
+vi.mock('../usage-storage', () => ({
+  UsageStorage: {
+    fromEnvironment: vi.fn(() => ({ insertEvent: mockInsertEvent })),
+  },
+}));
+
 describe('eval API key auth', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockClearDefaultLeague.mockResolvedValue({ success: true });
     mockClearStaleDefaultForLeague.mockResolvedValue(undefined);
     mockGetLeagues.mockResolvedValue([]);
+    mockInsertEvent.mockResolvedValue({ error: null });
+    vi.mocked(validateOAuthToken).mockResolvedValue(null);
   });
 
   // =========================================================================
@@ -149,11 +161,35 @@ describe('eval API key auth', () => {
       })
     );
     expect(res.status).toBe(200);
-    const body = await res.json() as { valid: boolean; userId: string; scope: string; authType: string };
+    const body = await res.json() as { valid: boolean; userId: string; scope: string; authType: string; client_name: string | null };
     expect(body.valid).toBe(true);
     expect(body.userId).toBe(EVAL_USER_ID);
     expect(body.scope).toBe('mcp:read');
     expect(body.authType).toBe('eval-api-key');
+    // client_name is OAuth-only — null for static API key auth
+    expect(body.client_name).toBeNull();
+  });
+
+  it('GET /auth/internal/introspect with OAuth token returns client_name', async () => {
+    vi.mocked(validateOAuthToken).mockResolvedValueOnce({
+      userId: 'user_oauth_test',
+      scope: 'mcp:read',
+      clientName: 'ChatGPT',
+    });
+    const res = await appFetch(
+      makeRequest('/auth/internal/introspect', {
+        headers: {
+          ...internalHeaders('oauth-access-token'),
+          'X-Flaim-Expected-Resource': 'https://api.flaim.app/mcp',
+        },
+      })
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as { valid: boolean; userId: string; authType: string; client_name: string | null };
+    expect(body.valid).toBe(true);
+    expect(body.userId).toBe('user_oauth_test');
+    expect(body.authType).toBe('oauth');
+    expect(body.client_name).toBe('ChatGPT');
   });
 
   it('GET /auth/internal/introspect with valid demo API key returns demo user', async () => {
@@ -171,6 +207,87 @@ describe('eval API key auth', () => {
     expect(body.userId).toBe(DEMO_USER_ID);
     expect(body.scope).toBe('mcp:read');
     expect(body.authType).toBe('demo-api-key');
+  });
+
+  // =========================================================================
+  // Usage analytics ingest (POST /internal/usage-event)
+  // =========================================================================
+
+  it('POST /auth/internal/usage-event with internal token inserts and returns ok', async () => {
+    const event = {
+      env: 'prod',
+      user_id: 'user_123',
+      auth_type: 'oauth',
+      client_name: 'ChatGPT',
+      tool_name: 'get_players',
+      platform: 'espn',
+      sport: 'baseball',
+      status: 'ok',
+      error_code: null,
+      latency_ms: 123,
+      league_hash: 'abc123',
+      correlation_id: 'corr-xyz',
+    };
+    const res = await appFetch(
+      makeRequest('/auth/internal/usage-event', {
+        method: 'POST',
+        headers: {
+          'X-Flaim-Internal-Token': INTERNAL_SERVICE_TOKEN,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(event),
+      })
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as { ok: boolean };
+    expect(body.ok).toBe(true);
+    expect(mockInsertEvent).toHaveBeenCalledTimes(1);
+    expect(mockInsertEvent).toHaveBeenCalledWith(expect.objectContaining(event));
+  });
+
+  it('POST /auth/internal/usage-event without internal token is rejected (403)', async () => {
+    const res = await appFetch(
+      makeRequest('/auth/internal/usage-event', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ env: 'prod', user_id: 'u', auth_type: 'oauth', tool_name: 't', status: 'ok' }),
+      })
+    );
+    expect(res.status).toBe(403);
+    expect(mockInsertEvent).not.toHaveBeenCalled();
+  });
+
+  it('POST /auth/internal/usage-event tolerates storage errors (still 200)', async () => {
+    mockInsertEvent.mockResolvedValueOnce({ error: { message: 'insert failed' } });
+    const res = await appFetch(
+      makeRequest('/auth/internal/usage-event', {
+        method: 'POST',
+        headers: {
+          'X-Flaim-Internal-Token': INTERNAL_SERVICE_TOKEN,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ env: 'prod', user_id: 'u', auth_type: 'oauth', tool_name: 't', status: 'ok' }),
+      })
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as { ok: boolean };
+    expect(body.ok).toBe(true);
+  });
+
+  it('POST /auth/internal/usage-event tolerates malformed JSON body (still 200)', async () => {
+    const res = await appFetch(
+      makeRequest('/auth/internal/usage-event', {
+        method: 'POST',
+        headers: {
+          'X-Flaim-Internal-Token': INTERNAL_SERVICE_TOKEN,
+          'Content-Type': 'application/json',
+        },
+        body: 'not-json',
+      })
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as { ok: boolean };
+    expect(body.ok).toBe(true);
   });
 
   it('GET /auth/internal/credentials/espn/raw with valid API key returns credentials', async () => {

--- a/workers/auth-worker/src/__tests__/eval-api-key.test.ts
+++ b/workers/auth-worker/src/__tests__/eval-api-key.test.ts
@@ -3,8 +3,6 @@ import app from '../index-hono';
 import { validateOAuthToken } from '../oauth-handlers';
 import { UsageStorage } from '../usage-storage';
 
-const mockInsertEvent = vi.fn().mockResolvedValue({ error: null });
-
 // Mock Clerk JWKS fetch so JWT verification always fails (no real Clerk in tests)
 vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('no network in test')));
 
@@ -15,10 +13,11 @@ const DEMO_USER_ID = 'user_demo_test_54321';
 const INTERNAL_SERVICE_TOKEN = 'internal-service-secret';
 
 const mockRateLimiter = { limit: async () => ({ success: true }) };
-const { mockClearDefaultLeague, mockClearStaleDefaultForLeague, mockGetLeagues } = vi.hoisted(() => ({
+const { mockClearDefaultLeague, mockClearStaleDefaultForLeague, mockGetLeagues, mockInsertEvent } = vi.hoisted(() => ({
   mockClearDefaultLeague: vi.fn().mockResolvedValue({ success: true }),
   mockClearStaleDefaultForLeague: vi.fn().mockResolvedValue(undefined),
   mockGetLeagues: vi.fn().mockResolvedValue([]),
+  mockInsertEvent: vi.fn().mockResolvedValue({ error: null }),
 }));
 
 const baseEnv = {

--- a/workers/auth-worker/src/__tests__/oauth-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/oauth-handlers.test.ts
@@ -1025,7 +1025,7 @@ describe('validateOAuthToken resource enforcement', () => {
     } as unknown as OAuthStorage);
 
     const result = await validateOAuthToken('test-token', env, 'https://api.flaim.app/mcp');
-    expect(result).toEqual({ userId: 'user-123', scope: 'mcp:read' });
+    expect(result).toEqual({ userId: 'user-123', scope: 'mcp:read', clientName: null });
   });
 
   it('accepts token when no resource was stored (backwards compat)', async () => {
@@ -1039,6 +1039,6 @@ describe('validateOAuthToken resource enforcement', () => {
     } as unknown as OAuthStorage);
 
     const result = await validateOAuthToken('test-token', env, 'https://api.flaim.app/mcp');
-    expect(result).toEqual({ userId: 'user-123', scope: 'mcp:read' });
+    expect(result).toEqual({ userId: 'user-123', scope: 'mcp:read', clientName: null });
   });
 });

--- a/workers/auth-worker/src/__tests__/usage-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/usage-storage.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { UsageStorage, type UsageEvent } from '../usage-storage';
+
+const insertPayloads: Record<string, unknown>[] = [];
+const mockInsert = vi.fn((payload: Record<string, unknown>) => {
+  insertPayloads.push(payload);
+  return Promise.resolve({ data: null, error: null });
+});
+const mockFrom = vi.fn(() => ({ insert: mockInsert }));
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({ from: mockFrom }),
+}));
+
+const baseEvent: UsageEvent = {
+  env: 'prod',
+  user_id: 'user_123',
+  auth_type: 'oauth',
+  client_name: 'ChatGPT',
+  tool_name: 'get_players',
+  platform: 'espn',
+  sport: 'baseball',
+  status: 'ok',
+  error_code: null,
+  latency_ms: 123,
+  league_hash: 'abc123',
+  correlation_id: 'corr-xyz',
+};
+
+describe('UsageStorage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    insertPayloads.length = 0;
+  });
+
+  it('inserts into mcp_tool_events with the event fields', async () => {
+    const storage = UsageStorage.fromEnvironment({
+      SUPABASE_URL: 'https://example.supabase.co',
+      SUPABASE_SERVICE_KEY: 'test-key',
+    });
+    const { error } = await storage.insertEvent(baseEvent);
+
+    expect(error).toBeNull();
+    expect(mockFrom).toHaveBeenCalledWith('mcp_tool_events');
+    expect(insertPayloads).toHaveLength(1);
+    expect(insertPayloads[0]).toMatchObject({
+      env: 'prod',
+      user_id: 'user_123',
+      auth_type: 'oauth',
+      client_name: 'ChatGPT',
+      tool_name: 'get_players',
+      platform: 'espn',
+      sport: 'baseball',
+      status: 'ok',
+      error_code: null,
+      latency_ms: 123,
+      league_hash: 'abc123',
+    });
+  });
+
+  it('does NOT insert correlation_id (no column on the table)', async () => {
+    const storage = UsageStorage.fromEnvironment({
+      SUPABASE_URL: 'https://example.supabase.co',
+      SUPABASE_SERVICE_KEY: 'test-key',
+    });
+    await storage.insertEvent(baseEvent);
+
+    expect(insertPayloads[0]).not.toHaveProperty('correlation_id');
+  });
+
+  it('does NOT insert ts (let DB default it)', async () => {
+    const storage = UsageStorage.fromEnvironment({
+      SUPABASE_URL: 'https://example.supabase.co',
+      SUPABASE_SERVICE_KEY: 'test-key',
+    });
+    await storage.insertEvent(baseEvent);
+
+    expect(insertPayloads[0]).not.toHaveProperty('ts');
+  });
+
+  it('defaults nullable fields to null when omitted', async () => {
+    const storage = UsageStorage.fromEnvironment({
+      SUPABASE_URL: 'https://example.supabase.co',
+      SUPABASE_SERVICE_KEY: 'test-key',
+    });
+    await storage.insertEvent({
+      env: 'prod',
+      user_id: 'user_123',
+      auth_type: 'clerk',
+      tool_name: 'get_players',
+      status: 'ok',
+    });
+
+    expect(insertPayloads[0]).toMatchObject({
+      client_name: null,
+      platform: null,
+      sport: null,
+      error_code: null,
+      latency_ms: null,
+      league_hash: null,
+    });
+  });
+
+  it('returns the storage error without throwing', async () => {
+    const dbError = { message: 'insert failed' };
+    mockInsert.mockResolvedValueOnce({ data: null, error: dbError } as never);
+
+    const storage = UsageStorage.fromEnvironment({
+      SUPABASE_URL: 'https://example.supabase.co',
+      SUPABASE_SERVICE_KEY: 'test-key',
+    });
+    const { error } = await storage.insertEvent(baseEvent);
+
+    expect(error).toBe(dbError);
+  });
+});

--- a/workers/auth-worker/src/index-hono.ts
+++ b/workers/auth-worker/src/index-hono.ts
@@ -37,6 +37,7 @@ import {
   validateOAuthToken,
   OAuthEnv,
 } from './oauth-handlers';
+import { UsageStorage, type UsageEvent } from './usage-storage';
 import {
   handleSyncCredentials,
   handleGetExtensionStatus,
@@ -343,6 +344,7 @@ interface AuthResult {
   status?: 401 | 403 | 500;
   authType?: 'clerk' | 'oauth' | 'eval-api-key' | 'demo-api-key';
   scope?: string;
+  clientName?: string | null; // OAuth-only; null/absent for clerk/eval-api-key/demo-api-key
 }
 
 async function constantTimeEqual(a: string, b: string): Promise<boolean> {
@@ -441,7 +443,7 @@ async function getVerifiedUserId(
       const oauthResult = await validateOAuthToken(token, env as OAuthEnv, expectedResource);
       if (oauthResult) {
         debugLog(env, `✅ [auth-worker] OAuth token validated, userId: ${maskUserId(oauthResult.userId)}`);
-        return { userId: oauthResult.userId, authType: 'oauth', scope: oauthResult.scope };
+        return { userId: oauthResult.userId, authType: 'oauth', scope: oauthResult.scope, clientName: oauthResult.clientName ?? null };
       }
       debugLog(env, `⚠️ [auth-worker] OAuth token validation returned null`);
     } catch (e) {
@@ -741,7 +743,7 @@ api.post('/revoke', (c) => {
 // Token introspection (internal — called by fantasy-mcp gateway via service binding)
 api.get('/internal/introspect', async (c) => {
   const expectedResource = c.req.header('X-Flaim-Expected-Resource') || undefined;
-  const { userId, error: authError, status: authStatus, scope, authType } = await getInternalUserId(c.req.raw, c.env, expectedResource, { allowStaticApiKey: true });
+  const { userId, error: authError, status: authStatus, scope, authType, clientName } = await getInternalUserId(c.req.raw, c.env, expectedResource, { allowStaticApiKey: true });
 
   if (!userId) {
     // 403/500 internal-service auth failures are already logged by getInternalUserId.
@@ -758,7 +760,34 @@ api.get('/internal/introspect', async (c) => {
     return c.json({ valid: false, error: authError || 'Invalid token' }, authStatus ?? 401);
   }
 
-  return c.json({ valid: true, userId, scope: scope || 'mcp:read', authType });
+  return c.json({ valid: true, userId, scope: scope || 'mcp:read', authType, client_name: clientName ?? null });
+});
+
+// Usage analytics ingest (internal — called by fantasy-mcp gateway via service binding).
+// Service-token only: the gateway has already verified the user and passes user_id
+// in the body, so we do NOT re-verify identity here. Best-effort and tolerant — a
+// failed insert must never break the caller's request path.
+api.post('/internal/usage-event', async (c) => {
+  const internalError = await requireInternalService(c.req.raw, c.env);
+  if (internalError) {
+    return c.json({ ok: false, error: internalError.error }, internalError.status);
+  }
+
+  try {
+    const body = await c.req.json() as UsageEvent;
+    // correlation_id is accepted on the wire (for log joining) but is not a column
+    // on mcp_tool_events; UsageStorage.insertEvent drops it.
+    const { error } = await UsageStorage.fromEnvironment(c.env).insertEvent(body);
+    if (error) {
+      // Swallow storage errors — analytics is non-critical. Already logged in storage.
+      return c.json({ ok: true });
+    }
+  } catch (e) {
+    // Never throw back to the caller; usage events are fire-and-forget.
+    debugLog(c.env, `[auth-worker] usage-event ingest failed: ${e instanceof Error ? e.message : 'unknown error'}`);
+  }
+
+  return c.json({ ok: true });
 });
 
 // =============================================================================

--- a/workers/auth-worker/src/oauth-handlers.ts
+++ b/workers/auth-worker/src/oauth-handlers.ts
@@ -1042,7 +1042,7 @@ export async function validateOAuthToken(
   token: string,
   env: OAuthEnv,
   expectedResource?: string
-): Promise<{ userId: string; scope: string } | null> {
+): Promise<{ userId: string; scope: string; clientName: string | null } | null> {
   const storage = OAuthStorage.fromEnvironment(env);
   const result = await storage.validateAccessToken(token, expectedResource);
 
@@ -1058,6 +1058,7 @@ export async function validateOAuthToken(
   return {
     userId: result.userId,
     scope: result.scope || 'mcp:read',
+    clientName: result.clientName ?? null,
   };
 }
 

--- a/workers/auth-worker/src/oauth-storage.ts
+++ b/workers/auth-worker/src/oauth-storage.ts
@@ -92,6 +92,7 @@ export interface TokenValidationResult {
   userId?: string;
   scope?: string;
   resource?: string | null;
+  clientName?: string | null;
   error?: string;
 }
 
@@ -534,7 +535,7 @@ export class OAuthStorage {
   async validateAccessToken(accessToken: string, expectedResource?: string): Promise<TokenValidationResult> {
     const { data, error } = await this.supabase
       .from('oauth_tokens')
-      .select('user_id, scope, resource, expires_at, revoked_at')
+      .select('user_id, scope, resource, client_name, expires_at, revoked_at')
       .eq('access_token', accessToken)
       .single();
 
@@ -562,6 +563,7 @@ export class OAuthStorage {
       userId: data.user_id,
       scope: data.scope,
       resource: data.resource || null,
+      clientName: data.client_name || null,
     };
   }
 

--- a/workers/auth-worker/src/usage-storage.ts
+++ b/workers/auth-worker/src/usage-storage.ts
@@ -1,0 +1,84 @@
+/**
+ * Usage analytics storage (FLA-156)
+ *
+ * Append-only writes of MCP tool-call events into Supabase `mcp_tool_events`.
+ * Events arrive at the auth-worker via POST /internal/usage-event from the
+ * fantasy-mcp gateway, which has already verified the caller. This module only
+ * performs the insert; it does not validate identity.
+ *
+ * Mirrors the shape of OAuthStorage (private supabase client, constructor via
+ * createClient, static fromEnvironment factory) without overloading it.
+ */
+
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+
+export interface UsageStorageEnv {
+  SUPABASE_URL: string;
+  SUPABASE_SERVICE_KEY: string;
+}
+
+/**
+ * Raw usage event payload.
+ *
+ * Mirrors the `mcp_tool_events` table columns (migration 026). `ts` is omitted
+ * intentionally so the DB default (now()) populates it. `correlation_id` is
+ * accepted on the wire for log joining but is NOT a column on the table, so it
+ * is never inserted.
+ */
+export interface UsageEvent {
+  env: string;
+  user_id: string;
+  auth_type: string;
+  client_name?: string | null;
+  tool_name: string;
+  platform?: string | null;
+  sport?: string | null;
+  status: string;
+  error_code?: string | null;
+  latency_ms?: number | null;
+  league_hash?: string | null;
+  // Accepted but not stored (no column on mcp_tool_events).
+  correlation_id?: string | null;
+}
+
+export class UsageStorage {
+  private supabase: SupabaseClient;
+
+  constructor(supabaseUrl: string, supabaseKey: string) {
+    this.supabase = createClient(supabaseUrl, supabaseKey);
+  }
+
+  /**
+   * Append a single tool-call event to mcp_tool_events.
+   * `ts` is left to the DB default. `correlation_id` is intentionally dropped
+   * because the table has no such column.
+   */
+  async insertEvent(e: UsageEvent): Promise<{ error: unknown }> {
+    const { error } = await this.supabase.from('mcp_tool_events').insert({
+      env: e.env,
+      user_id: e.user_id,
+      auth_type: e.auth_type,
+      client_name: e.client_name ?? null,
+      tool_name: e.tool_name,
+      platform: e.platform ?? null,
+      sport: e.sport ?? null,
+      status: e.status,
+      error_code: e.error_code ?? null,
+      latency_ms: e.latency_ms ?? null,
+      league_hash: e.league_hash ?? null,
+    });
+
+    if (error) {
+      console.error('[usage-storage] Failed to insert tool event:', error);
+    }
+
+    return { error };
+  }
+
+  /**
+   * Create instance from environment variables
+   */
+  static fromEnvironment(env: UsageStorageEnv): UsageStorage {
+    return new UsageStorage(env.SUPABASE_URL, env.SUPABASE_SERVICE_KEY);
+  }
+}

--- a/workers/fantasy-mcp/src/index.ts
+++ b/workers/fantasy-mcp/src/index.ts
@@ -274,6 +274,10 @@ async function handleMcpRequest(c: Context<{ Bindings: Env }>): Promise<Response
     : 'https://api.flaim.app/mcp';
 
   let tokenScope: string | undefined;
+  // Captured for usage analytics (FLA-156) — passed into the MCP server context.
+  let userId: string | undefined;
+  let authType: 'clerk' | 'oauth' | 'eval-api-key' | 'demo-api-key' | undefined;
+  let clientName: string | null = null;
   if (authHeader) {
     try {
       const introspectRes = await c.env.AUTH_WORKER.fetch(
@@ -301,6 +305,7 @@ async function handleMcpRequest(c: Context<{ Bindings: Env }>): Promise<Response
         scope?: string;
         userId?: string;
         authType?: 'clerk' | 'oauth' | 'eval-api-key' | 'demo-api-key';
+        client_name?: string | null;
       };
       if (!tokenInfo.valid) {
         logFantasySetupFailure(c, 'auth_trust_path_failed', {
@@ -327,6 +332,11 @@ async function handleMcpRequest(c: Context<{ Bindings: Env }>): Promise<Response
         });
         return buildMcpAuthErrorResponse(c.req.raw);
       }
+
+      // Capture identity for usage analytics after the token is validated.
+      userId = tokenInfo.userId;
+      authType = tokenInfo.authType;
+      clientName = tokenInfo.client_name ?? null;
 
       // Rate limit authenticated MCP requests.
       // Opt-out: all auth types are rate-limited unless explicitly exempted.
@@ -388,6 +398,10 @@ async function handleMcpRequest(c: Context<{ Bindings: Env }>): Promise<Response
     correlationId,
     evalRunId,
     evalTraceId,
+    userId,
+    authType,
+    clientName,
+    executionCtx: c.executionCtx,
   });
   const handler = createMcpHandler(server, { enableJsonResponse: false });
   const normalizedRequest = normalizeMcpAcceptHeader(c.req.raw);

--- a/workers/fantasy-mcp/src/mcp/server.ts
+++ b/workers/fantasy-mcp/src/mcp/server.ts
@@ -1,7 +1,8 @@
 // workers/fantasy-mcp/src/mcp/server.ts
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { Env } from '../types';
-import { getUnifiedTools, hasRequiredScope, mcpAuthError } from './tools';
+import { getUnifiedTools, hasRequiredScope, mcpAuthError, type McpToolResponse } from './tools';
+import { emitUsageEvent, type UsageStatus } from './usage';
 import { USER_SESSION_WIDGET_HTML } from '../widgets/user-session-widget';
 import { FLAIM_MCP_INSTRUCTIONS } from './instructions';
 
@@ -12,6 +13,34 @@ export interface McpContext {
   correlationId?: string;
   evalRunId?: string;
   evalTraceId?: string;
+  // Identity + execution context for usage analytics (FLA-156).
+  userId?: string;
+  authType?: 'clerk' | 'oauth' | 'eval-api-key' | 'demo-api-key';
+  clientName?: string | null;
+  executionCtx: ExecutionContext;
+}
+
+/**
+ * Fire the best-effort usage emit without ever influencing the tool call. The
+ * emit itself is async-and-swallowed (.catch), but wrapping the waitUntil in a
+ * try/catch also guards against a *synchronous* throw from waitUntil (e.g. a
+ * disposed ExecutionContext) altering tool-call control flow.
+ */
+function safeEmit(
+  ctx: McpContext,
+  toolName: string,
+  args: Record<string, unknown>,
+  status: UsageStatus,
+  latencyMs: number | null,
+  result?: McpToolResponse,
+): void {
+  try {
+    ctx.executionCtx.waitUntil(
+      emitUsageEvent(ctx, toolName, args, status, latencyMs, result).catch(() => {})
+    );
+  } catch {
+    /* never affect the tool call */
+  }
 }
 
 /**
@@ -92,10 +121,27 @@ export function createFantasyMcpServer(ctx: McpContext): McpServer {
         },
       },
       async (args) => {
+        // Scope-denied path: emit a 'denied' event (no latency timing) before the
+        // auth error returns. Its own waitUntil so it never blocks the response.
         if (!hasRequiredScope(tokenScope, tool.requiredScope)) {
+          safeEmit(ctx, tool.name, args, 'denied', null);
           return mcpAuthError('https://api.flaim.app/mcp');
         }
-        return tool.handler(args, env, authHeader || undefined, correlationId, evalRunId, evalTraceId);
+
+        // Time and emit exactly one event per tool call. Default status 'error'
+        // covers the throw path (a handler can throw; withToolLogging re-throws).
+        // The emit runs in waitUntil AFTER the response, so it adds no latency, and
+        // the original throw still propagates out of finally — never swallowed.
+        const start = Date.now();
+        let status: 'ok' | 'error' = 'error';
+        let result: McpToolResponse | undefined;
+        try {
+          result = await tool.handler(args, env, authHeader || undefined, correlationId, evalRunId, evalTraceId);
+          status = result?.isError === true ? 'error' : 'ok';
+          return result;
+        } finally {
+          safeEmit(ctx, tool.name, args, status, Date.now() - start, result);
+        }
       }
     );
   }

--- a/workers/fantasy-mcp/src/mcp/usage.ts
+++ b/workers/fantasy-mcp/src/mcp/usage.ts
@@ -31,7 +31,9 @@ interface UsageEventBody {
 
 /** Best-effort string extraction from an unknown args/result field. */
 function asStringOrNull(value: unknown): string | null {
-  return typeof value === 'string' && value.length > 0 ? value : null;
+  if (typeof value === 'string' && value.length > 0) return value;
+  if (typeof value === 'number') return String(value);
+  return null;
 }
 
 /**
@@ -52,7 +54,9 @@ async function computeLeagueHash(args: Record<string, unknown>): Promise<string 
 /** Best-effort structured error code from the tool result (often null). */
 function extractErrorCode(result?: McpToolResponse): string | null {
   const code = result?.structuredContent?.code;
-  return typeof code === 'string' && code.length > 0 ? code : null;
+  if (typeof code === 'string' && code.length > 0) return code;
+  if (typeof code === 'number') return String(code);
+  return null;
 }
 
 /**

--- a/workers/fantasy-mcp/src/mcp/usage.ts
+++ b/workers/fantasy-mcp/src/mcp/usage.ts
@@ -1,0 +1,109 @@
+// workers/fantasy-mcp/src/mcp/usage.ts
+//
+// Usage analytics emit (FLA-156, gateway side).
+//
+// Fires exactly one fire-and-forget event per MCP tool call to the auth-worker
+// (POST /internal/usage-event). This is best-effort telemetry: it MUST never add
+// latency to or break a tool call. Callers run it inside ctx.executionCtx.waitUntil
+// with a trailing .catch(() => {}), so it executes after the response is returned
+// and any failure is swallowed. Nothing here is awaited on the request path.
+
+import { withInternalServiceToken } from '@flaim/worker-shared';
+import type { McpContext } from './server';
+import type { McpToolResponse } from './tools';
+
+export type UsageStatus = 'ok' | 'error' | 'denied';
+
+interface UsageEventBody {
+  env: string;
+  user_id: string;
+  auth_type: string;
+  client_name: string | null;
+  tool_name: string;
+  platform: string | null;
+  sport: string | null;
+  status: UsageStatus;
+  error_code: string | null;
+  latency_ms: number | null;
+  league_hash: string | null;
+  correlation_id: string | null;
+}
+
+/** Best-effort string extraction from an unknown args/result field. */
+function asStringOrNull(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+/**
+ * SHA-256 hex of `<platform>:<league_id>`. Returns null when league_id is absent.
+ * Pseudonymizes the league identity so analytics never stores raw league IDs.
+ */
+async function computeLeagueHash(args: Record<string, unknown>): Promise<string | null> {
+  const leagueId = asStringOrNull(args.league_id);
+  if (!leagueId) return null;
+  const platform = asStringOrNull(args.platform) ?? '';
+  const input = `${platform}:${leagueId}`;
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(input));
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/** Best-effort structured error code from the tool result (often null). */
+function extractErrorCode(result?: McpToolResponse): string | null {
+  const code = result?.structuredContent?.code;
+  return typeof code === 'string' && code.length > 0 ? code : null;
+}
+
+/**
+ * Build and POST a single usage event to the auth-worker. Intended to be wrapped
+ * in waitUntil(...).catch(() => {}). Being an async function, any synchronous
+ * throw (e.g. missing INTERNAL_SERVICE_TOKEN) surfaces as a rejected promise that
+ * the caller's .catch swallows — it never reaches the request path.
+ */
+export async function emitUsageEvent(
+  ctx: McpContext,
+  toolName: string,
+  args: Record<string, unknown>,
+  status: UsageStatus,
+  latencyMs: number | null,
+  result?: McpToolResponse,
+): Promise<void> {
+  // No user_id means no useful analytics row — skip the POST entirely so we
+  // never write blank-user junk. introspect normally guarantees userId; this is
+  // the rare valid-without-userId guard.
+  if (!ctx.userId) return;
+
+  const leagueHash = await computeLeagueHash(args);
+
+  const body: UsageEventBody = {
+    // ENVIRONMENT only ('prod' | 'preview' | 'dev'). Intentionally no NODE_ENV
+    // fallback — that would emit Node's 'production' instead of our 'prod'.
+    env: ctx.env.ENVIRONMENT ?? 'unknown',
+    user_id: ctx.userId ?? '',
+    auth_type: ctx.authType ?? 'unknown',
+    client_name: ctx.clientName ?? null,
+    tool_name: toolName,
+    platform: asStringOrNull(args.platform),
+    sport: asStringOrNull(args.sport),
+    status,
+    error_code: extractErrorCode(result),
+    latency_ms: latencyMs,
+    league_hash: leagueHash,
+    correlation_id: ctx.correlationId ?? null,
+  };
+
+  const headers = withInternalServiceToken(
+    { 'Content-Type': 'application/json' },
+    ctx.env,
+    'auth-worker /internal/usage-event',
+  );
+
+  await ctx.env.AUTH_WORKER.fetch(
+    new Request('https://internal/internal/usage-event', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+    }),
+  );
+}

--- a/workers/fantasy-mcp/tests/integration/index.integration.test.ts
+++ b/workers/fantasy-mcp/tests/integration/index.integration.test.ts
@@ -1,8 +1,19 @@
 import { describe, expect, it, vi } from 'vitest';
 import app from '../../src/index';
 import type { Env } from '../../src/types';
-import { getUnifiedTools } from '../../src/mcp/tools';
+import { getUnifiedTools, type UnifiedTool } from '../../src/mcp/tools';
 import { INTERNAL_SERVICE_TOKEN_HEADER, getDefaultSeasonYear } from '@flaim/worker-shared';
+
+// Mock the tools module so a single test can inject a custom tool (e.g. a
+// throwing handler) via mockReturnValueOnce, while every other test/request
+// transparently falls through to the real getUnifiedTools implementation.
+vi.mock('../../src/mcp/tools', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/mcp/tools')>();
+  return {
+    ...actual,
+    getUnifiedTools: vi.fn(actual.getUnifiedTools),
+  };
+});
 
 function buildMcpRequest(pathname: '/mcp' | '/fantasy/mcp'): Request {
   return buildMcpJsonRpcRequest(pathname, 'tools/list');
@@ -110,6 +121,24 @@ function mockExecutionContext(): ExecutionContext {
     waitUntil: vi.fn(),
     passThroughOnException: vi.fn(),
   } as unknown as ExecutionContext;
+}
+
+// Execution context that collects waitUntil promises so fire-and-forget work
+// (e.g. the FLA-156 usage-event emit) can be awaited and asserted in tests.
+function collectingExecutionContext(): { ctx: ExecutionContext; settled: () => Promise<void> } {
+  const pending: Promise<unknown>[] = [];
+  const ctx = {
+    waitUntil: vi.fn((p: Promise<unknown>) => {
+      pending.push(Promise.resolve(p));
+    }),
+    passThroughOnException: vi.fn(),
+  } as unknown as ExecutionContext;
+  return {
+    ctx,
+    settled: async () => {
+      await Promise.allSettled(pending);
+    },
+  };
 }
 
 function emittedSetupSignal(spy: { mock: { calls: unknown[][] } }): boolean {
@@ -700,5 +729,222 @@ describe('fantasy-mcp gateway integration', () => {
     expect(payloadText).toContain('Test ESPN League');
     expect(payloadText).toContain('Test Yahoo League');
     expect(payloadText).toContain('Test Sleeper League');
+  });
+
+  it('emits a fire-and-forget usage event to /internal/usage-event after a tool call', async () => {
+    const usageRequests: Request[] = [];
+    const authFetch = vi.fn(async (request: Request) => {
+      const url = new URL(request.url);
+      if (url.pathname === '/internal/introspect') {
+        return new Response(
+          JSON.stringify({
+            valid: true,
+            userId: 'user-123',
+            scope: 'mcp:read mcp:write',
+            authType: 'oauth',
+            client_name: 'Claude',
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+      if (url.pathname === '/internal/usage-event') {
+        // Clone so the body stays readable after the gateway consumes it.
+        usageRequests.push(request.clone());
+        return new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response('not found', { status: 404 });
+    });
+    const espnFetch = vi.fn(async () =>
+      new Response(
+        JSON.stringify({ success: true, data: { leagueId: '123', standings: [] } }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+    const env = buildEnv(authFetch);
+    env.ESPN = { fetch: espnFetch } as unknown as Fetcher;
+
+    const { ctx, settled } = collectingExecutionContext();
+    const request = new Request('https://api.flaim.app/mcp', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-token',
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 'usage-event-test-1',
+        method: 'tools/call',
+        params: {
+          name: 'get_standings',
+          arguments: { platform: 'espn', sport: 'football', league_id: '123', season_year: 2025 },
+        },
+      }),
+    });
+
+    const response = await app.fetch(request, env, ctx);
+    expect(response.status).toBe(200);
+    // Drain the SSE body so the streamed tool handler (and its finally emit) runs.
+    await response.text();
+
+    // The emit must be fire-and-forget via executionCtx.waitUntil — never awaited inline.
+    expect(ctx.waitUntil).toHaveBeenCalled();
+    await settled();
+
+    expect(usageRequests).toHaveLength(1);
+    const usageReq = usageRequests[0];
+    expect(usageReq.method).toBe('POST');
+    expect(usageReq.headers.get(INTERNAL_SERVICE_TOKEN_HEADER)).toBe('internal-secret');
+
+    const body = await usageReq.json() as Record<string, unknown>;
+    expect(body.tool_name).toBe('get_standings');
+    expect(body.status).toBe('ok');
+    expect(body.user_id).toBe('user-123');
+    expect(body.auth_type).toBe('oauth');
+    expect(body.client_name).toBe('Claude');
+    expect(body.platform).toBe('espn');
+    expect(body.sport).toBe('football');
+    expect(typeof body.latency_ms).toBe('number');
+    // league_hash is the SHA-256 hex of `espn:123` (64 hex chars).
+    expect(typeof body.league_hash).toBe('string');
+    expect(body.league_hash).toHaveLength(64);
+    expect(body).toHaveProperty('correlation_id');
+    expect(espnFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits a single denied usage event (latency null) and skips the handler when the scope check fails', async () => {
+    const usageRequests: Request[] = [];
+    const authFetch = vi.fn(async (request: Request) => {
+      const url = new URL(request.url);
+      if (url.pathname === '/internal/introspect') {
+        // 'mcp:write' is non-empty so it clears the gateway scope gate, but it
+        // lacks 'mcp:read' — which get_standings requires — so the per-tool
+        // scope check in server.ts denies the call before the handler runs.
+        return new Response(
+          JSON.stringify({ valid: true, userId: 'user-123', scope: 'mcp:write', authType: 'oauth', client_name: 'Claude' }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+      if (url.pathname === '/internal/usage-event') {
+        usageRequests.push(request.clone());
+        return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response('not found', { status: 404 });
+    });
+    const espnFetch = vi.fn(async () =>
+      new Response(JSON.stringify({ success: true, data: {} }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    );
+    const env = buildEnv(authFetch);
+    env.ESPN = { fetch: espnFetch } as unknown as Fetcher;
+
+    const { ctx, settled } = collectingExecutionContext();
+    const request = new Request('https://api.flaim.app/mcp', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-token',
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 'usage-denied-1',
+        method: 'tools/call',
+        params: {
+          name: 'get_standings',
+          arguments: { platform: 'espn', sport: 'football', league_id: '123', season_year: 2025 },
+        },
+      }),
+    });
+
+    const response = await app.fetch(request, env, ctx);
+    expect(response.status).toBe(200);
+    const text = await response.text();
+    const data = text.split(/\r?\n/).filter((l) => l.startsWith('data:')).map((l) => l.slice(5).trim()).join('\n').trim();
+    const parsed = JSON.parse(data) as { result?: { isError?: boolean; content?: Array<{ text?: string }> } };
+    // The tool call resolves to the MCP auth error, not a handler result.
+    expect(parsed.result?.isError).toBe(true);
+    expect(parsed.result?.content?.[0]?.text).toContain('AUTH_FAILED');
+
+    // Handler must NOT run on the denied path.
+    expect(espnFetch).not.toHaveBeenCalled();
+
+    await settled();
+    expect(usageRequests).toHaveLength(1);
+    const body = await usageRequests[0].json() as Record<string, unknown>;
+    expect(body.tool_name).toBe('get_standings');
+    expect(body.status).toBe('denied');
+    expect(body.latency_ms).toBeNull();
+    expect(body.user_id).toBe('user-123');
+  });
+
+  it('propagates a thrown handler error and emits a single error usage event', async () => {
+    const usageRequests: Request[] = [];
+    const authFetch = vi.fn(async (request: Request) => {
+      const url = new URL(request.url);
+      if (url.pathname === '/internal/introspect') {
+        return new Response(
+          JSON.stringify({ valid: true, userId: 'user-123', scope: 'mcp:read', authType: 'oauth', client_name: 'Claude' }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+      if (url.pathname === '/internal/usage-event') {
+        usageRequests.push(request.clone());
+        return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response('not found', { status: 404 });
+    });
+    const env = buildEnv(authFetch);
+
+    // Inject a single tool whose handler throws. The MCP SDK wraps a *propagated*
+    // throw into an isError CallToolResult carrying the thrown message — so seeing
+    // that message in the response proves server.ts re-propagated the throw and
+    // its finally-block emit did not swallow it. status stays 'error' on this path.
+    const explodingTool: UnifiedTool = {
+      name: 'explode',
+      title: 'Explode',
+      description: 'Test-only tool whose handler always throws.',
+      inputSchema: {},
+      requiredScope: 'mcp:read',
+      securitySchemes: [{ type: 'oauth2', scopes: ['mcp:read'] }],
+      handler: async () => {
+        throw new Error('handler boom');
+      },
+    };
+    vi.mocked(getUnifiedTools).mockReturnValueOnce([explodingTool]);
+
+    const { ctx, settled } = collectingExecutionContext();
+    const request = new Request('https://api.flaim.app/mcp', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-token',
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 'usage-error-1',
+        method: 'tools/call',
+        params: { name: 'explode', arguments: {} },
+      }),
+    });
+
+    const response = await app.fetch(request, env, ctx);
+    expect(response.status).toBe(200);
+    const text = await response.text();
+    const data = text.split(/\r?\n/).filter((l) => l.startsWith('data:')).map((l) => l.slice(5).trim()).join('\n').trim();
+    const parsed = JSON.parse(data) as { result?: { isError?: boolean; content?: Array<{ text?: string }> } };
+    // The thrown message surfaces — only possible if the throw propagated.
+    expect(parsed.result?.isError).toBe(true);
+    expect(parsed.result?.content?.[0]?.text).toContain('handler boom');
+
+    await settled();
+    expect(usageRequests).toHaveLength(1);
+    const body = await usageRequests[0].json() as Record<string, unknown>;
+    expect(body.tool_name).toBe('explode');
+    expect(body.status).toBe('error');
+    expect(typeof body.latency_ms).toBe('number');
   });
 });


### PR DESCRIPTION
Implements FLA-156 — ground-truth usage analytics from the fantasy-mcp gateway.

## What
One fire-and-forget event per MCP tool call → auth-worker `/internal/usage-event` → Supabase `mcp_tool_events`. Daily pg_cron rollups into `mcp_user_daily` / `mcp_tool_daily`; raw pruned at 90d.

## Changes
- **gateway:** emit in try/finally via `executionCtx.waitUntil` (safeEmit guard) — never awaited, post-response, cannot slow or break a tool call. status ok/error/denied, env tag, league_hash (sha256).
- **auth-worker:** `UsageStorage` + tolerant `/internal/usage-event` (service-token guarded, always 200); introspect additively returns `client_name`.
- **docs/tests:** DATABASE.md analytics tables; tests for ok/denied/throw paths + ingest tolerance.

## Migration
`026_mcp_usage_analytics.sql` (tables + rollup/prune functions + pg_cron) is **already applied to prod** (additive, empty tables, jobs scheduled).

## Validation
Preview deploy emits `env='preview'` rows (separated from prod metrics, which filter `env='prod'`). Plan: run an eval against `--target preview`, confirm rows land in `mcp_tool_events` with correct shape.

Verified: typecheck clean (both workers); tests green (auth-worker 429, fantasy-mcp 20); independent audit — no blockers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)