### PR TITLE
[codex] Add manual league refresh surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Flaim Fantasy
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![MCP Tools](https://img.shields.io/badge/MCP_Tools-9-green.svg)](https://api.flaim.app/mcp)
+[![MCP Tools](https://img.shields.io/badge/MCP_Tools-10-green.svg)](https://api.flaim.app/mcp)
 [![Chrome Web Store](https://img.shields.io/badge/Chrome_Extension-v1.5.2-yellow.svg)](https://chromewebstore.google.com/detail/flaim-espn-fantasy-connec/mbnokejgglkfgkeeenolgdpcnfakpbkn)
 
 Connect your ESPN, Yahoo, and Sleeper leagues, then use Flaim Fantasy in ChatGPT for read-only analysis grounded in your real league. The same MCP service also supports optional manual MCP clients like Claude, Perplexity, and Gemini CLI where their MCP capabilities allow.
 
-Read-only by design. No trades, no drops, no roster changes — just advice.
+Analysis tools are read-only by design. No trades, no drops, no roster changes — just advice. League refresh can update Flaim's connected-league records so newly available seasons show up.
 
 ## How It Works
 
@@ -42,6 +42,7 @@ The AI will detect and activate the skill automatically when you ask fantasy que
 | Tool | What it does |
 |------|-------------|
 | `get_user_session` | Your leagues across all platforms |
+| `refresh_leagues` | Re-discover connected leagues and update Flaim's league records |
 | `get_ancient_history` | Past seasons and historical leagues outside the current season |
 | `get_league_info` | Baseline league context: settings, scoring, roster config, teams/owners |
 | `get_roster` | Team roster with player stats |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -168,6 +168,7 @@ ChatGPT Apps / manual MCP clients → fantasy-mcp (gateway) → espn-client    �
 
 **Unified tools:**
 - `get_user_session` — Current-season leagues only with `structuredContent` for ChatGPT widget rendering
+- `refresh_leagues` — Re-discover connected leagues and update Flaim's league records (`mcp:write`; non-destructive)
 - `get_ancient_history` — Past seasons and historical leagues (everything not in the current season)
 - `get_league_info` — Baseline league context: settings, roster config, teams/owners (requires platform, sport, league_id, season_year)
 - `get_standings` — League standings

--- a/docs/CONNECTOR-DOCS.md
+++ b/docs/CONNECTOR-DOCS.md
@@ -65,11 +65,14 @@ Perplexity custom remote connectors require HTTPS. In some workspaces, admins mu
 1. `gemini mcp add flaim https://api.flaim.app/mcp --transport http`
 2. In Gemini: `/mcp auth flaim` and complete the OAuth consent screen.
 
-## Tools (Read-Only)
+## Tools
 
 All tools take explicit parameters: `platform`, `sport`, `league_id`, `season_year` (plus optional fields where applicable).
 
+Analysis tools are read-only. `refresh_leagues` requires `mcp:write` because it can add or update Flaim league records after provider discovery, but it does not make roster moves, trades, drops, or lineup changes.
+
 - `get_user_session` (required first call in a normal chat): your leagues and defaults
+- `refresh_leagues`: re-discover connected leagues and update Flaim's league records
 - `get_league_info` (usually second): baseline league context for team-name resolution, owner/team mapping, scoring, and roster-slot context before downstream league tools
 - `get_roster`
 - `get_standings`

--- a/web/app/(site)/leagues/page.tsx
+++ b/web/app/(site)/leagues/page.tsx
@@ -94,6 +94,20 @@ interface UserPreferencesState {
   defaultHockey: LeagueDefault | null;
 }
 
+interface LeagueRefreshProviderResult {
+  status?: 'success' | 'skipped' | 'error';
+  error?: string;
+  error_description?: string;
+  retryAfter?: string;
+}
+
+interface LeagueRefreshResponse {
+  success?: boolean;
+  results?: Partial<Record<'espn' | 'yahoo' | 'sleeper', LeagueRefreshProviderResult>>;
+  error?: string;
+  error_description?: string;
+}
+
 type Sport = 'football' | 'baseball' | 'basketball' | 'hockey';
 
 // Unified league for display - combines ESPN, Yahoo, and Sleeper into common format
@@ -195,6 +209,42 @@ function ConnectionBadge({ isChecking, isConnected }: { isChecking: boolean; isC
 
 function canApplyState(shouldApply?: () => boolean): boolean {
   return shouldApply ? shouldApply() : true;
+}
+
+function summarizeLeagueRefresh(data: LeagueRefreshResponse): string {
+  const results = data.results ? Object.values(data.results) : [];
+  const successful = results.filter((result) => result?.status === 'success').length;
+  const skipped = results.filter((result) => result?.status === 'skipped').length;
+  const failed = results.filter((result) => result?.status === 'error').length;
+  const retryAfter = results.find((result) => result?.status === 'error' && result.retryAfter)?.retryAfter;
+  const firstError = results.find(
+    (result) => result?.status === 'error' && (result.error_description || result.error)
+  );
+
+  if (successful > 0 && failed === 0) {
+    return skipped > 0
+      ? 'Synced connected platforms. Some platforms are not connected yet.'
+      : 'Synced connected platforms.';
+  }
+
+  if (retryAfter) {
+    return `Some platforms are temporarily rate limited. Try again in ${retryAfter} seconds.`;
+  }
+
+  if (successful > 0) {
+    return 'Synced some platforms. Check any platform warnings below.';
+  }
+
+  if (skipped > 0 && failed === 0) {
+    return 'No connected platforms needed a sync.';
+  }
+
+  return firstError?.error_description || firstError?.error || data.error_description || data.error || 'No platforms were synced.';
+}
+
+function didEveryRefreshProviderError(data: LeagueRefreshResponse): boolean {
+  const results = data.results ? Object.values(data.results) : [];
+  return results.length > 0 && results.every((result) => result?.status === 'error');
 }
 
 type ConnectionStatusResult = 'connected' | 'disconnected' | 'unknown';
@@ -384,6 +434,7 @@ function LeaguesPageContent() {
   const [isLoadingSleeperLeagues, setIsLoadingSleeperLeagues] = useState(true);
   const [isSleeperDisconnecting, setIsSleeperDisconnecting] = useState(false);
   const [isDiscoveringSleeper, setIsDiscoveringSleeper] = useState(false);
+  const [isRefreshingLeagues, setIsRefreshingLeagues] = useState(false);
   const [sleeperConnectInput, setSleeperConnectInput] = useState('');
   const [sleeperError, setSleeperError] = useState<string | null>(null);
   const [preferences, setPreferences] = useState<UserPreferencesState>(() => createEmptyPreferences());
@@ -440,6 +491,7 @@ function LeaguesPageContent() {
     setIsReconnectingYahoo(false);
     setIsYahooDisconnecting(false);
     setIsDiscoveringSleeper(false);
+    setIsRefreshingLeagues(false);
     setIsSleeperDisconnecting(false);
     setDeletingSleeperKey(null);
   }, [clearSleeperConnectionState, clearYahooConnectionState]);
@@ -738,6 +790,59 @@ function LeaguesPageContent() {
       if (canApplyState(shouldApply)) setIsLoadingSleeperLeagues(false);
     }
   }, []);
+
+  const refreshConnectedLeagues = useCallback(async () => {
+    const shouldApply = createAccountGuard();
+    if (!shouldApply()) return;
+
+    setIsRefreshingLeagues(true);
+    setLeagueError(null);
+    setLeagueNotice(null);
+    setSleeperError(null);
+
+    try {
+      const res = await fetch('/api/leagues/refresh', { method: 'POST' });
+      const data = await res.json().catch(() => ({ error: 'Unknown error' })) as LeagueRefreshResponse;
+      if (!shouldApply()) return;
+
+      if (!res.ok) {
+        throw new Error(data.error_description || data.error || 'Failed to sync leagues');
+      }
+
+      if (data.success === false && didEveryRefreshProviderError(data)) {
+        throw new Error(summarizeLeagueRefresh(data));
+      }
+
+      setIsCheckingYahoo(true);
+      setIsCheckingSleeper(true);
+      await Promise.allSettled([
+        loadLeagues({ showSpinner: false, shouldApply }),
+        loadYahooLeagues(shouldApply),
+        loadSleeperLeagues(shouldApply),
+        checkYahooStatus(shouldApply),
+        checkSleeperStatus(shouldApply),
+      ]);
+
+      if (shouldApply()) {
+        setLeagueNotice(summarizeLeagueRefresh(data));
+      }
+    } catch (err) {
+      if (shouldApply()) {
+        setLeagueError(err instanceof Error ? err.message : 'Failed to sync leagues');
+      }
+    } finally {
+      if (shouldApply()) {
+        setIsRefreshingLeagues(false);
+      }
+    }
+  }, [
+    checkSleeperStatus,
+    checkYahooStatus,
+    createAccountGuard,
+    loadLeagues,
+    loadSleeperLeagues,
+    loadYahooLeagues,
+  ]);
 
   const discoverSleeperLeagues = useCallback(async (username: string) => {
     const shouldApply = createAccountGuard();
@@ -1393,6 +1498,26 @@ function LeaguesPageContent() {
                 </div>
               </button>
               <div className="flex items-center gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={refreshConnectedLeagues}
+                  disabled={!isAccountStateCurrent || isRefreshingLeagues}
+                  className="h-8 shrink-0"
+                >
+                  {isRefreshingLeagues ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      Syncing...
+                    </>
+                  ) : (
+                    <>
+                      <RefreshCw className="mr-2 h-4 w-4" />
+                      Sync all
+                    </>
+                  )}
+                </Button>
                 <Popover>
                   <PopoverTrigger asChild>
                     <button

--- a/web/app/api/leagues/refresh/route.ts
+++ b/web/app/api/leagues/refresh/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@clerk/nextjs/server';
+
+const LEAGUE_REFRESH_TIMEOUT_MS = 15_000;
+
+/**
+ * POST /api/leagues/refresh
+ * Broad league refresh proxy for the /leagues UI.
+ */
+export async function POST(request: NextRequest) {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    const { userId, getToken } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+    }
+
+    const authWorkerUrl = process.env.NEXT_PUBLIC_AUTH_WORKER_URL || process.env.AUTH_WORKER_URL;
+    if (!authWorkerUrl) {
+      return NextResponse.json({ error: 'AUTH_WORKER_URL is not configured' }, { status: 500 });
+    }
+
+    const bearer = await getToken();
+    if (!bearer) {
+      return NextResponse.json({ error: 'Authentication token unavailable' }, { status: 401 });
+    }
+
+    const rawBody = await request.text();
+    const controller = new AbortController();
+    timeoutId = setTimeout(() => controller.abort(), LEAGUE_REFRESH_TIMEOUT_MS);
+    const workerRes = await fetch(`${authWorkerUrl.replace(/\/+$/, '')}/leagues/refresh`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${bearer}`,
+      },
+      signal: controller.signal,
+      ...(rawBody.trim() ? { body: rawBody } : {}),
+    });
+    if (timeoutId) clearTimeout(timeoutId);
+
+    const data = await workerRes.json().catch(() => ({ error: 'Unknown error' })) as Record<string, unknown>;
+    const headers = new Headers();
+    const retryAfter = workerRes.headers.get('Retry-After');
+    if (retryAfter) {
+      headers.set('Retry-After', retryAfter);
+    }
+
+    return NextResponse.json(data, { status: workerRes.status, headers });
+  } catch (error) {
+    if (timeoutId) clearTimeout(timeoutId);
+    if (error instanceof Error && error.name === 'AbortError') {
+      return NextResponse.json({
+        error: 'refresh_timeout',
+        error_description: 'League refresh timed out after 15 seconds',
+      }, { status: 504 });
+    }
+    console.error('League refresh route error:', error);
+    return NextResponse.json({ error: 'Failed to refresh leagues' }, { status: 500 });
+  }
+}

--- a/web/lib/server/__tests__/league-refresh-route.test.ts
+++ b/web/lib/server/__tests__/league-refresh-route.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NextRequest } from 'next/server';
+
+const mocks = vi.hoisted(() => ({
+  auth: vi.fn(),
+}));
+
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: mocks.auth,
+}));
+
+import { POST } from '../../../app/api/leagues/refresh/route';
+
+const ORIGINAL_AUTH_WORKER_URL = process.env.AUTH_WORKER_URL;
+const ORIGINAL_NEXT_PUBLIC_AUTH_WORKER_URL = process.env.NEXT_PUBLIC_AUTH_WORKER_URL;
+
+function mockSignedInUser() {
+  const getToken = vi.fn(async () => 'test-token');
+  mocks.auth.mockResolvedValue({
+    userId: 'user_123',
+    getToken,
+  });
+  return { getToken };
+}
+
+function makeRequest(body?: unknown): NextRequest {
+  return new Request('https://flaim.app/api/leagues/refresh', {
+    method: 'POST',
+    headers: body === undefined ? undefined : { 'Content-Type': 'application/json' },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  }) as NextRequest;
+}
+
+beforeEach(() => {
+  process.env.NEXT_PUBLIC_AUTH_WORKER_URL = 'https://auth.example/';
+  delete process.env.AUTH_WORKER_URL;
+  mockSignedInUser();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  if (ORIGINAL_AUTH_WORKER_URL === undefined) {
+    delete process.env.AUTH_WORKER_URL;
+  } else {
+    process.env.AUTH_WORKER_URL = ORIGINAL_AUTH_WORKER_URL;
+  }
+  if (ORIGINAL_NEXT_PUBLIC_AUTH_WORKER_URL === undefined) {
+    delete process.env.NEXT_PUBLIC_AUTH_WORKER_URL;
+  } else {
+    process.env.NEXT_PUBLIC_AUTH_WORKER_URL = ORIGINAL_NEXT_PUBLIC_AUTH_WORKER_URL;
+  }
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('POST /api/leagues/refresh', () => {
+  it('rejects unauthenticated requests without calling the auth worker', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    mocks.auth.mockResolvedValue({
+      userId: null,
+      getToken: vi.fn(),
+    });
+
+    const response = await POST(makeRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body).toEqual({ error: 'Authentication required' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('proxies the refresh request to auth-worker and preserves Retry-After', async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({
+        success: true,
+        requestedPlatforms: ['espn'],
+        results: {
+          espn: { platform: 'espn', status: 'success', httpStatus: 200 },
+        },
+      }), {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+          'Retry-After': '12',
+        },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await POST(makeRequest({ platforms: ['espn'] }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Retry-After')).toBe('12');
+    expect(body).toMatchObject({ success: true });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe('https://auth.example/leagues/refresh');
+    expect(init.method).toBe('POST');
+    expect(init.headers).toMatchObject({
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer test-token',
+    });
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+    expect(init.body).toBe(JSON.stringify({ platforms: ['espn'] }));
+  });
+
+  it('times out a hanging auth-worker refresh request', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn((_url: string, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          const error = new Error('Aborted');
+          error.name = 'AbortError';
+          reject(error);
+        });
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const responsePromise = POST(makeRequest({ platforms: ['espn'] }));
+    await vi.advanceTimersByTimeAsync(15_000);
+    const response = await responsePromise;
+    const body = await response.json();
+
+    expect(response.status).toBe(504);
+    expect(body).toEqual({
+      error: 'refresh_timeout',
+      error_description: 'League refresh timed out after 15 seconds',
+    });
+  });
+});

--- a/web/public/llms-full.txt
+++ b/web/public/llms-full.txt
@@ -1,6 +1,6 @@
 # Flaim Fantasy
 
-> Flaim connects your ESPN, Yahoo, and Sleeper fantasy leagues to Flaim Fantasy in ChatGPT, with optional manual MCP clients also available for read-only, league-specific analysis using the Model Context Protocol (MCP).
+> Flaim connects your ESPN, Yahoo, and Sleeper fantasy leagues to Flaim Fantasy in ChatGPT, with optional manual MCP clients also available for league-specific analysis using the Model Context Protocol (MCP).
 
 ## What Flaim Is
 
@@ -8,11 +8,12 @@ Flaim is a free, open-source MCP server behind a live ChatGPT-first fantasy anal
 
 Single MCP endpoint: https://api.flaim.app/mcp
 
-## MCP Tools (9 total)
+## MCP Tools (10 total)
 
 | Tool | What it does |
 |------|-------------|
 | get_user_session | Lists all connected leagues across all platforms |
+| refresh_leagues | Re-discovers connected leagues and updates Flaim's league records |
 | get_ancient_history | Historical leagues and seasons (2+ years old) |
 | get_league_info | League settings, scoring format, and members |
 | get_roster | Team roster with player stats and lineup slots |

--- a/workers/README.md
+++ b/workers/README.md
@@ -108,6 +108,7 @@ Ensure `wrangler.jsonc` has `"workers_dev": true` so the `.workers.dev` URL exis
 All tools take explicit parameters: `platform`, `sport`, `league_id`, `season_year`
 
 - `get_user_session` — All leagues across platforms with IDs (call first to get params)
+- `refresh_leagues` — Re-discover connected leagues and update Flaim's league records (`mcp:write`; non-destructive)
 - `get_ancient_history` — Past seasons and historical leagues outside the current season
 - `get_league_info` — Baseline league context: settings, members, teams/owners
 - `get_standings` — League standings

--- a/workers/auth-worker/src/__tests__/league-refresh-route.test.ts
+++ b/workers/auth-worker/src/__tests__/league-refresh-route.test.ts
@@ -1,0 +1,483 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockEspnStorage = vi.hoisted(() => ({
+  getCredentials: vi.fn(),
+  getCurrentSeasonLeagues: vi.fn(),
+  getLeagues: vi.fn(),
+  getSetupStatus: vi.fn(),
+  getCredentialMetadata: vi.fn(),
+}));
+
+vi.mock('../supabase-storage', () => ({
+  EspnSupabaseStorage: {
+    fromEnvironment: vi.fn().mockReturnValue(mockEspnStorage),
+  },
+}));
+
+vi.mock('../v3/league-discovery', () => ({
+  discoverAndSaveLeagues: vi.fn(),
+}));
+
+vi.mock('../oauth-storage', () => ({
+  OAuthStorage: {
+    fromEnvironment: vi.fn().mockReturnValue({}),
+  },
+}));
+
+vi.mock('../yahoo-storage', () => ({
+  YahooStorage: {
+    fromEnvironment: vi.fn().mockReturnValue({}),
+  },
+}));
+
+vi.mock('../yahoo-connect-handlers', () => ({
+  handleYahooAuthorize: vi.fn(),
+  handleYahooCallback: vi.fn(),
+  handleYahooCredentials: vi.fn(),
+  handleYahooCredentialHealth: vi.fn(),
+  handleYahooDisconnect: vi.fn(),
+  handleYahooDiscover: vi.fn().mockResolvedValue(
+    new Response(JSON.stringify({ success: true, count: 0, leagues: [] }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  ),
+  handleYahooStatus: vi.fn(),
+  resolveYahooArchiveTarget: vi.fn(),
+  YahooConnectEnv: {},
+}));
+
+vi.mock('../sleeper-connect-handlers', () => ({
+  handleSleeperDiscover: vi.fn(),
+  handleSleeperStatus: vi.fn(),
+  handleSleeperDisconnect: vi.fn(),
+  handleSleeperLeagues: vi.fn(),
+  handleSleeperLeagueDelete: vi.fn(),
+  resolveSleeperArchiveTarget: vi.fn(),
+  refreshSleeperLeaguesFromStoredConnection: vi.fn(),
+  SleeperConnectEnv: {},
+}));
+
+vi.mock('../oauth-handlers', () => ({
+  handleMetadataDiscovery: vi.fn(),
+  handleClientRegistration: vi.fn(),
+  handleAuthorize: vi.fn(),
+  handleCreateCode: vi.fn(),
+  handleToken: vi.fn(),
+  handleRevoke: vi.fn(),
+  handleCheckStatus: vi.fn(),
+  handleRevokeAll: vi.fn(),
+  handleRevokeSingle: vi.fn(),
+  validateOAuthToken: vi.fn().mockResolvedValue(null),
+  OAuthEnv: {},
+}));
+
+import app from '../index-hono';
+import { refreshLeaguesForUser } from '../league-refresh';
+import { validateOAuthToken } from '../oauth-handlers';
+import { refreshSleeperLeaguesFromStoredConnection } from '../sleeper-connect-handlers';
+import { handleYahooDiscover } from '../yahoo-connect-handlers';
+import { discoverAndSaveLeagues } from '../v3/league-discovery';
+
+const ISSUER = 'https://flaim-test.clerk.accounts.dev';
+const KEY_ID = 'league-refresh-route-test-key';
+const EVAL_API_KEY = 'flaim_eval_refresh_route_test';
+const EVAL_USER_ID = 'user_eval_refresh';
+const INTERNAL_SERVICE_TOKEN = 'internal-refresh-secret';
+
+const baseEnv = {
+  SUPABASE_URL: 'https://example.supabase.co',
+  SUPABASE_SERVICE_KEY: 'test-key',
+  NODE_ENV: 'test',
+  ENVIRONMENT: 'test',
+  CLERK_ISSUER: ISSUER,
+  EVAL_API_KEY,
+  EVAL_USER_ID,
+  INTERNAL_SERVICE_TOKEN,
+  TOKEN_RATE_LIMITER: { limit: async () => ({ success: true }) },
+  CREDENTIALS_RATE_LIMITER: { limit: async () => ({ success: true }) },
+};
+
+type TestJwk = JsonWebKey & { kid: string; alg: string; use: string };
+
+let privateKey: CryptoKey;
+let publicJwk: TestJwk;
+
+function base64Url(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+function base64UrlJson(value: unknown): string {
+  return base64Url(new TextEncoder().encode(JSON.stringify(value)));
+}
+
+async function signedClerkToken(sub = 'user_refresh_route'): Promise<string> {
+  const header = base64UrlJson({ alg: 'RS256', kid: KEY_ID, typ: 'JWT' });
+  const payload = base64UrlJson({
+    sub,
+    iss: ISSUER,
+    exp: Math.floor(Date.now() / 1000) + 3600,
+  });
+  const data = `${header}.${payload}`;
+  const signature = await crypto.subtle.sign(
+    'RSASSA-PKCS1-v1_5',
+    privateKey,
+    new TextEncoder().encode(data),
+  );
+  return `${data}.${base64Url(new Uint8Array(signature))}`;
+}
+
+function makeRequest(path: string, init?: RequestInit): Request {
+  return new Request(`https://api.flaim.app${path}`, init);
+}
+
+beforeAll(async () => {
+  const keyPair = await crypto.subtle.generateKey(
+    {
+      name: 'RSASSA-PKCS1-v1_5',
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: 'SHA-256',
+    },
+    true,
+    ['sign', 'verify'],
+  ) as CryptoKeyPair;
+  privateKey = keyPair.privateKey;
+  const exported = await crypto.subtle.exportKey('jwk', keyPair.publicKey) as JsonWebKey;
+  publicJwk = {
+    ...exported,
+    kid: KEY_ID,
+    alg: 'RS256',
+    use: 'sig',
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal('fetch', vi.fn(async () => {
+    return new Response(JSON.stringify({ keys: [publicJwk] }), {
+      headers: { 'content-type': 'application/json' },
+    });
+  }));
+  vi.mocked(refreshSleeperLeaguesFromStoredConnection).mockResolvedValue({
+    status: 'success',
+    details: {
+      success: true,
+      username: 'stored_user',
+      leagues_found: 1,
+      seasons_discovered: 1,
+    },
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('POST /leagues/refresh', () => {
+  it('requires Clerk authentication for the public route', async () => {
+    const res = await app.fetch(makeRequest('/auth/leagues/refresh', {
+      method: 'POST',
+      body: JSON.stringify({ platforms: ['sleeper'] }),
+      headers: { 'Content-Type': 'application/json' },
+    }), baseEnv);
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({
+      error: 'unauthorized',
+      error_description: 'Clerk authentication required',
+    });
+    expect(refreshSleeperLeaguesFromStoredConnection).not.toHaveBeenCalled();
+  });
+
+  it('rejects unknown platforms before provider refresh runs', async () => {
+    const token = await signedClerkToken();
+    const res = await app.fetch(makeRequest('/auth/leagues/refresh', {
+      method: 'POST',
+      body: JSON.stringify({ platforms: ['espn', 'bad-platform'] }),
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+    }), baseEnv);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: 'unknown_platform',
+      error_description: 'Unknown platform(s): bad-platform',
+      unknownPlatforms: ['bad-platform'],
+    });
+    expect(refreshSleeperLeaguesFromStoredConnection).not.toHaveBeenCalled();
+  });
+
+  it('rejects oversized platform arrays before provider refresh runs', async () => {
+    const token = await signedClerkToken();
+    const res = await app.fetch(makeRequest('/auth/leagues/refresh', {
+      method: 'POST',
+      body: JSON.stringify({ platforms: ['espn', 'espn', 'espn', 'espn'] }),
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+    }), baseEnv);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: 'invalid_platforms',
+      error_description: 'platforms may include at most 3 entries',
+    });
+    expect(refreshSleeperLeaguesFromStoredConnection).not.toHaveBeenCalled();
+  });
+
+  it('rejects empty platform arrays before provider refresh runs', async () => {
+    const token = await signedClerkToken();
+    const res = await app.fetch(makeRequest('/auth/leagues/refresh', {
+      method: 'POST',
+      body: JSON.stringify({ platforms: [] }),
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+    }), baseEnv);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: 'invalid_platforms',
+      error_description: 'platforms must include at least one platform',
+    });
+    expect(refreshSleeperLeaguesFromStoredConnection).not.toHaveBeenCalled();
+  });
+
+  it('allows a Clerk-authenticated public caller and aggregates Sleeper refresh', async () => {
+    const token = await signedClerkToken('user_public_refresh');
+    const res = await app.fetch(makeRequest('/auth/leagues/refresh', {
+      method: 'POST',
+      body: JSON.stringify({ platforms: ['sleeper'] }),
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+    }), baseEnv);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      success: true,
+      requestedPlatforms: ['sleeper'],
+      results: {
+        sleeper: {
+          platform: 'sleeper',
+          status: 'success',
+          httpStatus: 200,
+          details: {
+            success: true,
+            username: 'stored_user',
+            leagues_found: 1,
+            seasons_discovered: 1,
+          },
+        },
+      },
+    });
+    expect(refreshSleeperLeaguesFromStoredConnection).toHaveBeenCalledWith(baseEnv, 'user_public_refresh');
+  });
+
+  it('rate-limits public refresh per user before provider refresh runs', async () => {
+    const token = await signedClerkToken('user_rate_limited');
+    const res = await app.fetch(makeRequest('/auth/leagues/refresh', {
+      method: 'POST',
+      body: JSON.stringify({ platforms: ['sleeper'] }),
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+    }), {
+      ...baseEnv,
+      CREDENTIALS_RATE_LIMITER: {
+        limit: vi.fn(async ({ key }: { key: string }) => {
+          expect(key).toBe('refresh:user_rate_limited');
+          return { success: false };
+        }),
+      },
+    });
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get('Retry-After')).toBe('60');
+    expect(await res.json()).toEqual({
+      error: 'rate_limit_exceeded',
+      error_description: 'Too many refresh requests. Please try again later.',
+    });
+    expect(refreshSleeperLeaguesFromStoredConnection).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /internal/leagues/refresh', () => {
+  it('requires the internal service token', async () => {
+    const res = await app.fetch(makeRequest('/auth/internal/leagues/refresh', {
+      method: 'POST',
+      body: JSON.stringify({ platforms: ['sleeper'] }),
+      headers: {
+        Authorization: `Bearer ${EVAL_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+    }), baseEnv);
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({
+      error: 'unauthorized',
+      error_description: 'Missing or invalid X-Flaim-Internal-Token',
+    });
+    expect(refreshSleeperLeaguesFromStoredConnection).not.toHaveBeenCalled();
+  });
+
+  it('rejects an internal static API key caller without mcp:write scope', async () => {
+    const res = await app.fetch(makeRequest('/auth/internal/leagues/refresh', {
+      method: 'POST',
+      body: JSON.stringify({ platforms: ['sleeper'] }),
+      headers: {
+        Authorization: `Bearer ${EVAL_API_KEY}`,
+        'X-Flaim-Internal-Token': INTERNAL_SERVICE_TOKEN,
+        'Content-Type': 'application/json',
+      },
+    }), baseEnv);
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({
+      error: 'insufficient_scope',
+      error_description: 'mcp:write scope is required to refresh leagues',
+    });
+    expect(refreshSleeperLeaguesFromStoredConnection).not.toHaveBeenCalled();
+  });
+
+  it('allows an internal mcp:write OAuth caller and aggregates Sleeper refresh', async () => {
+    vi.mocked(validateOAuthToken).mockResolvedValueOnce({
+      userId: 'user_oauth_refresh',
+      scope: 'mcp:write',
+      clientName: 'ChatGPT',
+    });
+
+    const res = await app.fetch(makeRequest('/auth/internal/leagues/refresh', {
+      method: 'POST',
+      body: JSON.stringify({ platforms: ['sleeper'] }),
+      headers: {
+        Authorization: 'Bearer oauth-refresh-token',
+        'X-Flaim-Internal-Token': INTERNAL_SERVICE_TOKEN,
+        'Content-Type': 'application/json',
+      },
+    }), baseEnv);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      success: true,
+      requestedPlatforms: ['sleeper'],
+      results: {
+        sleeper: {
+          platform: 'sleeper',
+          status: 'success',
+          httpStatus: 200,
+          details: {
+            success: true,
+            username: 'stored_user',
+            leagues_found: 1,
+            seasons_discovered: 1,
+          },
+        },
+      },
+    });
+    expect(refreshSleeperLeaguesFromStoredConnection).toHaveBeenCalledWith(baseEnv, 'user_oauth_refresh');
+  });
+
+  it('rate-limits internal refresh per resolved user before provider refresh runs', async () => {
+    vi.mocked(validateOAuthToken).mockResolvedValueOnce({
+      userId: 'user_oauth_rate_limited',
+      scope: 'mcp:write',
+      clientName: 'ChatGPT',
+    });
+    const limit = vi.fn(async ({ key }: { key: string }) => {
+      expect(key).toBe('refresh:user_oauth_rate_limited');
+      return { success: false };
+    });
+
+    const res = await app.fetch(makeRequest('/auth/internal/leagues/refresh', {
+      method: 'POST',
+      body: JSON.stringify({ platforms: ['sleeper'] }),
+      headers: {
+        Authorization: 'Bearer oauth-refresh-token',
+        'X-Flaim-Internal-Token': INTERNAL_SERVICE_TOKEN,
+        'Content-Type': 'application/json',
+      },
+    }), {
+      ...baseEnv,
+      CREDENTIALS_RATE_LIMITER: { limit },
+    });
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get('Retry-After')).toBe('60');
+    expect(await res.json()).toEqual({
+      error: 'rate_limit_exceeded',
+      error_description: 'Too many refresh requests. Please try again later.',
+    });
+    expect(limit).toHaveBeenCalledOnce();
+    expect(refreshSleeperLeaguesFromStoredConnection).not.toHaveBeenCalled();
+  });
+});
+
+describe('refreshLeaguesForUser', () => {
+  it('starts requested platform refreshes concurrently', async () => {
+    mockEspnStorage.getCredentials.mockResolvedValue({ swid: '{SWID}', s2: 'espn_s2' });
+    vi.mocked(discoverAndSaveLeagues).mockResolvedValue({
+      discovered: [],
+      currentSeason: { found: 0, added: 0, alreadySaved: 0, refreshed: 0 },
+      pastSeasons: { found: 0, added: 0, alreadySaved: 0, refreshed: 0 },
+    });
+
+    const started = new Set<string>();
+    let releaseAll: (() => void) | null = null;
+    const allStarted = new Promise<void>((resolve) => {
+      releaseAll = resolve;
+    });
+
+    function markStarted(platform: string) {
+      started.add(platform);
+      if (started.size === 3) releaseAll?.();
+    }
+
+    vi.mocked(discoverAndSaveLeagues).mockImplementation(async () => {
+      markStarted('espn');
+      await allStarted;
+      return {
+        discovered: [],
+        currentSeason: { found: 0, added: 0, alreadySaved: 0, refreshed: 0 },
+        pastSeasons: { found: 0, added: 0, alreadySaved: 0, refreshed: 0 },
+      };
+    });
+    vi.mocked(handleYahooDiscover).mockImplementation(async () => {
+      markStarted('yahoo');
+      await allStarted;
+      return new Response(JSON.stringify({ success: true, count: 0, leagues: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+    vi.mocked(refreshSleeperLeaguesFromStoredConnection).mockImplementation(async () => {
+      markStarted('sleeper');
+      await allStarted;
+      return {
+        status: 'success',
+        details: { success: true, username: 'stored_user', leagues_found: 0, seasons_discovered: 0 },
+      };
+    });
+
+    const result = await Promise.race([
+      refreshLeaguesForUser(baseEnv, 'user_concurrent', ['espn', 'yahoo', 'sleeper'], {}),
+      new Promise<never>((_, reject) => {
+        setTimeout(() => reject(new Error('refresh did not start all platforms concurrently')), 100);
+      }),
+    ]);
+
+    expect(result.success).toBe(true);
+    expect(started).toEqual(new Set(['espn', 'yahoo', 'sleeper']));
+  });
+});

--- a/workers/auth-worker/src/__tests__/sleeper-connect-handlers.test.ts
+++ b/workers/auth-worker/src/__tests__/sleeper-connect-handlers.test.ts
@@ -4,6 +4,7 @@ import {
   handleSleeperLeagueDelete,
   handleSleeperLeagues,
   handleSleeperStatus,
+  refreshSleeperLeaguesFromStoredConnection,
   resolveSleeperArchiveTarget,
   backfillSleeperRecurringIds,
   type SleeperConnectEnv,
@@ -237,6 +238,89 @@ describe('sleeper-connect-handlers', () => {
         recurringLeagueId: 'league_nfl_1',
       }),
     );
+  });
+
+  it('refreshes Sleeper leagues from the stored connection username', async () => {
+    mockStorage.getSleeperConnection.mockResolvedValueOnce({
+      sleeperUserId: 'old_sleeper_id',
+      sleeperUsername: 'stored_user',
+      updatedAt: '2026-07-04T12:00:00.000Z',
+    });
+
+    mockFetch.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith('/user/stored_user')) {
+        return jsonResponse({
+          user_id: 'sleeper_stored',
+          username: 'stored_user',
+          display_name: 'Stored User',
+        });
+      }
+      if (url.includes('/user/sleeper_stored/leagues/nfl/2025')) {
+        return jsonResponse([
+          {
+            league_id: 'stored-nfl-1',
+            name: 'Stored NFL',
+            sport: 'nfl',
+            season: '2025',
+            previous_league_id: null,
+          },
+        ]);
+      }
+      if (url.includes('/user/sleeper_stored/leagues/nba/2024')) {
+        return jsonResponse([]);
+      }
+      if (url.includes('/league/stored-nfl-1/rosters')) {
+        return jsonResponse([
+          { roster_id: 3, owner_id: 'sleeper_stored' },
+        ]);
+      }
+      return new Response(null, { status: 404 });
+    });
+
+    const result = await refreshSleeperLeaguesFromStoredConnection(env, 'user_1');
+
+    expect(result.status).toBe('success');
+    if (result.status !== 'success') {
+      throw new Error('Expected success result');
+    }
+    expect(result.details).toEqual({
+      success: true,
+      username: 'stored_user',
+      leagues_found: 1,
+      seasons_discovered: 1,
+    });
+    expect(mockStorage.saveSleeperConnection).toHaveBeenCalledWith('user_1', 'sleeper_stored', 'stored_user');
+    expect(mockStorage.saveSleeperLeague).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clerkUserId: 'user_1',
+        leagueId: 'stored-nfl-1',
+        sport: 'football',
+        seasonYear: 2025,
+        rosterId: 3,
+        recurringLeagueId: 'stored-nfl-1',
+        sleeperUserId: 'sleeper_stored',
+      }),
+    );
+  });
+
+  it('skips stored-connection refresh when the Sleeper username is missing', async () => {
+    mockStorage.getSleeperConnection.mockResolvedValueOnce({
+      sleeperUserId: 'sleeper_without_username',
+      sleeperUsername: null,
+      updatedAt: '2026-07-04T12:00:00.000Z',
+    });
+
+    const result = await refreshSleeperLeaguesFromStoredConnection(env, 'user_1');
+
+    expect(result).toEqual({
+      status: 'skipped',
+      error: 'username_missing',
+      error_description: 'Stored Sleeper connection does not include a username',
+      details: { sleeperUserId: 'sleeper_without_username' },
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockStorage.saveSleeperLeague).not.toHaveBeenCalled();
   });
 
   it('persists recurringLeagueId during discovery for every season in the history chain', async () => {

--- a/workers/auth-worker/src/index-hono.ts
+++ b/workers/auth-worker/src/index-hono.ts
@@ -73,6 +73,10 @@ import {
   type SleeperConnectEnv,
 } from './sleeper-connect-handlers';
 import { logEvalEvent } from './logging';
+import {
+  parseLeagueRefreshRequest,
+  refreshLeaguesForUser,
+} from './league-refresh';
 
 // =============================================================================
 // TYPES
@@ -126,6 +130,20 @@ const EVAL_TRACE_HEADER = 'X-Flaim-Eval-Trace';
 const INTERNAL_SERVICE_TOKEN_HEADER = 'X-Flaim-Internal-Token';
 const MASKED_ESPN_SWID = '{********-****-****-****-************}';
 const MASKED_ESPN_S2 = '************';
+
+async function enforceLeagueRefreshRateLimit(c: Context<{ Bindings: Env }>, userId: string) {
+  const { success } = await c.env.CREDENTIALS_RATE_LIMITER.limit({ key: `refresh:${userId}` });
+  if (success) return null;
+
+  return c.json(
+    {
+      error: 'rate_limit_exceeded',
+      error_description: 'Too many refresh requests. Please try again later.',
+    },
+    429,
+    { 'Retry-After': '60' }
+  );
+}
 
 const ALLOWED_ORIGINS = [
   'https://flaim-*.vercel.app',
@@ -681,7 +699,7 @@ api.get('/.well-known/oauth-protected-resource', (c) => {
     resource: 'https://api.flaim.app/mcp',
     authorization_servers: ['https://api.flaim.app'],
     bearer_methods_supported: ['header'],
-    scopes_supported: ['mcp:read'],
+    scopes_supported: ['mcp:read', 'mcp:write'],
   }, 200, {
     'Cache-Control': 'public, max-age=3600',
   });
@@ -698,7 +716,7 @@ api.get('/.well-known/oauth-protected-resource/*', (c) => {
     resource: `https://api.flaim.app${resourcePath}`,
     authorization_servers: ['https://api.flaim.app'],
     bearer_methods_supported: ['header'],
-    scopes_supported: ['mcp:read'],
+    scopes_supported: ['mcp:read', 'mcp:write'],
   }, 200, {
     'Cache-Control': 'public, max-age=3600',
   });
@@ -761,6 +779,42 @@ api.get('/internal/introspect', async (c) => {
   }
 
   return c.json({ valid: true, userId, scope: scope || 'mcp:read', authType, client_name: clientName ?? null });
+});
+
+// Refresh provider league caches. fantasy-mcp enforces mcp:write before
+// forwarding, and this route checks it again as defense in depth.
+api.post('/internal/leagues/refresh', async (c) => {
+  const { userId, error: authError, status: authStatus, scope } = await getInternalUserId(c.req.raw, c.env, undefined, { allowStaticApiKey: true });
+  if (!userId) {
+    return c.json({
+      error: 'unauthorized',
+      error_description: authError || 'Authentication required',
+    }, authStatus ?? 401);
+  }
+
+  if (!scope?.split(/\s+/).includes('mcp:write')) {
+    return c.json({
+      error: 'insufficient_scope',
+      error_description: 'mcp:write scope is required to refresh leagues',
+    }, 403);
+  }
+
+  const rateLimited = await enforceLeagueRefreshRateLimit(c, userId);
+  if (rateLimited) return rateLimited;
+
+  const validation = await parseLeagueRefreshRequest(c.req.raw);
+  if (validation.error) {
+    return c.json(validation.error.body, validation.error.status);
+  }
+
+  const result = await refreshLeaguesForUser(
+    c.env,
+    userId,
+    validation.platforms ?? ['espn', 'yahoo', 'sleeper'],
+    getCorsHeaders(c.req.raw),
+    c.req.header('X-Correlation-ID') || undefined
+  );
+  return c.json(result, 200);
 });
 
 // Usage analytics ingest (internal — called by fantasy-mcp gateway via service binding).
@@ -1032,6 +1086,34 @@ api.post('/extension/discover', async (c) => {
       error_description: errorMessage,
     }, isAuthError ? 401 : 500);
   }
+});
+
+// Refresh provider league caches (Clerk-authenticated web UI).
+api.post('/leagues/refresh', async (c) => {
+  const { userId, error: authError } = await getClerkUserId(c.req.raw, c.env);
+  if (!userId) {
+    return c.json({
+      error: 'unauthorized',
+      error_description: authError || 'Authentication required',
+    }, 401);
+  }
+
+  const rateLimited = await enforceLeagueRefreshRateLimit(c, userId);
+  if (rateLimited) return rateLimited;
+
+  const validation = await parseLeagueRefreshRequest(c.req.raw);
+  if (validation.error) {
+    return c.json(validation.error.body, validation.error.status);
+  }
+
+  const result = await refreshLeaguesForUser(
+    c.env,
+    userId,
+    validation.platforms ?? ['espn', 'yahoo', 'sleeper'],
+    getCorsHeaders(c.req.raw),
+    c.req.header('X-Correlation-ID') || undefined
+  );
+  return c.json(result, 200);
 });
 
 // =============================================================================

--- a/workers/auth-worker/src/league-refresh.ts
+++ b/workers/auth-worker/src/league-refresh.ts
@@ -1,0 +1,296 @@
+import { EspnSupabaseStorage } from './supabase-storage';
+import { AutomaticLeagueDiscoveryFailed, EspnAuthenticationFailed } from './espn-types';
+import { discoverAndSaveLeagues, type DiscoveredLeague, type SeasonCounts } from './v3/league-discovery';
+import { handleYahooDiscover, type YahooConnectEnv } from './yahoo-connect-handlers';
+import {
+  refreshSleeperLeaguesFromStoredConnection,
+  type SleeperConnectEnv,
+} from './sleeper-connect-handlers';
+
+export const REFRESH_PLATFORMS = ['espn', 'yahoo', 'sleeper'] as const;
+export type RefreshPlatform = typeof REFRESH_PLATFORMS[number];
+
+type ProviderStatus = 'success' | 'skipped' | 'error';
+
+export interface ProviderRefreshResult {
+  platform: RefreshPlatform;
+  status: ProviderStatus;
+  httpStatus?: number;
+  error?: string;
+  error_description?: string;
+  retryAfter?: string;
+  details?: unknown;
+}
+
+export interface LeagueRefreshResponse {
+  success: boolean;
+  requestedPlatforms: RefreshPlatform[];
+  results: Partial<Record<RefreshPlatform, ProviderRefreshResult>>;
+}
+
+export interface RefreshRequestValidation {
+  platforms?: RefreshPlatform[];
+  error?: {
+    status: 400;
+    body: {
+      error: string;
+      error_description: string;
+      unknownPlatforms?: string[];
+    };
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export async function parseLeagueRefreshRequest(request: Request): Promise<RefreshRequestValidation> {
+  const rawBody = await request.text();
+  if (!rawBody.trim()) {
+    return { platforms: [...REFRESH_PLATFORMS] };
+  }
+
+  let body: unknown;
+  try {
+    body = JSON.parse(rawBody);
+  } catch {
+    return {
+      error: {
+        status: 400,
+        body: {
+          error: 'invalid_request',
+          error_description: 'Request body must be valid JSON',
+        },
+      },
+    };
+  }
+
+  if (!isRecord(body) || body.platforms === undefined) {
+    return { platforms: [...REFRESH_PLATFORMS] };
+  }
+
+  if (!Array.isArray(body.platforms) || body.platforms.some((platform) => typeof platform !== 'string')) {
+    return {
+      error: {
+        status: 400,
+        body: {
+          error: 'invalid_platforms',
+          error_description: 'platforms must be an array of platform names',
+        },
+      },
+    };
+  }
+
+  if (body.platforms.length === 0) {
+    return {
+      error: {
+        status: 400,
+        body: {
+          error: 'invalid_platforms',
+          error_description: 'platforms must include at least one platform',
+        },
+      },
+    };
+  }
+
+  if (body.platforms.length > REFRESH_PLATFORMS.length) {
+    return {
+      error: {
+        status: 400,
+        body: {
+          error: 'invalid_platforms',
+          error_description: `platforms may include at most ${REFRESH_PLATFORMS.length} entries`,
+        },
+      },
+    };
+  }
+
+  const requested = Array.from(new Set(body.platforms));
+  const known = new Set<string>(REFRESH_PLATFORMS);
+  const unknownPlatforms = requested.filter((platform) => !known.has(platform));
+  if (unknownPlatforms.length > 0) {
+    return {
+      error: {
+        status: 400,
+        body: {
+          error: 'unknown_platform',
+          error_description: `Unknown platform(s): ${unknownPlatforms.join(', ')}`,
+          unknownPlatforms,
+        },
+      },
+    };
+  }
+
+  return { platforms: requested as RefreshPlatform[] };
+}
+
+function errorDescription(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : fallback;
+}
+
+async function refreshEspnLeagues(env: { SUPABASE_URL: string; SUPABASE_SERVICE_KEY: string }, userId: string): Promise<ProviderRefreshResult> {
+  const storage = EspnSupabaseStorage.fromEnvironment(env);
+  const credentials = await storage.getCredentials(userId);
+  if (!credentials) {
+    return {
+      platform: 'espn',
+      status: 'skipped',
+      httpStatus: 400,
+      error: 'credentials_not_found',
+      error_description: 'ESPN credentials not found. Please sync credentials first.',
+    };
+  }
+
+  try {
+    const result = await discoverAndSaveLeagues(userId, credentials.swid, credentials.s2, storage);
+    return {
+      platform: 'espn',
+      status: 'success',
+      httpStatus: 200,
+      details: {
+        discovered: result.discovered,
+        currentSeason: result.currentSeason,
+        pastSeasons: result.pastSeasons,
+        currentSeasonCount: result.currentSeason.found,
+        pastSeasonsCount: result.pastSeasons.found,
+      },
+    };
+  } catch (error) {
+    if (error instanceof AutomaticLeagueDiscoveryFailed) {
+      const savedLeagues = await storage.getCurrentSeasonLeagues(userId);
+      const discovered: DiscoveredLeague[] = savedLeagues.map((league) => ({
+        sport: league.sport,
+        leagueId: league.leagueId,
+        leagueName: league.leagueName || '',
+        teamId: league.teamId || '',
+        teamName: league.teamName || '',
+        seasonYear: league.seasonYear || 0,
+      }));
+      const currentSeason: SeasonCounts = {
+        found: savedLeagues.length,
+        added: 0,
+        alreadySaved: savedLeagues.length,
+        refreshed: 0,
+      };
+      return {
+        platform: 'espn',
+        status: 'success',
+        httpStatus: 200,
+        details: {
+          discovered,
+          currentSeason,
+          pastSeasons: { found: 0, added: 0, alreadySaved: 0, refreshed: 0 },
+          currentSeasonCount: currentSeason.found,
+          pastSeasonsCount: 0,
+        },
+      };
+    }
+
+    const description = errorDescription(error, 'ESPN league refresh failed');
+    const isAuthError = error instanceof EspnAuthenticationFailed ||
+      description.includes('authentication') ||
+      description.includes('expired') ||
+      description.includes('invalid');
+    return {
+      platform: 'espn',
+      status: 'error',
+      httpStatus: isAuthError ? 401 : 500,
+      error: isAuthError ? 'espn_auth_failed' : 'discovery_failed',
+      error_description: description,
+    };
+  }
+}
+
+async function parseResponseBody(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text.trim()) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+async function refreshYahooLeagues(
+  env: YahooConnectEnv,
+  userId: string,
+  corsHeaders: Record<string, string>,
+  correlationId?: string
+): Promise<ProviderRefreshResult> {
+  const response = await handleYahooDiscover(env, userId, corsHeaders, correlationId);
+  const body = await parseResponseBody(response);
+  const retryAfter = response.headers.get('Retry-After') ?? undefined;
+
+  return {
+    platform: 'yahoo',
+    status: response.ok ? 'success' : response.status === 404 ? 'skipped' : 'error',
+    httpStatus: response.status,
+    ...(retryAfter ? { retryAfter } : {}),
+    ...(isRecord(body) && typeof body.error === 'string' ? { error: body.error } : {}),
+    ...(isRecord(body) && typeof body.error_description === 'string' ? { error_description: body.error_description } : {}),
+    details: body,
+  };
+}
+
+async function refreshSleeperLeagues(env: SleeperConnectEnv, userId: string): Promise<ProviderRefreshResult> {
+  try {
+    const result = await refreshSleeperLeaguesFromStoredConnection(env, userId);
+    return {
+      platform: 'sleeper',
+      status: result.status,
+      httpStatus: result.status === 'success' ? 200 : 404,
+      ...(result.status === 'skipped'
+        ? {
+            error: result.error,
+            error_description: result.error_description,
+            details: result.details,
+          }
+        : { details: result.details }),
+    };
+  } catch (error) {
+    return {
+      platform: 'sleeper',
+      status: 'error',
+      httpStatus: 500,
+      error: 'discovery_failed',
+      error_description: errorDescription(error, 'Sleeper league refresh failed'),
+    };
+  }
+}
+
+export async function refreshLeaguesForUser(
+  env: { SUPABASE_URL: string; SUPABASE_SERVICE_KEY: string },
+  userId: string,
+  platforms: RefreshPlatform[],
+  corsHeaders: Record<string, string>,
+  correlationId?: string
+): Promise<LeagueRefreshResponse> {
+  const refreshOne = async (platform: RefreshPlatform): Promise<[RefreshPlatform, ProviderRefreshResult]> => {
+    try {
+      if (platform === 'espn') {
+        return [platform, await refreshEspnLeagues(env, userId)];
+      }
+      if (platform === 'yahoo') {
+        return [platform, await refreshYahooLeagues(env as YahooConnectEnv, userId, corsHeaders, correlationId)];
+      }
+      return [platform, await refreshSleeperLeagues(env as SleeperConnectEnv, userId)];
+    } catch (error) {
+      return [platform, {
+        platform,
+        status: 'error',
+        httpStatus: 500,
+        error: 'refresh_failed',
+        error_description: errorDescription(error, `${platform} league refresh failed`),
+      }];
+    }
+  };
+
+  const entries = await Promise.all(platforms.map(refreshOne));
+  const results = Object.fromEntries(entries) as Partial<Record<RefreshPlatform, ProviderRefreshResult>>;
+
+  return {
+    success: Object.values(results).some((result) => result?.status === 'success'),
+    requestedPlatforms: platforms,
+    results,
+  };
+}

--- a/workers/auth-worker/src/oauth-handlers.ts
+++ b/workers/auth-worker/src/oauth-handlers.ts
@@ -287,7 +287,7 @@ export function handleMetadataDiscovery(env: OAuthEnv, corsHeaders: Record<strin
     grant_types_supported: ['authorization_code', 'refresh_token'],
     code_challenge_methods_supported: ['S256'],
     token_endpoint_auth_methods_supported: ['none', 'client_secret_post'],
-    scopes_supported: ['mcp:read'],
+    scopes_supported: ['mcp:read', 'mcp:write'],
 
     // Service documentation
     service_documentation: 'https://flaim.app/docs/oauth',

--- a/workers/auth-worker/src/sleeper-connect-handlers.ts
+++ b/workers/auth-worker/src/sleeper-connect-handlers.ts
@@ -46,6 +46,14 @@ interface RecurringLeagueResolutionResult {
   failureReason?: string;
 }
 
+export interface SleeperRefreshResult {
+  success: boolean;
+  username: string;
+  leagues_found: number;
+  seasons_discovered: number;
+  warning?: string;
+}
+
 /**
  * Annotate-path archive lookup that fails OPEN: a transient DB error treats
  * nothing as archived (the UI just loses the `archived`/`archiveMode` flags) rather
@@ -348,119 +356,163 @@ export async function handleSleeperDiscover(
       });
     }
 
-    // Resolve username → user_id
-    // Sleeper returns HTTP 200 with null body for unknown usernames; throws on 429/5xx
-    const sleeperUser = await sleeperGet<SleeperApiUser | null>(`/user/${username}`);
-    if (!sleeperUser || !sleeperUser.user_id) {
+    const result = await refreshSleeperLeaguesForUsername(env, userId, username);
+
+    return new Response(
+      JSON.stringify(result),
+      { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  } catch (error) {
+    console.error('[handleSleeperDiscover]', error);
+    if (error instanceof Error && error.message === 'sleeper_user_not_found') {
       return new Response(JSON.stringify({ error: 'Sleeper user not found. Check the username and try again.' }), {
         status: 404,
         headers: { ...corsHeaders, 'Content-Type': 'application/json' },
       });
     }
-
-    // Capture as consts so TypeScript retains the non-null narrowing inside closures
-    const sleeperUserId = sleeperUser.user_id;
-    const sleeperUsername = sleeperUser.username;
-
-    const storage = SleeperStorage.fromEnvironment(env);
-    await storage.saveSleeperConnection(userId, sleeperUserId, sleeperUsername ?? username);
-
-    // Discover leagues for current season (NFL + NBA)
-    // Use allSettled so a failure in one sport doesn't discard the other
-    const [nflResult, nbaResult] = await Promise.allSettled([
-      sleeperGet<SleeperApiLeague[]>(`/user/${sleeperUserId}/leagues/nfl/${getDefaultSeasonYear('football')}`),
-      sleeperGet<SleeperApiLeague[]>(`/user/${sleeperUserId}/leagues/nba/${getDefaultSeasonYear('basketball')}`),
-    ]);
-    const nflLeagues = nflResult.status === 'fulfilled' ? nflResult.value : [];
-    const nbaLeagues = nbaResult.status === 'fulfilled' ? nbaResult.value : [];
-    const hadFetchErrors = nflResult.status === 'rejected' || nbaResult.status === 'rejected';
-
-    const currentLeagues = [...(nflLeagues ?? []), ...(nbaLeagues ?? [])];
-    let totalSaved = 0;
-    const seasonsDiscovered = new Set<string>();
-    const recurringIdCache = new Map<string, string | null>();
-    const leagueCache = new Map<string, Promise<SleeperApiLeague | null>>();
-    const processedLeagueIds = new Set<string>();
-
-    // Process each league and traverse history chain
-    async function processLeague(league: SleeperApiLeague, recurringLeagueId: string | undefined, depth = 0): Promise<void> {
-      if (depth >= MAX_HISTORY_YEARS || processedLeagueIds.has(league.league_id)) return;
-
-      processedLeagueIds.add(league.league_id);
-      cacheSleeperLeague(leagueCache, league);
-
-      // Find user's roster_id in this league
-      let rosterId: number | null = null;
-      try {
-        const rosters = await sleeperGet<SleeperApiRoster[]>(`/league/${league.league_id}/rosters`);
-        const userRoster = rosters?.find((r) => r.owner_id === sleeperUserId);
-        rosterId = userRoster?.roster_id ?? null;
-      } catch (error) {
-        console.warn(
-          `[sleeper-connect] Failed to load rosters for ${league.league_id}; saving without rosterId: ${describeSleeperResolutionFailure(league.league_id, error)}`
-        );
-      }
-
-      const leagueToSave: Parameters<SleeperStorage['saveSleeperLeague']>[0] = {
-        clerkUserId: userId,
-        leagueId: league.league_id,
-        sport: mapSport(league.sport),
-        seasonYear: parseInt(league.season, 10) || getDefaultSeasonYear('football'),
-        leagueName: league.name,
-        rosterId,
-        sleeperUserId: sleeperUserId,
-      };
-      if (recurringLeagueId) {
-        leagueToSave.recurringLeagueId = recurringLeagueId;
-      }
-
-      await storage.saveSleeperLeague(leagueToSave);
-      totalSaved++;
-      seasonsDiscovered.add(league.season);
-
-      // Traverse previous season
-      if (league.previous_league_id) {
-        try {
-          const prevLeague = await getSleeperLeague(league.previous_league_id, leagueCache);
-          if (prevLeague?.league_id) {
-            await processLeague(prevLeague, recurringLeagueId, depth + 1);
-          }
-        } catch (error) {
-          console.warn(
-            `[sleeper-connect] Failed to traverse previous league ${league.previous_league_id} from ${league.league_id}: ${describeSleeperResolutionFailure(league.previous_league_id, error)}`
-          );
-        }
-      }
-    }
-
-    await Promise.all(currentLeagues.map(async (league) => {
-      cacheSleeperLeague(leagueCache, league);
-      const resolution = await tryResolveRecurringLeagueId(league.league_id, recurringIdCache, leagueCache);
-      if (!resolution.recurringLeagueId) {
-        console.warn(
-          `[sleeper-connect] Discovery could not persist recurringLeagueId for ${league.league_id}: ${resolution.failureReason ?? 'unresolved recurring chain'}`
-        );
-      }
-      await processLeague(league, resolution.recurringLeagueId);
-    }));
-
-    return new Response(
-      JSON.stringify({
-        success: totalSaved > 0 || !hadFetchErrors,
-        username: sleeperUsername ?? username,
-        leagues_found: totalSaved,
-        seasons_discovered: seasonsDiscovered.size,
-        ...(hadFetchErrors && totalSaved === 0 ? { warning: 'Some league data could not be fetched. Try reconnecting later.' } : {}),
-      }),
-      { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-    );
-  } catch (error) {
-    console.error('[handleSleeperDiscover]', error);
     return new Response(
       JSON.stringify({ error: error instanceof Error ? error.message : 'Discovery failed' }),
       { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
   }
+}
+
+export async function refreshSleeperLeaguesForUsername(
+  env: SleeperConnectEnv,
+  userId: string,
+  username: string
+): Promise<SleeperRefreshResult> {
+  // Resolve username → user_id.
+  // Sleeper returns HTTP 200 with null body for unknown usernames; throws on 429/5xx.
+  const sleeperUser = await sleeperGet<SleeperApiUser | null>(`/user/${username}`);
+  if (!sleeperUser || !sleeperUser.user_id) {
+    throw new Error('sleeper_user_not_found');
+  }
+
+  // Capture as consts so TypeScript retains the non-null narrowing inside closures.
+  const sleeperUserId = sleeperUser.user_id;
+  const sleeperUsername = sleeperUser.username;
+
+  const storage = SleeperStorage.fromEnvironment(env);
+  await storage.saveSleeperConnection(userId, sleeperUserId, sleeperUsername ?? username);
+
+  // Discover leagues for current season (NFL + NBA).
+  // Use allSettled so a failure in one sport doesn't discard the other.
+  const [nflResult, nbaResult] = await Promise.allSettled([
+    sleeperGet<SleeperApiLeague[]>(`/user/${sleeperUserId}/leagues/nfl/${getDefaultSeasonYear('football')}`),
+    sleeperGet<SleeperApiLeague[]>(`/user/${sleeperUserId}/leagues/nba/${getDefaultSeasonYear('basketball')}`),
+  ]);
+  const nflLeagues = nflResult.status === 'fulfilled' ? nflResult.value : [];
+  const nbaLeagues = nbaResult.status === 'fulfilled' ? nbaResult.value : [];
+  const hadFetchErrors = nflResult.status === 'rejected' || nbaResult.status === 'rejected';
+
+  const currentLeagues = [...(nflLeagues ?? []), ...(nbaLeagues ?? [])];
+  let totalSaved = 0;
+  const seasonsDiscovered = new Set<string>();
+  const recurringIdCache = new Map<string, string | null>();
+  const leagueCache = new Map<string, Promise<SleeperApiLeague | null>>();
+  const processedLeagueIds = new Set<string>();
+
+  // Process each league and traverse history chain.
+  async function processLeague(league: SleeperApiLeague, recurringLeagueId: string | undefined, depth = 0): Promise<void> {
+    if (depth >= MAX_HISTORY_YEARS || processedLeagueIds.has(league.league_id)) return;
+
+    processedLeagueIds.add(league.league_id);
+    cacheSleeperLeague(leagueCache, league);
+
+    // Find user's roster_id in this league.
+    let rosterId: number | null = null;
+    try {
+      const rosters = await sleeperGet<SleeperApiRoster[]>(`/league/${league.league_id}/rosters`);
+      const userRoster = rosters?.find((r) => r.owner_id === sleeperUserId);
+      rosterId = userRoster?.roster_id ?? null;
+    } catch (error) {
+      console.warn(
+        `[sleeper-connect] Failed to load rosters for ${league.league_id}; saving without rosterId: ${describeSleeperResolutionFailure(league.league_id, error)}`
+      );
+    }
+
+    const leagueToSave: Parameters<SleeperStorage['saveSleeperLeague']>[0] = {
+      clerkUserId: userId,
+      leagueId: league.league_id,
+      sport: mapSport(league.sport),
+      seasonYear: parseInt(league.season, 10) || getDefaultSeasonYear('football'),
+      leagueName: league.name,
+      rosterId,
+      sleeperUserId: sleeperUserId,
+    };
+    if (recurringLeagueId) {
+      leagueToSave.recurringLeagueId = recurringLeagueId;
+    }
+
+    await storage.saveSleeperLeague(leagueToSave);
+    totalSaved++;
+    seasonsDiscovered.add(league.season);
+
+    // Traverse previous season.
+    if (league.previous_league_id) {
+      try {
+        const prevLeague = await getSleeperLeague(league.previous_league_id, leagueCache);
+        if (prevLeague?.league_id) {
+          await processLeague(prevLeague, recurringLeagueId, depth + 1);
+        }
+      } catch (error) {
+        console.warn(
+          `[sleeper-connect] Failed to traverse previous league ${league.previous_league_id} from ${league.league_id}: ${describeSleeperResolutionFailure(league.previous_league_id, error)}`
+        );
+      }
+    }
+  }
+
+  await Promise.all(currentLeagues.map(async (league) => {
+    cacheSleeperLeague(leagueCache, league);
+    const resolution = await tryResolveRecurringLeagueId(league.league_id, recurringIdCache, leagueCache);
+    if (!resolution.recurringLeagueId) {
+      console.warn(
+        `[sleeper-connect] Discovery could not persist recurringLeagueId for ${league.league_id}: ${resolution.failureReason ?? 'unresolved recurring chain'}`
+      );
+    }
+    await processLeague(league, resolution.recurringLeagueId);
+  }));
+
+  return {
+    success: totalSaved > 0 || !hadFetchErrors,
+    username: sleeperUsername ?? username,
+    leagues_found: totalSaved,
+    seasons_discovered: seasonsDiscovered.size,
+    ...(hadFetchErrors && totalSaved === 0 ? { warning: 'Some league data could not be fetched. Try reconnecting later.' } : {}),
+  };
+}
+
+export async function refreshSleeperLeaguesFromStoredConnection(
+  env: SleeperConnectEnv,
+  userId: string
+): Promise<
+  | { status: 'success'; details: SleeperRefreshResult }
+  | { status: 'skipped'; error: string; error_description: string; details?: Record<string, unknown> }
+> {
+  const storage = SleeperStorage.fromEnvironment(env);
+  const connection = await storage.getSleeperConnection(userId);
+  if (!connection) {
+    return {
+      status: 'skipped',
+      error: 'not_connected',
+      error_description: 'User is not connected to Sleeper',
+    };
+  }
+
+  const username = connection.sleeperUsername?.trim();
+  if (!username) {
+    return {
+      status: 'skipped',
+      error: 'username_missing',
+      error_description: 'Stored Sleeper connection does not include a username',
+      details: { sleeperUserId: connection.sleeperUserId },
+    };
+  }
+
+  const details = await refreshSleeperLeaguesForUsername(env, userId, username);
+  return { status: 'success', details };
 }
 
 export async function handleSleeperStatus(

--- a/workers/fantasy-mcp/README.md
+++ b/workers/fantasy-mcp/README.md
@@ -39,9 +39,12 @@ fantasy-mcp (this worker)
 
 All tools take explicit parameters. Call `get_user_session` first in a normal chat to get league IDs and defaults. `get_league_info` is usually the second call for the selected league so team names, owner/team mapping, scoring, and roster-slot context are established before downstream league tools.
 
+Most tools are read-only analysis calls. `refresh_leagues` requires `mcp:write` because it can add or update Flaim league records after provider discovery, but it never makes roster moves, trades, drops, or lineup changes.
+
 | Tool | Description |
 |------|-------------|
 | `get_user_session` | User's leagues across all platforms (call first) |
+| `refresh_leagues` | Re-discover connected leagues and update Flaim's league records |
 | `get_ancient_history` | Past seasons and historical leagues outside the current season |
 | `get_league_info` | Baseline league context: settings, scoring, roster config, teams/owners |
 | `get_standings` | League standings with records |

--- a/workers/fantasy-mcp/src/__tests__/tools.test.ts
+++ b/workers/fantasy-mcp/src/__tests__/tools.test.ts
@@ -4,7 +4,8 @@ import { getUnifiedTools, hasRequiredScope, mcpAuthError } from '../mcp/tools';
 import { buildMcpAuthErrorResponse } from '../auth-response';
 import type { Env } from '../types';
 import { routeToClient } from '../router';
-import { USER_SESSION_WIDGET_HTML } from '../widgets/user-session-widget';
+import { USER_SESSION_WIDGET_HTML, USER_SESSION_WIDGET_URI } from '../widgets/user-session-widget';
+import { INTERNAL_SERVICE_TOKEN_HEADER } from '@flaim/worker-shared';
 
 /** Helper to cast an AnySchema value to z3 ZodTypeAny for .parse() in tests. */
 const asZod = (schema: unknown) => schema as z.ZodTypeAny;
@@ -38,6 +39,7 @@ describe('fantasy-mcp tools', () => {
       'get_standings',
       'get_transactions',
       'get_user_session',
+      'refresh_leagues',
     ]);
   });
 
@@ -84,8 +86,8 @@ describe('fantasy-mcp tools', () => {
     // structuredContent mirrors the text payload
     expect(result.structuredContent).toBeDefined();
     expect((result.structuredContent as Record<string, unknown>).totalLeaguesFound).toBe(0);
-    expect(result._meta?.ui).toEqual({ resourceUri: 'ui://widget/user-session.html' });
-    expect(result._meta?.['openai/outputTemplate']).toBe('ui://widget/user-session.html');
+    expect(result._meta?.ui).toEqual({ resourceUri: USER_SESSION_WIDGET_URI });
+    expect(result._meta?.['openai/outputTemplate']).toBe(USER_SESSION_WIDGET_URI);
     expect(result._meta?.['openai/widgetAccessible']).toBe(true);
     expect(result._meta?.['openai/resultCanProduceWidget']).toBe(true);
   });
@@ -122,7 +124,7 @@ describe('fantasy-mcp tools', () => {
 
   it('get_user_session includes widgetUri in tool definition', () => {
     const tool = getUnifiedTools().find((t) => t.name === 'get_user_session');
-    expect(tool?.widgetUri).toBe('ui://widget/user-session.html');
+    expect(tool?.widgetUri).toBe(USER_SESSION_WIDGET_URI);
   });
 
   it('user session widget declares the MCP Apps lifecycle messages', () => {
@@ -134,6 +136,200 @@ describe('fantasy-mcp tools', () => {
     expect(USER_SESSION_WIDGET_HTML).toContain("msg.method === 'ui/notifications/tool-result'");
     expect(USER_SESSION_WIDGET_HTML).toContain("msg.method === 'ui/resource-teardown'");
     expect(USER_SESSION_WIDGET_HTML).toContain('isTrustedMessageEvent(event)');
+  });
+
+  it('user session widget refreshes through callTool and reloads session output', () => {
+    expect(USER_SESSION_WIDGET_HTML).toContain("window.openai.callTool('refresh_leagues', {})");
+    expect(USER_SESSION_WIDGET_HTML).toContain("window.openai.callTool('get_user_session', {})");
+    expect(USER_SESSION_WIDGET_HTML).toContain('extractRefreshResult');
+    expect(USER_SESSION_WIDGET_HTML).toContain('refreshPayload.success === false');
+    expect(USER_SESSION_WIDGET_HTML).toContain('Leagues refreshed.');
+    expect(USER_SESSION_WIDGET_HTML).toContain('Refresh failed.');
+    expect(USER_SESSION_WIDGET_HTML).toContain('Open leagues');
+    expect(USER_SESSION_WIDGET_HTML).toContain('var hasRendered = false');
+    expect(USER_SESSION_WIDGET_HTML).not.toContain('if (rendered) return');
+  });
+
+  it('refresh_leagues forwards the user auth and internal token to auth-worker', async () => {
+    const tool = getUnifiedTools().find((t) => t.name === 'refresh_leagues');
+    expect(tool).toBeTruthy();
+
+    let capturedRequest: Request | null = null;
+    const env = {
+      INTERNAL_SERVICE_TOKEN: 'internal-secret',
+      AUTH_WORKER: {
+        fetch: async (req: Request) => {
+          capturedRequest = req;
+          return new Response(JSON.stringify({
+            success: true,
+            requestedPlatforms: ['espn'],
+            results: {
+              espn: { platform: 'espn', status: 'success', httpStatus: 200 },
+            },
+          }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        },
+      },
+    } as unknown as Env;
+
+    const result = await tool!.handler(
+      { platforms: ['espn'] },
+      env,
+      'Bearer user-token',
+      'corr-refresh',
+      'eval-run',
+      'eval-trace'
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(result.structuredContent).toMatchObject({ success: true });
+    expect(capturedRequest).toBeTruthy();
+    expect(new URL(capturedRequest!.url).pathname).toBe('/internal/leagues/refresh');
+    expect(capturedRequest!.method).toBe('POST');
+    expect(capturedRequest!.headers.get('Authorization')).toBe('Bearer user-token');
+    expect(capturedRequest!.headers.get(INTERNAL_SERVICE_TOKEN_HEADER)).toBe('internal-secret');
+    expect(capturedRequest!.headers.get('X-Correlation-ID')).toBe('corr-refresh');
+    expect(await capturedRequest!.json()).toEqual({ platforms: ['espn'] });
+  });
+
+  it('refresh_leagues rejects invalid platforms instead of widening to all platforms', async () => {
+    const tool = getUnifiedTools().find((t) => t.name === 'refresh_leagues');
+    expect(tool).toBeTruthy();
+
+    let calledAuthWorker = false;
+    const env = {
+      INTERNAL_SERVICE_TOKEN: 'internal-secret',
+      AUTH_WORKER: {
+        fetch: async () => {
+          calledAuthWorker = true;
+          return new Response(JSON.stringify({ success: true }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        },
+      },
+    } as unknown as Env;
+
+    const result = await tool!.handler(
+      { platforms: ['not-real'] },
+      env,
+      'Bearer user-token',
+      'corr-refresh-invalid'
+    );
+
+    expect(calledAuthWorker).toBe(false);
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain('Invalid platform(s): not-real');
+  });
+
+  it('refresh_leagues rejects empty platform arrays instead of widening to all platforms', async () => {
+    const tool = getUnifiedTools().find((t) => t.name === 'refresh_leagues');
+    expect(tool).toBeTruthy();
+
+    let calledAuthWorker = false;
+    const env = {
+      INTERNAL_SERVICE_TOKEN: 'internal-secret',
+      AUTH_WORKER: {
+        fetch: async () => {
+          calledAuthWorker = true;
+          return new Response(JSON.stringify({ success: true }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        },
+      },
+    } as unknown as Env;
+
+    const result = await tool!.handler({ platforms: [] }, env, 'Bearer user-token');
+
+    expect(calledAuthWorker).toBe(false);
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain('platforms must include at least one platform');
+  });
+
+  it('refresh_leagues includes the write scope challenge when auth-worker denies refresh', async () => {
+    const tool = getUnifiedTools().find((t) => t.name === 'refresh_leagues');
+    expect(tool).toBeTruthy();
+
+    const env = {
+      INTERNAL_SERVICE_TOKEN: 'internal-secret',
+      AUTH_WORKER: {
+        fetch: async () => {
+          return new Response(JSON.stringify({
+            error: 'insufficient_scope',
+            error_description: 'mcp:write scope is required to refresh leagues',
+          }), {
+            status: 403,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        },
+      },
+    } as unknown as Env;
+
+    const result = await tool!.handler({ platforms: ['espn'] }, env, 'Bearer user-token');
+    const challenge = (result._meta?.['mcp/www_authenticate'] as string[] | undefined)?.[0];
+
+    expect(result.isError).toBe(true);
+    expect(challenge).toContain('scope="mcp:write"');
+  });
+
+  it('refresh_leagues marks all-provider batch failures as MCP tool errors', async () => {
+    const tool = getUnifiedTools().find((t) => t.name === 'refresh_leagues');
+    expect(tool).toBeTruthy();
+
+    const env = {
+      INTERNAL_SERVICE_TOKEN: 'internal-secret',
+      AUTH_WORKER: {
+        fetch: async () => {
+          return new Response(JSON.stringify({
+            success: false,
+            requestedPlatforms: ['espn', 'yahoo'],
+            results: {
+              espn: { platform: 'espn', status: 'error', httpStatus: 500, error: 'discovery_failed' },
+              yahoo: { platform: 'yahoo', status: 'error', httpStatus: 429, error: 'rate_limited' },
+            },
+          }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        },
+      },
+    } as unknown as Env;
+
+    const result = await tool!.handler({ platforms: ['espn', 'yahoo'] }, env, 'Bearer user-token');
+
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toMatchObject({ success: false });
+  });
+
+  it('refresh_leagues marks skipped-only unsuccessful batch results as MCP tool errors', async () => {
+    const tool = getUnifiedTools().find((t) => t.name === 'refresh_leagues');
+    expect(tool).toBeTruthy();
+
+    const env = {
+      INTERNAL_SERVICE_TOKEN: 'internal-secret',
+      AUTH_WORKER: {
+        fetch: async () => {
+          return new Response(JSON.stringify({
+            success: false,
+            requestedPlatforms: ['sleeper'],
+            results: {
+              sleeper: { platform: 'sleeper', status: 'skipped', httpStatus: 404, error: 'not_connected' },
+            },
+          }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        },
+      },
+    } as unknown as Env;
+
+    const result = await tool!.handler({ platforms: ['sleeper'] }, env, 'Bearer user-token');
+
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toMatchObject({ success: false });
   });
 
   it('user session widget reports the card size instead of the host frame size', () => {
@@ -1273,8 +1469,8 @@ describe('auth error _meta', () => {
     expect(Array.isArray(result._meta?.['mcp/www_authenticate'])).toBe(true);
   });
 
-  it('scope-denied mcpAuthError includes correct resource_metadata URL', () => {
-    const result = mcpAuthError('https://api.flaim.app/mcp');
+  it('scope-denied mcpAuthError includes correct resource_metadata URL and required scope', () => {
+    const result = mcpAuthError('https://api.flaim.app/mcp', 'mcp:write');
     expect(result.isError).toBe(true);
     expect(result._meta).toBeDefined();
     expect(Array.isArray(result._meta?.['mcp/www_authenticate'])).toBe(true);
@@ -1282,6 +1478,7 @@ describe('auth error _meta', () => {
     expect(challenge).toContain('Bearer');
     // Must point to the actual served route, not /mcp/.well-known
     expect(challenge).toContain('resource_metadata="https://api.flaim.app/.well-known/oauth-protected-resource"');
+    expect(challenge).toContain('scope="mcp:write"');
     expect(challenge).not.toContain('/mcp/.well-known');
   });
 

--- a/workers/fantasy-mcp/src/index.ts
+++ b/workers/fantasy-mcp/src/index.ts
@@ -146,7 +146,7 @@ function buildOauthMetadata(resource: string) {
     resource,
     authorization_servers: ['https://api.flaim.app'],
     bearer_methods_supported: ['header'],
-    scopes_supported: ['mcp:read'],
+    scopes_supported: ['mcp:read', 'mcp:write'],
   };
 }
 

--- a/workers/fantasy-mcp/src/mcp/server.ts
+++ b/workers/fantasy-mcp/src/mcp/server.ts
@@ -3,7 +3,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { Env } from '../types';
 import { getUnifiedTools, hasRequiredScope, mcpAuthError, type McpToolResponse } from './tools';
 import { emitUsageEvent, type UsageStatus } from './usage';
-import { USER_SESSION_WIDGET_HTML } from '../widgets/user-session-widget';
+import { USER_SESSION_WIDGET_HTML, USER_SESSION_WIDGET_URI } from '../widgets/user-session-widget';
 import { FLAIM_MCP_INSTRUCTIONS } from './instructions';
 
 export interface McpContext {
@@ -67,13 +67,13 @@ export function createFantasyMcpServer(ctx: McpContext): McpServer {
   // Register widget resources
   server.registerResource(
     'user-session-widget',
-    'ui://widget/user-session.html',
+    USER_SESSION_WIDGET_URI,
     {
       mimeType: 'text/html;profile=mcp-app',
     },
     async () => ({
       contents: [{
-        uri: 'ui://widget/user-session.html',
+        uri: USER_SESSION_WIDGET_URI,
         mimeType: 'text/html;profile=mcp-app',
         text: USER_SESSION_WIDGET_HTML,
         _meta: {
@@ -102,8 +102,7 @@ export function createFantasyMcpServer(ctx: McpContext): McpServer {
         title: tool.title,
         description: tool.description,
         inputSchema: tool.inputSchema,
-        // OpenAI/Anthropic reviewer-safe annotation profile for read-only external data tools.
-        annotations: { readOnlyHint: true, openWorldHint: true, destructiveHint: false, idempotentHint: true },
+        annotations: tool.annotations,
         _meta: {
           securitySchemes: tool.securitySchemes,
           ...(tool.openaiMeta && {
@@ -125,7 +124,7 @@ export function createFantasyMcpServer(ctx: McpContext): McpServer {
         // auth error returns. Its own waitUntil so it never blocks the response.
         if (!hasRequiredScope(tokenScope, tool.requiredScope)) {
           safeEmit(ctx, tool.name, args, 'denied', null);
-          return mcpAuthError('https://api.flaim.app/mcp');
+          return mcpAuthError('https://api.flaim.app/mcp', tool.requiredScope);
         }
 
         // Time and emit exactly one event per tool call. Default status 'error'

--- a/workers/fantasy-mcp/src/mcp/tools.ts
+++ b/workers/fantasy-mcp/src/mcp/tools.ts
@@ -13,6 +13,7 @@ import {
   type SetupSignalEvent,
 } from '@flaim/worker-shared';
 import { logEvalEvent } from '../logging';
+import { USER_SESSION_WIDGET_URI } from '../widgets/user-session-widget';
 
 // =============================================================================
 // MCP RESPONSE TYPES
@@ -32,6 +33,13 @@ export type ToolSecuritySchemes = Array<{
   scopes: string[];
 }>;
 
+export interface ToolAnnotations {
+  readOnlyHint: boolean;
+  destructiveHint: boolean;
+  idempotentHint: boolean;
+  openWorldHint: boolean;
+}
+
 export interface UnifiedTool {
   name: string;
   title: string;
@@ -39,6 +47,7 @@ export interface UnifiedTool {
   inputSchema: ZodRawShapeCompat;
   requiredScope: 'mcp:read' | 'mcp:write';
   securitySchemes: ToolSecuritySchemes;
+  annotations: ToolAnnotations;
   openaiMeta?: {
     invoking: string;
     invoked: string;
@@ -67,6 +76,20 @@ export function hasRequiredScope(grantedScope: string | undefined, requiredScope
 function buildSecuritySchemes(scope: 'mcp:read' | 'mcp:write'): ToolSecuritySchemes {
   return [{ type: 'oauth2', scopes: [scope] }];
 }
+
+const READ_ONLY_TOOL_ANNOTATIONS: ToolAnnotations = {
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+  openWorldHint: true,
+};
+
+const REFRESH_TOOL_ANNOTATIONS: ToolAnnotations = {
+  readOnlyHint: false,
+  destructiveHint: false,
+  idempotentHint: true,
+  openWorldHint: true,
+};
 
 // =============================================================================
 // HELPER: Active league threshold
@@ -148,6 +171,88 @@ function getActiveLeagueGroupKey(league: UserLeague): string {
  */
 function archivedQuery(includeHistorical: boolean): string {
   return includeHistorical ? '?archived=exclude-hidden' : '';
+}
+
+async function refreshUserLeagues(
+  env: Env,
+  platforms: Platform[] | undefined,
+  authHeader?: string,
+  correlationId?: string,
+  evalRunId?: string,
+  evalTraceId?: string
+): Promise<McpToolResponse> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 15000);
+  const cid = correlationId || 'no-cid';
+
+  try {
+    console.log(`[fantasy-mcp] ${cid} refreshing leagues via auth-worker`);
+    const baseHeaders: Record<string, string> = {
+      'Content-Type': 'application/json',
+      ...(authHeader ? { Authorization: authHeader } : {}),
+    };
+    const withCorrelation = correlationId ? withCorrelationId(baseHeaders, correlationId) : new Headers(baseHeaders);
+    const withInternal = withInternalServiceToken(withCorrelation, env, 'auth-worker /internal/leagues/refresh');
+    const headers = withEvalHeaders(withInternal, evalRunId, evalTraceId);
+
+    const response = await env.AUTH_WORKER.fetch(
+      new Request('https://internal/internal/leagues/refresh', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(platforms && platforms.length > 0 ? { platforms } : {}),
+        signal: controller.signal,
+      })
+    );
+
+    clearTimeout(timeoutId);
+
+    if (response.status === 401 || response.status === 403) {
+      return mcpAuthError('https://api.flaim.app/mcp', 'mcp:write');
+    }
+
+    const contentType = response.headers.get('Content-Type') || '';
+    const payload = contentType.includes('application/json')
+      ? await response.json().catch(() => ({ success: false, error: 'Invalid JSON from auth-worker' }))
+      : { success: response.ok, error: await response.text().catch(() => 'No response body') };
+
+    if (!response.ok) {
+      const errorPayload = {
+        success: false,
+        status: response.status,
+        error: typeof payload === 'object' && payload !== null && 'error' in payload
+          ? String((payload as { error?: unknown }).error)
+          : `Auth-worker refresh failed with ${response.status}`,
+        data: payload,
+      };
+      return {
+        content: [{ type: 'text', text: JSON.stringify(errorPayload, null, 2) }],
+        structuredContent: errorPayload,
+        isError: true,
+      };
+    }
+
+    return {
+      content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }],
+      structuredContent: payload as Record<string, unknown>,
+      ...(didRefreshBatchFail(payload) ? { isError: true } : {}),
+    };
+  } catch (error) {
+    clearTimeout(timeoutId);
+    const isTimeout = error instanceof Error && error.name === 'AbortError';
+    const errorPayload = {
+      success: false,
+      code: isTimeout ? 'AUTH_WORKER_TIMEOUT' : 'AUTH_WORKER_REFRESH_FAILED',
+      error: isTimeout
+        ? 'League refresh timed out after 15 seconds'
+        : `League refresh failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+    };
+    console.error(`[fantasy-mcp] ${cid} failed to refresh leagues:`, error);
+    return {
+      content: [{ type: 'text', text: JSON.stringify(errorPayload, null, 2) }],
+      structuredContent: errorPayload,
+      isError: true,
+    };
+  }
 }
 
 async function fetchUserLeagues(
@@ -396,19 +501,26 @@ function mcpError(message: string): McpToolResponse {
   };
 }
 
-export function mcpAuthError(resource: string): McpToolResponse {
+function didRefreshBatchFail(payload: unknown): boolean {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return false;
+  const record = payload as { success?: unknown; results?: unknown };
+  return record.success === false;
+}
+
+export function mcpAuthError(resource: string, requiredScope?: 'mcp:read' | 'mcp:write'): McpToolResponse {
   // Derive metadata URL from resource: strip /mcp path, add .well-known
   // e.g. https://api.flaim.app/mcp → https://api.flaim.app/.well-known/oauth-protected-resource
   //      https://api.flaim.app/fantasy/mcp → https://api.flaim.app/fantasy/.well-known/oauth-protected-resource
   const url = new URL(resource);
   const basePath = url.pathname.replace(/\/mcp$/, '');
   const resourceMetadata = `${url.origin}${basePath}/.well-known/oauth-protected-resource`;
+  const scopeChallenge = requiredScope ? `, scope="${requiredScope}"` : '';
   return {
     content: [{ type: 'text', text: 'AUTH_FAILED: Authentication required' }],
     isError: true,
     _meta: {
       'mcp/www_authenticate': [
-        `Bearer resource_metadata="${resourceMetadata}", error="invalid_token", error_description="Authentication required"`,
+        `Bearer resource_metadata="${resourceMetadata}"${scopeChallenge}, error="invalid_token", error_description="Authentication required"`,
       ],
     },
   };
@@ -526,8 +638,9 @@ export function getUnifiedTools(): UnifiedTool[] {
       title: 'User Session',
       requiredScope: 'mcp:read',
       securitySchemes: buildSecuritySchemes('mcp:read'),
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
       openaiMeta: { invoking: 'Loading your leagues\u2026', invoked: 'Leagues loaded' },
-      widgetUri: 'ui://widget/user-session.html',
+      widgetUri: USER_SESSION_WIDGET_URI,
       description:
         "Use only for fantasy sports questions that need the user's connected league data; do not call for generic coding, scraping, weather, travel, betting, or non-fantasy sports questions. Call this exactly once at the start of each chat before any other Flaim tool. Returns the user's full league landscape: allLeagues (all active leagues), defaultLeagues (per-sport defaults), and defaultLeague (populated only when a single league exists or defaultSport matches). For vague singular prompts, use defaultLeague when present; otherwise use the relevant sport entry in defaultLeagues. For explicit plural or comparative prompts (each, all, compare, across leagues/platforms), enumerate every matching league in allLeagues and call the target tool once per league. In normal chat flows, do not skip this first step. After this, strongly consider calling get_league_info for the target league. season_year always represents the start year of the season. Read-only. If this call errors, do not repeat it unchanged.",
       inputSchema: {},
@@ -773,9 +886,9 @@ export function getUnifiedTools(): UnifiedTool[] {
             structuredContent: sessionData as unknown as Record<string, unknown>,
             _meta: {
               ui: {
-                resourceUri: 'ui://widget/user-session.html',
+                resourceUri: USER_SESSION_WIDGET_URI,
               },
-              'openai/outputTemplate': 'ui://widget/user-session.html',
+              'openai/outputTemplate': USER_SESSION_WIDGET_URI,
               'openai/widgetAccessible': true,
               'openai/resultCanProduceWidget': true,
             },
@@ -789,6 +902,41 @@ export function getUnifiedTools(): UnifiedTool[] {
     },
 
     // -------------------------------------------------------------------------
+    // Tool 2: refresh_leagues
+    // -------------------------------------------------------------------------
+    {
+      name: 'refresh_leagues',
+      title: 'Refresh Leagues',
+      requiredScope: 'mcp:write',
+      securitySchemes: buildSecuritySchemes('mcp:write'),
+      annotations: REFRESH_TOOL_ANNOTATIONS,
+      openaiMeta: { invoking: 'Refreshing leagues\u2026', invoked: 'Leagues refreshed' },
+      description:
+        'Refresh connected fantasy leagues by asking Flaim to rediscover leagues through connected ESPN, Yahoo, and Sleeper accounts. Use only when the user explicitly asks to refresh or after the user presses the widget refresh button. This is non-destructive and idempotent: it may add/update discovered league records but does not make roster moves, trades, drops, or lineup changes. If this call succeeds, call get_user_session again to show the updated league list. If this call errors, do not repeat it unchanged.',
+      inputSchema: {
+        platforms: z
+          .array(z.enum(['espn', 'yahoo', 'sleeper']))
+          .optional()
+          .describe('Optional platforms to refresh. Omit to refresh every connected platform.'),
+      },
+      handler: async (args, env, authHeader, correlationId, evalRunId, evalTraceId) => {
+        const rawPlatforms = Array.isArray(args.platforms) ? args.platforms : undefined;
+        const invalidPlatforms = rawPlatforms
+          ?.filter((platform) => platform !== 'espn' && platform !== 'yahoo' && platform !== 'sleeper');
+        if (invalidPlatforms?.length) {
+          return mcpError(`Invalid platform(s): ${invalidPlatforms.map(String).join(', ')}`);
+        }
+        if (rawPlatforms?.length === 0) {
+          return mcpError('platforms must include at least one platform');
+        }
+        const platforms = rawPlatforms as Platform[] | undefined;
+        return withToolLogging(correlationId, 'refresh_leagues', `platforms=${platforms?.join(',') || 'all'}`, async () => {
+          return refreshUserLeagues(env, platforms, authHeader, correlationId, evalRunId, evalTraceId);
+        }, evalRunId, evalTraceId);
+      },
+    },
+
+    // -------------------------------------------------------------------------
     // GET ANCIENT HISTORY - Retrieve old leagues and seasons
     // -------------------------------------------------------------------------
     {
@@ -796,6 +944,7 @@ export function getUnifiedTools(): UnifiedTool[] {
       title: 'Ancient History',
       requiredScope: 'mcp:read',
       securitySchemes: buildSecuritySchemes('mcp:read'),
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
       openaiMeta: { invoking: 'Searching old seasons\u2026', invoked: 'History loaded' },
       description:
         'Use this only after get_user_session, and only when the user is clearly asking about a non-current season or an inactive league. This is the historical branch: it returns past seasons and historical leagues outside the current season view. Use for last season, older seasons, inactive leagues, or historical performance. Read-only. If this call errors, do not repeat it unchanged.',
@@ -892,6 +1041,7 @@ export function getUnifiedTools(): UnifiedTool[] {
       title: 'League Context',
       requiredScope: 'mcp:read',
       securitySchemes: buildSecuritySchemes('mcp:read'),
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
       openaiMeta: { invoking: 'Fetching league info\u2026', invoked: 'League info ready' },
       description: `Strongly encouraged as the second call after get_user_session for the specified league. This provides the baseline league context for analysis: league name, settings, scoring type, roster configuration, and team/owner context, plus schedule or season-window metadata when the platform provides it. Use it liberally before standings, matchups, roster, free-agent, player, or transaction analysis so team names are resolved and the model has league-type, scoring, and roster context. When fanning out across multiple leagues, call this once per league. The exact team fields vary by platform but all include ownerName. Use values from get_user_session. Read-only. If this call errors, do not repeat it unchanged. Current date is ${currentDate}.`,
       inputSchema: {
@@ -927,6 +1077,7 @@ export function getUnifiedTools(): UnifiedTool[] {
       title: 'League Standings',
       requiredScope: 'mcp:read',
       securitySchemes: buildSecuritySchemes('mcp:read'),
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
       openaiMeta: { invoking: 'Fetching standings\u2026', invoked: 'Standings ready' },
       description: `Get season standings and outcome snapshot; includes verified season-outcome fields when available. Returns team records, rankings, and points summaries. The rank field is a standings sort position (1 = best): on ESPN and Sleeper it is computed by Flaim from win percentage; on Yahoo it is passed through from Yahoo's own standings API. It is NOT a verified postseason finish. For verified postseason outcome, use finalRank and championshipWon instead. Also returns seasonPhase (regular_season/playoffs_in_progress/season_complete), seasonComplete, and per-team outcome fields: finalRank, championshipWon, playoffOutcome, outcomeConfidence, madePlayoffs, playoffSeed. Outcome fields are null when not verifiable — do not infer championship from rank or team name. Note: playoffOutcome returns 'in_progress' on Sleeper for teams in active playoffs; ESPN and Yahoo return null for that state. ESPN may also include projected-rank fields. Best used after get_user_session and after get_league_info for the specified league so team names and league context are already established. For multi-league comparisons, call once per league. For historical finish questions, call get_ancient_history first to discover seasons, then call this tool per season for verified outcomes. Read-only. If this call errors, do not repeat it unchanged. Current date is ${currentDate}.`,
       inputSchema: {
@@ -962,6 +1113,7 @@ export function getUnifiedTools(): UnifiedTool[] {
       title: 'League Matchups',
       requiredScope: 'mcp:read',
       securitySchemes: buildSecuritySchemes('mcp:read'),
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
       openaiMeta: { invoking: 'Fetching matchups\u2026', invoked: 'Matchups ready' },
       description: `Get matchups/scoreboard for a specific week or the current week. Best used after get_user_session and after get_league_info for the specified league so the model already knows the league's team names, owner/team mapping, and league context before interpreting the matchup. For multi-league comparisons, call once per league. Read-only. If this call errors, do not repeat it unchanged. Current date is ${currentDate}.`,
       inputSchema: {
@@ -999,6 +1151,7 @@ export function getUnifiedTools(): UnifiedTool[] {
       title: 'Team Roster',
       requiredScope: 'mcp:read',
       securitySchemes: buildSecuritySchemes('mcp:read'),
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
       openaiMeta: { invoking: 'Fetching roster\u2026', invoked: 'Roster ready' },
       description: `Get roster details for a specific team. Exact payload varies by platform: ESPN and Yahoo return player entries with lineup/position context, while Sleeper returns starters, bench, reserve, and record metadata for the selected roster. Best used after get_user_session and after get_league_info for the specified league so the model already knows the league's team names, owner/team mapping, league settings, and roster context before interpreting this roster. Requires authentication except on Sleeper's public API. Read-only. If this call errors, do not repeat it unchanged. Current date is ${currentDate}.`,
       inputSchema: {
@@ -1038,6 +1191,7 @@ export function getUnifiedTools(): UnifiedTool[] {
       title: 'Free Agents',
       requiredScope: 'mcp:read',
       securitySchemes: buildSecuritySchemes('mcp:read'),
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
       openaiMeta: { invoking: 'Searching free agents\u2026', invoked: 'Free agents ready' },
       description: `Get currently available players for the specified league, optionally filtered by position. Exact payload varies by platform: ESPN and Yahoo include ownership percentages and sort by ownership, while Sleeper returns available-player identities from the public player index without ownership percentages. Best used after get_user_session and usually after get_league_info for the specified league so team names, owner/team mapping, scoring context, and roster-slot context are already established before giving pickup advice. For multi-league comparisons, call once per league. Use this for player availability only. Do not use percentOwned or market ownership to infer who owns a player in the user's league; for ownership questions, use get_league_info (returns teams with ownerName) and get_roster. Requires authentication on ESPN and Yahoo; Sleeper uses the public API. Use values from get_user_session. Read-only. If this call errors, do not repeat it unchanged. Current date is ${currentDate}.`,
       inputSchema: {
@@ -1083,6 +1237,7 @@ export function getUnifiedTools(): UnifiedTool[] {
       title: 'Search Players',
       requiredScope: 'mcp:read',
       securitySchemes: buildSecuritySchemes('mcp:read'),
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
       openaiMeta: { invoking: 'Searching players\u2026', invoked: 'Players ready' },
       description: `Search for player identity by name. Always returns identity fields, but ownership context varies by platform. ESPN and Yahoo return market/global ownership and can also populate league ownership fields when credentials and league context are available. Sleeper returns identity plus ownership_scope="unavailable" with market_percent_owned=null. Best used after get_user_session and often after get_league_info when the user cares about league-specific ownership or team-name resolution. League ownership fields: league_status ("ROSTERED" = on a team, "FREE_AGENT" = available, null = unavailable), league_team_name (fantasy team name if rostered), league_owner_name (team owner if rostered). When those league fields are absent, null, or unavailable, fall back to get_league_info + get_roster to verify manually. Use values from get_user_session. Read-only. If this call errors, do not repeat it unchanged. Current date is ${currentDate}.`,
       inputSchema: {
@@ -1133,6 +1288,7 @@ export function getUnifiedTools(): UnifiedTool[] {
       title: 'League Transactions',
       requiredScope: 'mcp:read',
       securitySchemes: buildSecuritySchemes('mcp:read'),
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
       openaiMeta: { invoking: 'Fetching transactions\u2026', invoked: 'Transactions ready' },
       description: `Get recent league transactions including adds, drops, waivers, and trades. Best used after get_user_session and usually after get_league_info so the model already knows the league's team names and owner/team mapping before summarizing activity. Each normalized transaction includes a date field (YYYY-MM-DD), type, status, week, and optional team_ids. When presenting results, organize by time period (today, yesterday, this week, older) AND by team within each period so the user can see both when moves happened and what each team did. Week handling is platform-specific: ESPN/Sleeper use week windows (default current + previous week), while Yahoo uses a recent 14-day timestamp window and ignores explicit week. Type support is also platform-specific: Sleeper supports add/drop/trade/waiver; Yahoo supports add/drop/trade plus pending waiver/pending_trade views for the authenticated user's own items; ESPN also supports failed_bid and trade lifecycle types (trade_proposal, trade_decline, trade_veto, trade_uphold). ESPN uses mTransactions2 for structured transaction data, and accepted trade player details are supplemented from the activity feed. ESPN responses include a "teams" map (team ID → display name) to resolve the numeric team_ids on each transaction, while Yahoo and Sleeper generally rely on get_league_info for team-name resolution. Use values from get_user_session. Read-only. If this call errors, do not repeat it unchanged. Current date is ${currentDate}.`,
       inputSchema: {

--- a/workers/fantasy-mcp/src/widgets/user-session-widget.ts
+++ b/workers/fantasy-mcp/src/widgets/user-session-widget.ts
@@ -15,11 +15,14 @@
  * 1. MCP Apps postMessage JSON-RPC ui/notifications/tool-result
  * 2. openai:set_globals CustomEvent -> window.openai.toolOutput
  * 3. window.openai.toolOutput on immediate/DOMContentLoaded (may already be set)
+ * 4. window.openai.callTool refresh button for manual league discovery refresh
  *
  * References:
  * - https://developers.openai.com/apps-sdk/build/chatgpt-ui/
  * - https://developers.openai.com/apps-sdk/build/mcp-server/
  */
+export const USER_SESSION_WIDGET_URI = 'ui://widget/user-session.v2.html';
+
 export const USER_SESSION_WIDGET_HTML = `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -64,6 +67,30 @@ export const USER_SESSION_WIDGET_HTML = `<!DOCTYPE html>
     font-weight: 500;
     letter-spacing: -0.4px;
     color: #0d0d0d;
+  }
+  .header-actions {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    flex-shrink: 0;
+  }
+  .refresh-button {
+    height: 28px;
+    min-width: 68px;
+    border: 1px solid rgba(13, 13, 13, 0.12);
+    border-radius: 999px;
+    background: #f8fafc;
+    color: #0d0d0d;
+    font: inherit;
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 1;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+  .refresh-button:disabled {
+    cursor: default;
+    opacity: 0.62;
   }
   .edit-link {
     width: 24px;
@@ -181,21 +208,41 @@ export const USER_SESSION_WIDGET_HTML = `<!DOCTYPE html>
     color: #9ca3af;
     font-size: 13px;
   }
+  .refresh-status {
+    display: none;
+    padding: 8px 16px;
+    border-top: 1px solid rgba(13, 13, 13, 0.05);
+    font-size: 12px;
+    line-height: 16px;
+    color: #5d5d5d;
+  }
+  .refresh-status.is-visible { display: block; }
+  .refresh-status.is-error { color: #b91c1c; }
+  .refresh-status.is-success { color: #137a45; }
+  .refresh-status a {
+    color: inherit;
+    font-weight: 600;
+    text-decoration: underline;
+  }
 </style>
 </head>
 <body>
 <div class="widget">
   <div class="header">
     <span class="app-name">Your Leagues</span>
-    <a href="https://flaim.app/leagues" target="_blank" rel="noopener" class="edit-link" aria-label="Edit leagues" id="edit-link">
-      <svg viewBox="0 0 24 24" aria-hidden="true">
-        <path d="M15.6729 2.32843C15.235 1.89052 14.525 1.89052 14.0871 2.32843L8.14992 8.26562C7.69093 8.72461 7.39319 9.32009 7.30139 9.96267L7.17851 10.8228L8.03865 10.6999C8.68123 10.6081 9.27671 10.3104 9.7357 9.8514L15.6729 3.91421C16.1108 3.47631 16.1108 2.76633 15.6729 2.32843ZM12.6729 0.914213C13.8918 -0.304738 15.8682 -0.304738 17.0871 0.914213C18.3061 2.13316 18.3061 4.10948 17.0871 5.32843L11.1499 11.2656C10.3849 12.0306 9.39247 12.5268 8.32149 12.6798L6.14142 12.9913C5.82983 13.0358 5.51546 12.931 5.29289 12.7084C5.07033 12.4859 4.96554 12.1715 5.01005 11.8599L5.32149 9.67983C5.47449 8.60885 5.97072 7.61639 6.7357 6.8514L12.6729 0.914213ZM8 1.00063C8.00043 1.55291 7.55306 2.00098 7.00078 2.00141C6.00227 2.00219 5.29769 2.00962 4.74651 2.06198C4.20685 2.11326 3.88488 2.20251 3.63803 2.32829C3.07354 2.61591 2.6146 3.07485 2.32698 3.63934C2.19279 3.90269 2.10062 4.25038 2.05118 4.85555C2.00078 5.47239 2 6.2647 2 7.40131V10.6013C2 11.7379 2.00078 12.5302 2.05118 13.1471C2.10062 13.7522 2.19279 14.0999 2.32698 14.3633C2.6146 14.9278 3.07354 15.3867 3.63803 15.6743C3.90138 15.8085 4.24907 15.9007 4.85424 15.9501C5.47108 16.0005 6.26339 16.0013 7.4 16.0013H10.6C11.7366 16.0013 12.5289 16.0005 13.1458 15.9501C13.7509 15.9007 14.0986 15.8085 14.362 15.6743C14.9265 15.3867 15.3854 14.9278 15.673 14.3633C15.7988 14.1164 15.8881 13.7945 15.9393 13.2548C15.9917 12.7036 15.9991 11.999 15.9999 11.0005C16.0003 10.4482 16.4484 10.0009 17.0007 10.0013C17.553 10.0017 18.0003 10.4498 17.9999 11.0021C17.9991 11.9803 17.9932 12.7821 17.9304 13.444C17.8664 14.1173 17.7385 14.715 17.455 15.2713C16.9757 16.2121 16.2108 16.977 15.27 17.4563C14.6777 17.7581 14.0375 17.8839 13.3086 17.9435C12.6008 18.0013 11.7266 18.0013 10.6428 18.0013H7.35717C6.27339 18.0013 5.39925 18.0013 4.69138 17.9435C3.96253 17.8839 3.32234 17.7581 2.73005 17.4563C1.78924 16.977 1.02433 16.2121 0.544968 15.2713C0.24318 14.679 0.117368 14.0388 0.0578183 13.3099C-1.77398e-05 12.6021 -9.75112e-06 11.7279 2.62458e-07 10.6441V7.3585C-9.75112e-06 6.27471 -1.77398e-05 5.40056 0.0578183 4.69268C0.117368 3.96383 0.24318 3.32365 0.544968 2.73135C1.02433 1.79054 1.78924 1.02564 2.73005 0.546275C3.28633 0.262836 3.88399 0.134924 4.55735 0.0709492C5.21919 0.00806886 6.02103 0.00217121 6.99922 0.00140845C7.55151 0.00097781 7.99957 0.448344 8 1.00063Z"></path>
-      </svg>
-    </a>
+    <div class="header-actions">
+      <button type="button" class="refresh-button" id="refresh-button">Refresh</button>
+      <a href="https://flaim.app/leagues" target="_blank" rel="noopener" class="edit-link" aria-label="Edit leagues" id="edit-link">
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M15.6729 2.32843C15.235 1.89052 14.525 1.89052 14.0871 2.32843L8.14992 8.26562C7.69093 8.72461 7.39319 9.32009 7.30139 9.96267L7.17851 10.8228L8.03865 10.6999C8.68123 10.6081 9.27671 10.3104 9.7357 9.8514L15.6729 3.91421C16.1108 3.47631 16.1108 2.76633 15.6729 2.32843ZM12.6729 0.914213C13.8918 -0.304738 15.8682 -0.304738 17.0871 0.914213C18.3061 2.13316 18.3061 4.10948 17.0871 5.32843L11.1499 11.2656C10.3849 12.0306 9.39247 12.5268 8.32149 12.6798L6.14142 12.9913C5.82983 13.0358 5.51546 12.931 5.29289 12.7084C5.07033 12.4859 4.96554 12.1715 5.01005 11.8599L5.32149 9.67983C5.47449 8.60885 5.97072 7.61639 6.7357 6.8514L12.6729 0.914213ZM8 1.00063C8.00043 1.55291 7.55306 2.00098 7.00078 2.00141C6.00227 2.00219 5.29769 2.00962 4.74651 2.06198C4.20685 2.11326 3.88488 2.20251 3.63803 2.32829C3.07354 2.61591 2.6146 3.07485 2.32698 3.63934C2.19279 3.90269 2.10062 4.25038 2.05118 4.85555C2.00078 5.47239 2 6.2647 2 7.40131V10.6013C2 11.7379 2.00078 12.5302 2.05118 13.1471C2.10062 13.7522 2.19279 14.0999 2.32698 14.3633C2.6146 14.9278 3.07354 15.3867 3.63803 15.6743C3.90138 15.8085 4.24907 15.9007 4.85424 15.9501C5.47108 16.0005 6.26339 16.0013 7.4 16.0013H10.6C11.7366 16.0013 12.5289 16.0005 13.1458 15.9501C13.7509 15.9007 14.0986 15.8085 14.362 15.6743C14.9265 15.3867 15.3854 14.9278 15.673 14.3633C15.7988 14.1164 15.8881 13.7945 15.9393 13.2548C15.9917 12.7036 15.9991 11.999 15.9999 11.0005C16.0003 10.4482 16.4484 10.0009 17.0007 10.0013C17.553 10.0017 18.0003 10.4498 17.9999 11.0021C17.9991 11.9803 17.9932 12.7821 17.9304 13.444C17.8664 14.1173 17.7385 14.715 17.455 15.2713C16.9757 16.2121 16.2108 16.977 15.27 17.4563C14.6777 17.7581 14.0375 17.8839 13.3086 17.9435C12.6008 18.0013 11.7266 18.0013 10.6428 18.0013H7.35717C6.27339 18.0013 5.39925 18.0013 4.69138 17.9435C3.96253 17.8839 3.32234 17.7581 2.73005 17.4563C1.78924 16.977 1.02433 16.2121 0.544968 15.2713C0.24318 14.679 0.117368 14.0388 0.0578183 13.3099C-1.77398e-05 12.6021 -9.75112e-06 11.7279 2.62458e-07 10.6441V7.3585C-9.75112e-06 6.27471 -1.77398e-05 5.40056 0.0578183 4.69268C0.117368 3.96383 0.24318 3.32365 0.544968 2.73135C1.02433 1.79054 1.78924 1.02564 2.73005 0.546275C3.28633 0.262836 3.88399 0.134924 4.55735 0.0709492C5.21919 0.00806886 6.02103 0.00217121 6.99922 0.00140845C7.55151 0.00097781 7.99957 0.448344 8 1.00063Z"></path>
+        </svg>
+      </a>
+    </div>
   </div>
   <div id="content">
     <div class="loading">Loading&hellip;</div>
   </div>
+  <div id="refresh-status" class="refresh-status" aria-live="polite"></div>
 </div>
 <script>
 (function() {
@@ -206,7 +253,7 @@ export const USER_SESSION_WIDGET_HTML = `<!DOCTYPE html>
   var WIDGET_WIDTH = 353;
   var initId = 'flaim-init-' + Math.random().toString(36).slice(2);
   var initializedSent = false;
-  var rendered = false;
+  var hasRendered = false;
 
   function postToParent(message) {
     try {
@@ -320,8 +367,22 @@ export const USER_SESSION_WIDGET_HTML = `<!DOCTYPE html>
     return openLegacyLeagues();
   }
 
+  function setRefreshStatus(message, kind) {
+    var status = document.getElementById('refresh-status');
+    if (!status) return;
+    status.className = 'refresh-status' + (message ? ' is-visible' : '') + (kind ? ' is-' + kind : '');
+    status.innerHTML = message || '';
+    queueSizeChanged();
+  }
+
+  function setRefreshLoading(isLoading) {
+    var button = document.getElementById('refresh-button');
+    if (!button) return;
+    button.disabled = !!isLoading;
+    button.textContent = isLoading ? 'Refreshing' : 'Refresh';
+  }
+
   function render(data) {
-    if (rendered) return;
     var container = document.getElementById('content');
     if (!data || !data.allLeagues || data.allLeagues.length === 0) {
       container.innerHTML =
@@ -329,7 +390,7 @@ export const USER_SESSION_WIDGET_HTML = `<!DOCTYPE html>
         'No leagues found.<br>' +
         '<a href="https://flaim.app/leagues" target="_blank" rel="noopener">Connect a league</a>' +
         '</div>';
-      rendered = true;
+      hasRendered = true;
       queueSizeChanged();
       return;
     }
@@ -397,7 +458,7 @@ export const USER_SESSION_WIDGET_HTML = `<!DOCTYPE html>
     });
 
     container.innerHTML = html;
-    rendered = true;
+    hasRendered = true;
     queueSizeChanged();
   }
 
@@ -416,31 +477,84 @@ export const USER_SESSION_WIDGET_HTML = `<!DOCTYPE html>
 
   var editLink = document.getElementById('edit-link');
   if (editLink) editLink.addEventListener('click', openLeagues);
+  var refreshButton = document.getElementById('refresh-button');
+  if (refreshButton) refreshButton.addEventListener('click', refreshLeagues);
 
-  // Extract session data from any wrapper format
-  function extract(obj) {
+  // Extract payload data from any wrapper format
+  function unwrapPayload(obj) {
     if (!obj) return null;
     if (typeof obj === 'string') {
       try { obj = JSON.parse(obj); } catch(e) { return null; }
     }
-    if (obj.allLeagues) return obj;
-    if (obj.structuredContent) return extract(obj.structuredContent);
-    if (obj.params && obj.params.structuredContent) return extract(obj.params.structuredContent);
-    if (obj.content && obj.content[0] && obj.content[0].text) return extract(obj.content[0].text);
+    if (obj.structuredContent) return unwrapPayload(obj.structuredContent);
+    if (obj.toolOutput) return unwrapPayload(obj.toolOutput);
+    if (obj.result) return unwrapPayload(obj.result);
+    if (obj.output) return unwrapPayload(obj.output);
+    if (obj.params && obj.params.structuredContent) return unwrapPayload(obj.params.structuredContent);
+    if (obj.content && obj.content[0] && obj.content[0].text) return unwrapPayload(obj.content[0].text);
+    return obj;
+  }
+
+  // Extract session data from any wrapper format
+  function extract(obj) {
+    var payload = unwrapPayload(obj);
+    if (payload && payload.allLeagues) return payload;
+    return null;
+  }
+
+  function extractRefreshResult(obj) {
+    var payload = unwrapPayload(obj);
+    if (payload && typeof payload === 'object' && payload.success !== undefined) return payload;
     return null;
   }
 
   function tryToolOutput() {
-    if (rendered) return;
+    if (hasRendered) return;
     if (window.openai && window.openai.toolOutput != null) {
       var data = extract(window.openai.toolOutput);
       if (data) render(data);
     }
   }
 
+  async function refreshLeagues(e) {
+    if (e && e.preventDefault) e.preventDefault();
+    if (!window.openai || typeof window.openai.callTool !== 'function') {
+      setRefreshStatus('Open Flaim to manage leagues.', 'error');
+      openLegacyLeagues();
+      return false;
+    }
+    setRefreshLoading(true);
+    setRefreshStatus('Refreshing leagues...', '');
+    try {
+      var refreshResult = await window.openai.callTool('refresh_leagues', {});
+      var refreshPayload = extractRefreshResult(refreshResult);
+      if (refreshResult && refreshResult.isError) {
+        throw new Error((refreshPayload && (refreshPayload.error_description || refreshPayload.error)) || 'Refresh failed');
+      }
+      if (refreshPayload && refreshPayload.success === false) {
+        throw new Error(refreshPayload.error_description || refreshPayload.error || 'No leagues were refreshed');
+      }
+      var sessionResult = await window.openai.callTool('get_user_session', {});
+      var data = extract(sessionResult);
+      if (!data && window.openai.toolOutput != null) {
+        data = extract(window.openai.toolOutput);
+      }
+      if (!data) {
+        throw new Error('Session data unavailable');
+      }
+      render(data);
+      setRefreshStatus('Leagues refreshed.', 'success');
+    } catch (_) {
+      setRefreshStatus('Refresh failed. <a href="https://flaim.app/leagues" target="_blank" rel="noopener">Open leagues</a>.', 'error');
+    } finally {
+      setRefreshLoading(false);
+    }
+    return false;
+  }
+
   // ChatGPT compatibility: listen for openai:set_globals CustomEvent.
   window.addEventListener('openai:set_globals', function(event) {
-    if (rendered) return;
+    if (hasRendered) return;
     var globals = event.detail && event.detail.globals;
     if (globals && globals.toolOutput !== undefined) {
       tryToolOutput();
@@ -469,7 +583,7 @@ export const USER_SESSION_WIDGET_HTML = `<!DOCTYPE html>
       return;
     }
 
-    if (rendered) return;
+    if (hasRendered) return;
 
     if (msg.jsonrpc === '2.0' && msg.method === 'ui/notifications/tool-result') {
       var data = extract(msg.params);

--- a/workers/fantasy-mcp/tests/integration/index.integration.test.ts
+++ b/workers/fantasy-mcp/tests/integration/index.integration.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import app from '../../src/index';
 import type { Env } from '../../src/types';
 import { getUnifiedTools, type UnifiedTool } from '../../src/mcp/tools';
+import { USER_SESSION_WIDGET_URI } from '../../src/widgets/user-session-widget';
 import { INTERNAL_SERVICE_TOKEN_HEADER, getDefaultSeasonYear } from '@flaim/worker-shared';
 
 // Mock the tools module so a single test can inject a custom tool (e.g. a
@@ -307,23 +308,32 @@ describe('fantasy-mcp gateway integration', () => {
     expect(freeAgentsTool?.inputSchema?.properties?.platform?.enum).toContain('sleeper');
     const userSessionTool = tools?.find((tool) => tool.name === 'get_user_session');
     expect(userSessionTool).toBeDefined();
-    expect(userSessionTool?._meta?.ui).toEqual({ resourceUri: 'ui://widget/user-session.html' });
-    expect(userSessionTool?._meta?.['openai/outputTemplate']).toBe('ui://widget/user-session.html');
+    expect(userSessionTool?._meta?.ui).toEqual({ resourceUri: USER_SESSION_WIDGET_URI });
+    expect(userSessionTool?._meta?.['openai/outputTemplate']).toBe(USER_SESSION_WIDGET_URI);
     expect(userSessionTool?._meta?.['openai/widgetAccessible']).toBe(true);
     expect(userSessionTool?._meta?.['openai/resultCanProduceWidget']).toBe(true);
     expect(userSessionTool?._meta?.['openai/widgetDomain']).toBeUndefined();
+    const refreshTool = tools?.find((tool) => tool.name === 'refresh_leagues');
+    expect(refreshTool).toBeDefined();
+    expect(refreshTool?._meta?.securitySchemes?.[0]?.scopes).toContain('mcp:write');
+    expect(refreshTool?.annotations).toEqual({
+      readOnlyHint: false,
+      openWorldHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+    });
 
     const scopeByTool = new Map(getUnifiedTools().map((tool) => [tool.name, tool.requiredScope]));
     for (const tool of tools || []) {
       expect(tool._meta?.securitySchemes?.[0]?.type).toBe('oauth2');
       expect(tool._meta?.securitySchemes?.[0]?.scopes).toContain(scopeByTool.get(tool.name));
       // OpenAI Apps Directory review expects these hints to be explicitly declared.
-      expect(tool.annotations).toEqual({
-        readOnlyHint: true,
+      expect(tool.annotations).toMatchObject({
         openWorldHint: true,
         destructiveHint: false,
         idempotentHint: true,
       });
+      expect(tool.annotations?.readOnlyHint).toBe(tool.name === 'refresh_leagues' ? false : true);
     }
 
     expect(authFetch).toHaveBeenCalledTimes(1);
@@ -349,7 +359,7 @@ describe('fantasy-mcp gateway integration', () => {
     );
     expect(listResponse.status).toBe(200);
     const listPayload = await parseJsonRpcResponse(listResponse);
-    const resource = listPayload.result?.resources?.find((item) => item.uri === 'ui://widget/user-session.html');
+    const resource = listPayload.result?.resources?.find((item) => item.uri === USER_SESSION_WIDGET_URI);
     expect(resource).toBeDefined();
     expect(resource?.mimeType).toBe('text/html;profile=mcp-app');
 
@@ -357,7 +367,7 @@ describe('fantasy-mcp gateway integration', () => {
       buildMcpJsonRpcRequest(
         '/mcp',
         'resources/read',
-        { uri: 'ui://widget/user-session.html' },
+        { uri: USER_SESSION_WIDGET_URI },
         'resources-read-1'
       ),
       env,
@@ -365,7 +375,7 @@ describe('fantasy-mcp gateway integration', () => {
     );
     expect(readResponse.status).toBe(200);
     const readPayload = await parseJsonRpcResponse(readResponse);
-    const content = readPayload.result?.contents?.find((item) => item.uri === 'ui://widget/user-session.html');
+    const content = readPayload.result?.contents?.find((item) => item.uri === USER_SESSION_WIDGET_URI);
     expect(content?.mimeType).toBe('text/html;profile=mcp-app');
     expect(content?.text).toContain('<title>Flaim</title>');
     expect(content?._meta?.ui?.csp?.connectDomains).toEqual([]);
@@ -863,10 +873,13 @@ describe('fantasy-mcp gateway integration', () => {
     expect(response.status).toBe(200);
     const text = await response.text();
     const data = text.split(/\r?\n/).filter((l) => l.startsWith('data:')).map((l) => l.slice(5).trim()).join('\n').trim();
-    const parsed = JSON.parse(data) as { result?: { isError?: boolean; content?: Array<{ text?: string }> } };
+    const parsed = JSON.parse(data) as { result?: { isError?: boolean; content?: Array<{ text?: string }>; _meta?: Record<string, unknown> } };
     // The tool call resolves to the MCP auth error, not a handler result.
     expect(parsed.result?.isError).toBe(true);
     expect(parsed.result?.content?.[0]?.text).toContain('AUTH_FAILED');
+    const challenge = (parsed.result?._meta?.['mcp/www_authenticate'] as string[] | undefined)?.[0];
+    expect(challenge).toContain('scope="mcp:read"');
+    expect(challenge).toContain('resource_metadata="https://api.flaim.app/.well-known/oauth-protected-resource"');
 
     // Handler must NOT run on the denied path.
     expect(espnFetch).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

Adds the phase 2 manual league refresh flow for stale/rolled-season league data:

- adds auth-worker refresh endpoints for Clerk web UI and internal MCP callers
- reuses provider discovery for ESPN, Yahoo, and Sleeper stored connections
- adds the `refresh_leagues` MCP tool with `mcp:write` scope
- adds a ChatGPT widget refresh button that reruns `get_user_session` after refresh
- adds a `/leagues` Sync all action through a new web API proxy
- updates docs and tool inventory from 9 to 10 tools

## Notes

`refresh_leagues` uses `mcp:write` because it can add or update Flaim league records. It remains non-destructive for fantasy rosters: no trades, drops, adds, lineup changes, or roster mutations.

Existing ChatGPT users may need to reauthorize before the widget refresh button can call the new write-scoped tool.

## Validation

- `corepack pnpm --dir workers/auth-worker exec vitest run --reporter=dot`
- `corepack pnpm --dir workers/fantasy-mcp exec vitest run --reporter=dot`
- `corepack pnpm --dir workers/fantasy-mcp exec vitest run -c vitest.integration.config.ts --reporter=dot`
- `corepack pnpm --dir web exec vitest run --reporter=dot`
- `corepack pnpm --dir workers/auth-worker run type-check`
- `corepack pnpm --dir workers/fantasy-mcp run type-check`
- `corepack pnpm --dir web exec tsc --noEmit`
- `git diff --check`
- local `http://localhost:3000/leagues` smoke check returned HTTP 200

## Audit

Subagent audit found two issues before publishing:

- widget could report success after a `success: false` refresh response
- invalid MCP platform args could be filtered into an all-platform refresh

Both were fixed and covered by regression assertions.
