### PR TITLE
[codex] Refresh ESPN league metadata on discovery

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -88,7 +88,7 @@ Season year defaults are deterministic and use America/New_York time. The canoni
 | Sport | Rollover Date | Rationale |
 |-------|--------------|-----------|
 | Baseball | Feb 1 | ~10 weeks before Opening Day (late March) |
-| Football | Jul 1 | ~10 weeks before NFL kickoff (early September) |
+| Football | Jun 1 | Longer pre-draft window before NFL kickoff (early September) |
 | Basketball | Aug 1 | ~10 weeks before NBA opening night (late October) |
 | Hockey | Aug 1 | ~10 weeks before NHL opening night (early October) |
 

--- a/web/README.md
+++ b/web/README.md
@@ -69,7 +69,7 @@ Most API routes proxy to auth-worker. See `docs/ARCHITECTURE.md` for the full fl
 Leagues are stored per season year. The `/leagues` UI defaults the season year based on America/New_York time:
 
 - **Baseball (flb)**: Defaults to the previous year until Feb 1, then switches to the current year
-- **Football (ffl)**: Defaults to the previous year until Jul 1, then switches to the current year
+- **Football (ffl)**: Defaults to the previous year until Jun 1, then switches to the current year
 - **Basketball (fba)** / **Hockey (fhl)**: Manual ESPN onboarding still stores the canonical start year (for example `2024` for the 2024-25 season) even though ESPN's upstream API uses the end year
 
 Deleting a league removes all seasons for that league.

--- a/web/lib/server/__tests__/espn-refresh-route.test.ts
+++ b/web/lib/server/__tests__/espn-refresh-route.test.ts
@@ -54,16 +54,19 @@ describe('ESPN refresh normalization helpers', () => {
       found: 0,
       added: 0,
       alreadySaved: 0,
+      refreshed: 0,
     });
     expect(normalizeSeasonCounts(null)).toEqual({
       found: 0,
       added: 0,
       alreadySaved: 0,
+      refreshed: 0,
     });
     expect(normalizeSeasonCounts({ found: 3 })).toEqual({
       found: 3,
       added: 0,
       alreadySaved: 0,
+      refreshed: 0,
     });
   });
 
@@ -144,6 +147,7 @@ describe('POST /api/espn/refresh', () => {
         found: 2,
         added: 1,
         alreadySaved: 1,
+        refreshed: 1,
       },
     }));
     vi.stubGlobal('fetch', fetchMock);
