### PR TITLE
Restore published widget resource URI

### DIFF
--- a/workers/fantasy-mcp/src/widgets/user-session-widget.ts
+++ b/workers/fantasy-mcp/src/widgets/user-session-widget.ts
@@ -21,7 +21,7 @@
  * - https://developers.openai.com/apps-sdk/build/chatgpt-ui/
  * - https://developers.openai.com/apps-sdk/build/mcp-server/
  */
-export const USER_SESSION_WIDGET_URI = 'ui://widget/user-session.v2.html';
+export const USER_SESSION_WIDGET_URI = 'ui://widget/user-session.html';
 
 export const USER_SESSION_WIDGET_HTML = `<!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
## Summary
- restore the ChatGPT widget resource URI from ui://widget/user-session.v2.html to the previously published ui://widget/user-session.html
- keep the new refresh button/tool behavior and mcp:write scope intact

## Why
The prod ChatGPT app showed a blank widget frame after PR #131. The text tool response still worked, which points to component resource loading rather than league data. Reusing the already published/reviewed widget URI should restore compatibility while the v1.1 app submission is pending.

## Validation
- corepack pnpm --dir workers/fantasy-mcp exec vitest run src/__tests__/tools.test.ts --reporter=dot
- corepack pnpm --dir workers/fantasy-mcp run type-check
- corepack pnpm --dir workers/fantasy-mcp exec vitest run -c vitest.integration.config.ts --reporter=dot