### PR TITLE
Require explicit refresh success in widget

### DIFF
--- a/workers/fantasy-mcp/src/__tests__/tools.test.ts
+++ b/workers/fantasy-mcp/src/__tests__/tools.test.ts
@@ -142,7 +142,9 @@ describe('fantasy-mcp tools', () => {
     expect(USER_SESSION_WIDGET_HTML).toContain("window.openai.callTool('refresh_leagues', {})");
     expect(USER_SESSION_WIDGET_HTML).toContain("window.openai.callTool('get_user_session', {})");
     expect(USER_SESSION_WIDGET_HTML).toContain('extractRefreshResult');
+    expect(USER_SESSION_WIDGET_HTML).toContain('refreshResult.isError');
     expect(USER_SESSION_WIDGET_HTML).toContain('refreshPayload.success === false');
+    expect(USER_SESSION_WIDGET_HTML).toContain('!refreshPayload || refreshPayload.success !== true');
     expect(USER_SESSION_WIDGET_HTML).toContain('Leagues refreshed.');
     expect(USER_SESSION_WIDGET_HTML).toContain('Refresh failed.');
     expect(USER_SESSION_WIDGET_HTML).toContain('Open leagues');

--- a/workers/fantasy-mcp/src/widgets/user-session-widget.ts
+++ b/workers/fantasy-mcp/src/widgets/user-session-widget.ts
@@ -534,6 +534,9 @@ export const USER_SESSION_WIDGET_HTML = `<!DOCTYPE html>
       if (refreshPayload && refreshPayload.success === false) {
         throw new Error(refreshPayload.error_description || refreshPayload.error || 'No leagues were refreshed');
       }
+      if (!refreshPayload || refreshPayload.success !== true) {
+        throw new Error('Refresh did not complete');
+      }
       var sessionResult = await window.openai.callTool('get_user_session', {});
       var data = extract(sessionResult);
       if (!data && window.openai.toolOutput != null) {


### PR DESCRIPTION
## Summary
- require an explicit success:true payload from refresh_leagues before the widget shows "Leagues refreshed"
- preserve existing success:false and isError handling for auth/provider failures
- add widget-string regression assertions for the error-envelope and no-payload cases

## Why
Prod verification showed recent ChatGPT get_user_session events and real ESPN 2026 football rows, but no refresh_leagues usage events and the current ChatGPT token is still mcp:read. The widget could therefore show a false-positive refresh success after merely reloading session data.

## Validation
- corepack pnpm --dir workers/fantasy-mcp exec vitest run src/__tests__/tools.test.ts --reporter=dot
- corepack pnpm --dir workers/fantasy-mcp run type-check