@@ -157,11 +161,13 @@ describe('POST /api/espn/refresh', () => {
         found: 2,
         added: 1,
         alreadySaved: 1,
+        refreshed: 1,
       },
       pastSeasons: {
         found: 0,
         added: 0,
         alreadySaved: 0,
+        refreshed: 0,
       },
     });
     expect(fetchMock).toHaveBeenCalledWith(

--- a/web/lib/server/espn-refresh.ts
+++ b/web/lib/server/espn-refresh.ts
@@ -2,6 +2,7 @@ export interface SeasonCounts {
   found: number;
   added: number;
   alreadySaved: number;
+  refreshed: number;
 }
 
 export function normalizeSeasonCountValue(value: unknown): number | null {
@@ -12,7 +13,7 @@ export function normalizeSeasonCountValue(value: unknown): number | null {
 
 export function normalizeSeasonCounts(value: unknown): SeasonCounts | null {
   if (value === undefined || value === null) {
-    return { found: 0, added: 0, alreadySaved: 0 };
+    return { found: 0, added: 0, alreadySaved: 0, refreshed: 0 };
   }
 
   if (typeof value !== 'object' || Array.isArray(value)) return null;
@@ -21,10 +22,11 @@ export function normalizeSeasonCounts(value: unknown): SeasonCounts | null {
   const found = normalizeSeasonCountValue(record.found);
   const added = normalizeSeasonCountValue(record.added);
   const alreadySaved = normalizeSeasonCountValue(record.alreadySaved);
+  const refreshed = normalizeSeasonCountValue(record.refreshed);
 
-  if (found === null || added === null || alreadySaved === null) return null;
+  if (found === null || added === null || alreadySaved === null || refreshed === null) return null;
 
-  return { found, added, alreadySaved };
+  return { found, added, alreadySaved, refreshed };
 }
 
 export function normalizeWorkerErrorStatus(status: number): number {

--- a/workers/auth-worker/src/__tests__/league-discovery.test.ts
+++ b/workers/auth-worker/src/__tests__/league-discovery.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi, type MockedFunction } from 'vitest';
 vi.mock('../v3/get-league-info', () => ({
   getLeagueInfo: vi.fn(),
+  getLeagueInfoSafe: vi.fn(),
 }));
 vi.mock('../v3/get-league-teams', () => ({
   getLeagueTeams: vi.fn(),
@@ -11,7 +12,7 @@ import {
   discoverAndSaveLeagues,
 } from '../v3/league-discovery';
 import { EspnCredentialsRequired, AutomaticLeagueDiscoveryFailed } from '../espn-types';
-import { getLeagueInfo } from '../v3/get-league-info';
+import { getLeagueInfo, getLeagueInfoSafe } from '../v3/get-league-info';
 import { getLeagueTeams } from '../v3/get-league-teams';
 
 // Mock global fetch
@@ -20,6 +21,7 @@ global.fetch = mockFetch;
 let logSpy: ReturnType<typeof vi.spyOn>;
 let errorSpy: ReturnType<typeof vi.spyOn>;
 const mockGetLeagueInfo = vi.mocked(getLeagueInfo);
+const mockGetLeagueInfoSafe = vi.mocked(getLeagueInfoSafe);
 const mockGetLeagueTeams = vi.mocked(getLeagueTeams);
 
 describe('discoverLeaguesV3', () => {
@@ -28,6 +30,7 @@ describe('discoverLeaguesV3', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     mockFetch.mockReset();
     mockGetLeagueInfo.mockReset();
+    mockGetLeagueInfoSafe.mockReset();
     mockGetLeagueTeams.mockReset();
   });
 
@@ -99,6 +102,7 @@ describe('discoverAndSaveLeagues', () => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     mockFetch.mockReset();
     mockGetLeagueInfo.mockReset();
+    mockGetLeagueInfoSafe.mockReset();
     mockGetLeagueTeams.mockReset();
   });
 
@@ -167,7 +171,63 @@ describe('discoverAndSaveLeagues', () => {
     }));
   });
 
-  it('repairs existing historical rows with the season-specific team name', async () => {
+  it('refreshes existing current-season rows with latest ESPN metadata', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({
+        preferences: [
+          {
+            id: 'pref-1',
+            type: { code: 'fantasy' },
+            metaData: {
+              entry: {
+                entryId: 8,
+                gameId: 1,
+                seasonId: 2025,
+                entryMetadata: { teamName: 'Updated Team Name' },
+                groups: [{ groupId: 12345, groupName: 'Updated League Name' }],
+              },
+            },
+          },
+        ],
+      }),
+    } as Response);
+
+    mockGetLeagueInfo.mockResolvedValueOnce({
+      status: { previousSeasons: [] },
+    } as any);
+
+    const storage = {
+      leagueExists: vi.fn().mockResolvedValueOnce(true),
+      addLeague: vi.fn().mockResolvedValue({ success: true }),
+      updateLeague: vi.fn().mockResolvedValue(true),
+    } as any;
+
+    const result = await discoverAndSaveLeagues('user_123', '{swid}', 's2token', storage);
+
+    expect(storage.addLeague).not.toHaveBeenCalled();
+    expect(result.currentSeason).toEqual({
+      found: 1,
+      added: 0,
+      alreadySaved: 1,
+      refreshed: 1,
+    });
+    expect(storage.updateLeague).toHaveBeenCalledWith(
+      'user_123',
+      '12345',
+      'football',
+      2025,
+      expect.objectContaining({
+        leagueName: 'Updated League Name',
+        teamId: '8',
+        teamName: 'Updated Team Name',
+      })
+    );
+  });
+
+  it('repairs existing historical rows with the season-specific league and team name', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
       status: 200,
@@ -191,12 +251,77 @@ describe('discoverAndSaveLeagues', () => {
       }),
     } as Response);
 
-    mockGetLeagueInfo.mockResolvedValueOnce({
-      status: { previousSeasons: [2024] },
-    } as any);
+    mockGetLeagueInfo
+      .mockResolvedValueOnce({
+        status: { previousSeasons: [2024] },
+      } as any);
+    mockGetLeagueInfoSafe.mockResolvedValueOnce({ leagueName: 'Test League 2024' } as any);
 
     mockGetLeagueTeams.mockResolvedValueOnce([
       { teamId: '8', teamName: 'Old Team Name 2024' },
+    ]);
+
+    const storage = {
+      leagueExists: vi.fn()
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(true),
+      addLeague: vi.fn().mockResolvedValue({ success: true }),
+      updateLeague: vi.fn().mockResolvedValue(true),
+    } as any;
+
+    const result = await discoverAndSaveLeagues('user_123', '{swid}', 's2token', storage);
+
+    expect(result.pastSeasons).toEqual({
+      found: 1,
+      added: 0,
+      alreadySaved: 1,
+      refreshed: 1,
+    });
+    expect(storage.updateLeague).toHaveBeenCalledWith(
+      'user_123',
+      '12345',
+      'football',
+      2024,
+      expect.objectContaining({
+        leagueName: 'Test League 2024',
+        teamId: '8',
+        teamName: 'Old Team Name 2024',
+      })
+    );
+  });
+
+  it('does not overwrite an existing historical league name when ESPN omits the season-specific name', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({
+        preferences: [
+          {
+            id: 'pref-1',
+            type: { code: 'fantasy' },
+            metaData: {
+              entry: {
+                entryId: 8,
+                gameId: 1,
+                seasonId: 2025,
+                entryMetadata: { teamName: 'Current Team Name' },
+                groups: [{ groupId: 12345, groupName: 'Current League Name' }],
+              },
+            },
+          },
+        ],
+      }),
+    } as Response);
+
+    mockGetLeagueInfo
+      .mockResolvedValueOnce({
+        status: { previousSeasons: [2024] },
+      } as any);
+    mockGetLeagueInfoSafe.mockResolvedValueOnce({} as any);
+
+    mockGetLeagueTeams.mockResolvedValueOnce([
+      { teamId: '8', teamName: 'Historical Team Name' },
     ]);
 
     const storage = {
@@ -214,9 +339,78 @@ describe('discoverAndSaveLeagues', () => {
       '12345',
       'football',
       2024,
+      expect.not.objectContaining({
+        leagueName: 'Current League Name',
+      })
+    );
+    expect(storage.updateLeague).toHaveBeenCalledWith(
+      'user_123',
+      '12345',
+      'football',
+      2024,
       expect.objectContaining({
         teamId: '8',
-        teamName: 'Old Team Name 2024',
+        teamName: 'Historical Team Name',
+      })
+    );
+  });
+
+  it('preserves existing historical counts when season-specific league info cannot be refreshed', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({
+        preferences: [
+          {
+            id: 'pref-1',
+            type: { code: 'fantasy' },
+            metaData: {
+              entry: {
+                entryId: 8,
+                gameId: 1,
+                seasonId: 2025,
+                entryMetadata: { teamName: 'Current Team Name' },
+                groups: [{ groupId: 12345, groupName: 'Current League Name' }],
+              },
+            },
+          },
+        ],
+      }),
+    } as Response);
+
+    mockGetLeagueInfo.mockResolvedValueOnce({
+      status: { previousSeasons: [2024] },
+    } as any);
+    mockGetLeagueInfoSafe.mockResolvedValueOnce(null);
+    mockGetLeagueTeams.mockResolvedValueOnce([
+      { teamId: '8', teamName: 'Historical Team Name' },
+    ]);
+
+    const storage = {
+      leagueExists: vi.fn()
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(true),
+      addLeague: vi.fn().mockResolvedValue({ success: true }),
+      updateLeague: vi.fn().mockResolvedValue(true),
+    } as any;
+
+    const result = await discoverAndSaveLeagues('user_123', '{swid}', 's2token', storage);
+
+    expect(result.pastSeasons).toEqual({
+      found: 1,
+      added: 0,
+      alreadySaved: 1,
+      refreshed: 1,
+    });
+    expect(storage.updateLeague).toHaveBeenCalledWith(
+      'user_123',
+      '12345',
+      'football',
+      2024,
+      expect.objectContaining({
+        teamId: '8',
+        teamName: 'Historical Team Name',
       })
     );
   });

