### PR TITLE
feat(oauth): grant_type stamping for connection-health hygiene (FLA-155)

### DIFF
--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -187,6 +187,7 @@ Access and refresh tokens for MCP clients.
 | refresh_token | text | Optional refresh token; confidential-client refresh tokens encode a signed client binding |
 | refresh_token_expires_at | timestamptz | MCP refresh-token inactivity expiry (1 year by default; `OAUTH_REFRESH_TOKEN_TTL_SECONDS`) |
 | created_at | timestamptz | Created timestamp |
+| grant_type | text | Mint path (migration 028): `authorization_code` (new connection) or `refresh_token` (keepalive); null for pre-migration rows |
 
 When extending the MCP refresh-token inactivity window for an existing deployment, non-revoked rows with still-valid refresh tokens can be backfilled so current connectors inherit the longer window without reconnecting:
 
@@ -200,6 +201,9 @@ WHERE refresh_token IS NOT NULL
   AND revoked_at IS NULL
   AND refresh_token_expires_at > now();
 ```
+
+### oauth_connections (view)
+Connection-health view (migration 028, `security_invoker` so it inherits `oauth_tokens` RLS). One row per `(user_id, client_name)`: `connected` (a live, non-expired refresh token exists), `first_seen`, `last_refresh`, `token_rows`, and `auth_grants` (count of `authorization_code` mints). Use for connection status/health — distinct from the gateway engagement analytics (`mcp_tool_events`).
 
 ### oauth_states
 Short-lived OAuth state values used for server-side validation.

--- a/workers/auth-worker/src/__tests__/oauth-storage.test.ts
+++ b/workers/auth-worker/src/__tests__/oauth-storage.test.ts
@@ -241,9 +241,51 @@ describe('OAuthStorage MCP token lifetimes', () => {
 
     expect(token).not.toBeNull();
     expect(updateEq).toHaveBeenCalledWith('access_token', 'old-access-token');
+    expect(insertPayloads[0].grant_type).toBe('refresh_token');
     const refreshTokenExpiresAt = new Date(insertPayloads[0].refresh_token_expires_at as string).getTime();
     expect(refreshTokenExpiresAt).toBeGreaterThanOrEqual(before + 2592000 * 1000 - 1000);
     expect(refreshTokenExpiresAt).toBeLessThanOrEqual(after + 2592000 * 1000 + 1000);
+  });
+
+  it('records grant_type=authorization_code when exchanging an authorization code', async () => {
+    const redirectUri = 'https://claude.ai/api/mcp/auth_callback';
+    const code = 'plain-auth-code';
+
+    const claimSingle = vi.fn().mockResolvedValue({
+      data: {
+        code,
+        user_id: 'user_123',
+        redirect_uri: redirectUri,
+        code_challenge: null,
+        code_challenge_method: null,
+        scope: 'mcp:read',
+        resource: null,
+        expires_at: new Date(Date.now() + 60_000).toISOString(),
+      },
+      error: null,
+    });
+    const claimSelect = vi.fn().mockReturnValue({ single: claimSingle });
+    const claimGt = vi.fn().mockReturnValue({ select: claimSelect });
+    const claimIs = vi.fn().mockReturnValue({ gt: claimGt });
+    const claimEq = vi.fn().mockReturnValue({ is: claimIs });
+    const update = vi.fn().mockReturnValue({ eq: claimEq });
+
+    const insertPayloads: Record<string, unknown>[] = [];
+    const insertSingle = vi.fn().mockResolvedValue({ data: { id: 'token-id' }, error: null });
+    const insertSelect = vi.fn().mockReturnValue({ single: insertSingle });
+    const insert = vi.fn((payload: Record<string, unknown>) => {
+      insertPayloads.push(payload);
+      return { select: insertSelect };
+    });
+
+    mockFrom.mockReturnValue({ update, insert });
+    const storage = new OAuthStorage('https://example.supabase.co', 'test-key');
+
+    const token = await storage.exchangeCodeForToken(code, redirectUri);
+
+    expect(token).not.toBeNull();
+    expect(insertPayloads).toHaveLength(1);
+    expect(insertPayloads[0].grant_type).toBe('authorization_code');
   });
 
   it('refresh rotation preserves confidential client binding', async () => {

--- a/workers/auth-worker/src/oauth-storage.ts
+++ b/workers/auth-worker/src/oauth-storage.ts
@@ -78,6 +78,7 @@ export interface CreateTokenParams {
   expiresInSeconds?: number; // Default: 3600 (1 hour)
   includeRefreshToken?: boolean;
   refreshTokenExpiresInSeconds?: number; // Default: 31536000 (1 year)
+  grantType?: 'authorization_code' | 'refresh_token'; // Separates new connections from keepalive refreshes
 }
 
 export interface CreateStateParams {
@@ -465,6 +466,7 @@ export class OAuthStorage {
       redirectUri: authCode.redirectUri, // For deriving clientName
       clientId: authCode.clientId,
       includeRefreshToken: true,
+      grantType: 'authorization_code',
     });
 
     return token;
@@ -506,6 +508,7 @@ export class OAuthStorage {
       expires_at: expiresAt.toISOString(),
       refresh_token: refreshToken || null,
       refresh_token_expires_at: refreshTokenExpiresAt?.toISOString() || null,
+      grant_type: params.grantType ?? null,
     }).select('id').single();
 
     if (error) {
@@ -611,6 +614,7 @@ export class OAuthStorage {
       clientId: tokenClientId,
       clientName: data.client_name || undefined, // Preserve clientName
       includeRefreshToken: true,
+      grantType: 'refresh_token',
     });
 
     return newToken;


### PR DESCRIPTION
Part of FLA-155 (oauth_tokens hygiene). Records `grant_type` on minted tokens so **new connections** are cleanly separable from **keepalive refreshes** — the churn that makes the token table read as inflated active-usage.

## What's in this PR (code only)
- `createAccessToken()` now stamps `grant_type`: **`'authorization_code'`** on the code-exchange path (a real new connection) and **`'refresh_token'`** on refresh (keepalive). Additive — no token logic changed.
- Tests assert the correct `grant_type` on each path.

## Already applied to prod (additive, out of band)
- **Migration 028** — `grant_type` column + `oauth_connections` view (`security_invoker`, inherits RLS). Advisors clean. The column is nullable, so old prod code (not setting it) was unaffected before this deploys.

## Why
The gateway (`mcp_tool_events`) is the source of truth for *engagement*. This repurposes `oauth_tokens` as a clean **connection-health** layer: `oauth_connections` already shows ~137 active connections (101 ChatGPT / 32 Claude / 4 other), and `grant_type` will make 'new connections/day' trivially queryable.

## Not in this PR (separate gated step)
Scheduling `cleanup_expired_oauth_tokens()` — the only data-deleting part. Applied deliberately after this merges.

Verified: typecheck clean; auth-worker suite 430 passing; `createAccessToken` confirmed to have exactly the 2 mint-path callers, both handled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)