--- a/workers/auth-worker/src/index-hono.ts
+++ b/workers/auth-worker/src/index-hono.ts
@@ -969,7 +969,9 @@ api.post('/extension/discover', async (c) => {
       pastSeasons: result.pastSeasons,
       added: result.currentSeason.added,
       skipped: result.currentSeason.alreadySaved,
+      refreshed: result.currentSeason.refreshed,
       historical: result.pastSeasons.added,
+      historicalRefreshed: result.pastSeasons.refreshed,
     });
 
   } catch (error) {
@@ -999,11 +1001,13 @@ api.post('/extension/discover', async (c) => {
       return c.json({
         discovered,
         currentSeasonLeagues: currentSeasonWithDefault,
-        currentSeason: { found: savedCount, added: 0, alreadySaved: savedCount },
-        pastSeasons: { found: 0, added: 0, alreadySaved: 0 },
+        currentSeason: { found: savedCount, added: 0, alreadySaved: savedCount, refreshed: 0 },
+        pastSeasons: { found: 0, added: 0, alreadySaved: 0, refreshed: 0 },
         added: 0,
         skipped: savedCount,
+        refreshed: 0,
         historical: 0,
+        historicalRefreshed: 0,
       });
     }
 

--- a/workers/auth-worker/src/v3/league-discovery.ts
+++ b/workers/auth-worker/src/v3/league-discovery.ts
@@ -14,7 +14,7 @@ import {
   DiscoveredEspnLeague,
   gameIdToSport
 } from '../espn-types';
-import { getLeagueInfo } from './get-league-info';
+import { getLeagueInfo, getLeagueInfoSafe } from './get-league-info';
 import { getLeagueTeams } from './get-league-teams';
 import { toCanonicalYear, toPlatformYear } from '../season-utils';
 
@@ -214,6 +214,7 @@ export interface SeasonCounts {
   found: number;
   added: number;
   alreadySaved: number;
+  refreshed: number;
 }
 
 /**
@@ -223,6 +224,7 @@ interface HistoricalResult {
   found: number;        // Seasons where user was a member
   added: number;        // Successfully added to DB
   alreadySaved: number; // Already existed in DB
+  refreshed: number;    // Existing rows refreshed with latest ESPN metadata
 }
 
 /**
@@ -254,8 +256,8 @@ export async function discoverAndSaveLeagues(
   const leagues = await discoverLeaguesV3(swid, s2);
 
   const discovered: DiscoveredLeague[] = [];
-  const currentSeason: SeasonCounts = { found: 0, added: 0, alreadySaved: 0 };
-  const pastSeasons: SeasonCounts = { found: 0, added: 0, alreadySaved: 0 };
+  const currentSeason: SeasonCounts = { found: 0, added: 0, alreadySaved: 0, refreshed: 0 };
+  const pastSeasons: SeasonCounts = { found: 0, added: 0, alreadySaved: 0, refreshed: 0 };
 
   // 2. Process each league with per-league try/catch
   for (const league of leagues) {
@@ -283,6 +285,14 @@ export async function discoverAndSaveLeagues(
       );
 
       if (exists) {
+        const refreshed = await storage.updateLeague(userId, league.leagueId, sport, canonicalSeasonYear, {
+          leagueName: league.leagueName,
+          teamId: String(league.teamId),
+          teamName: league.teamName,
+        });
+        if (refreshed) {
+          currentSeason.refreshed++;
+        }
         currentSeason.alreadySaved++;
       } else {
         // Add the league with canonical year
@@ -323,6 +333,7 @@ export async function discoverAndSaveLeagues(
       pastSeasons.found += histResult.found;
       pastSeasons.added += histResult.added;
       pastSeasons.alreadySaved += histResult.alreadySaved;
+      pastSeasons.refreshed += histResult.refreshed;
 
     } catch (error) {
       // Per-league error handling - continue with other leagues
@@ -357,7 +368,7 @@ async function discoverHistoricalSeasons(
   s2: string,
   storage: EspnSupabaseStorage
 ): Promise<HistoricalResult> {
-  const result: HistoricalResult = { found: 0, added: 0, alreadySaved: 0 };
+  const result: HistoricalResult = { found: 0, added: 0, alreadySaved: 0, refreshed: 0 };
   const sport = gameIdToSport(league.gameId);
   if (!sport) return result;
 
@@ -392,11 +403,17 @@ async function discoverHistoricalSeasons(
         // Check if already saved (DB stores canonical year)
         const exists = await storage.leagueExists(userId, sport, league.leagueId, canonicalYear);
         if (exists) {
-          // Heal prior bad writes where historical seasons inherited the current season name.
-          await storage.updateLeague(userId, league.leagueId, sport, canonicalYear, {
+          // Heal prior bad writes where historical seasons inherited current-season metadata.
+          const historicalInfo = await getLeagueInfoSafe(swid, s2, league.leagueId, espnYear, league.gameId);
+          const updates = {
+            ...(historicalInfo?.leagueName ? { leagueName: historicalInfo.leagueName } : {}),
             teamId: historicalTeam.teamId,
             teamName: historicalTeam.teamName || league.teamName,
-          });
+          };
+          const refreshed = await storage.updateLeague(userId, league.leagueId, sport, canonicalYear, updates);
+          if (refreshed) {
+            result.refreshed++;
+          }
           result.alreadySaved++;
           continue;
         }


### PR DESCRIPTION
## Summary

- Refresh existing ESPN current-season league rows during discovery instead of only counting them as already saved.
- Refresh existing ESPN historical rows with season-specific league and team metadata when historical discovery verifies the season.
- Preserve legacy `/extension/discover` response fields while adding explicit `refreshed` and `historicalRefreshed` counts for manual/widget status copy.
- Normalize the new refresh count in the web ESPN refresh route, defaulting missing fields to `0` for compatibility.
- Update the documented football rollover date from July 1 to June 1.

## Root Cause

ESPN discovery treated existing league-season rows as skipped. That meant stale display metadata persisted even when the provider returned newer league/team labels during refresh.

## Validation

- `corepack pnpm --dir workers/auth-worker exec vitest run src/__tests__/league-discovery.test.ts`
- `corepack pnpm --dir workers/auth-worker run type-check`
- `corepack pnpm --dir workers/auth-worker run test`
- `corepack pnpm --dir web exec vitest run lib/server/__tests__/espn-refresh-route.test.ts`
- `corepack pnpm --dir web run test`
- `git diff --check`
- `npm test` in `flaim-eval`
- `npm run type-check` in `flaim-eval`
- Football public-demo eval smoke: `2026-06-30T23-24-05Z`, final acceptance `PASS`

## Notes

The eval smoke validates the current preview read surface for demo football. The write-path behavior in this PR is covered locally by auth-worker unit tests; a deployed preview smoke can validate the live write path after the PR preview is available.
