### PR TITLE
Improve new-user connector onboarding

### DIFF
--- a/web/app/(site)/oauth/consent/page.tsx
+++ b/web/app/(site)/oauth/consent/page.tsx
@@ -146,10 +146,12 @@ function OAuthConsentContent() {
       <div className="min-h-screen bg-background flex items-center justify-center p-4">
         <div className="w-full max-w-md space-y-6">
           <div className="text-center space-y-2">
-            <h1 className="text-2xl font-semibold">Sign in to continue</h1>
-          <p className="text-muted-foreground">
-              Sign in to your Flaim account to authorize access.
-          </p>
+            <h1 className="text-2xl font-semibold">Connect Flaim to your AI app</h1>
+            <p className="text-muted-foreground">
+              Sign in or create a Flaim account to authorize access. New users
+              still need to connect at least one fantasy league in My Leagues
+              before the assistant can answer with league-specific data.
+            </p>
           </div>
           <SignIn
             routing="hash"

--- a/web/components/site/connectors/ConsentScreen.tsx
+++ b/web/components/site/connectors/ConsentScreen.tsx
@@ -53,7 +53,7 @@ export default function ConsentScreen({
         </div>
         <CardTitle>Authorize Flaim Access</CardTitle>
         <CardDescription>
-          An AI app is requesting read-only access to your Flaim account
+          Your AI app is requesting read-only access to your Flaim account
         </CardDescription>
       </CardHeader>
 
@@ -107,9 +107,15 @@ export default function ConsentScreen({
         )}
 
         {/* Security note */}
-        <p className="text-xs text-muted-foreground text-center">
-          You can revoke this access anytime from your AI app&apos;s integration settings.
-        </p>
+        <div className="space-y-2 text-center text-xs text-muted-foreground">
+          <p>
+            New account? After authorizing, open My Leagues to connect ESPN,
+            Yahoo, or Sleeper before asking your assistant for league advice.
+          </p>
+          <p>
+            You can revoke this access anytime from your AI app&apos;s integration settings.
+          </p>
+        </div>
       </CardContent>
 
       <CardFooter className="flex gap-3">

--- a/workers/fantasy-mcp/src/__tests__/tools.test.ts
+++ b/workers/fantasy-mcp/src/__tests__/tools.test.ts
@@ -79,9 +79,15 @@ describe('fantasy-mcp tools', () => {
     const text = result.content?.[0]?.text;
     expect(typeof text).toBe('string');
 
-    const payload = JSON.parse(text as string) as { success?: boolean; totalLeaguesFound?: number };
+    const payload = JSON.parse(text as string) as {
+      success?: boolean;
+      totalLeaguesFound?: number;
+      instructions?: string;
+    };
     expect(payload.success).toBe(true);
     expect(payload.totalLeaguesFound).toBe(0);
+    expect(payload.instructions).toContain('https://flaim.app/leagues');
+    expect(payload.instructions).not.toContain('flaim.app/settings');
 
     // structuredContent mirrors the text payload
     expect(result.structuredContent).toBeDefined();
@@ -148,6 +154,13 @@ describe('fantasy-mcp tools', () => {
     expect(USER_SESSION_WIDGET_HTML).toContain('Open leagues');
     expect(USER_SESSION_WIDGET_HTML).toContain('var hasRendered = false');
     expect(USER_SESSION_WIDGET_HTML).not.toContain('if (rendered) return');
+  });
+
+  it('user session widget opens the empty-state league setup link externally', () => {
+    expect(USER_SESSION_WIDGET_HTML).toContain('Flaim is connected, but no fantasy leagues are set up yet.');
+    expect(USER_SESSION_WIDGET_HTML).toContain('id="connect-league-link"');
+    expect(USER_SESSION_WIDGET_HTML).toContain("connectLeagueLink.addEventListener('click', openLeagues)");
+    expect(USER_SESSION_WIDGET_HTML).toContain('window.openai.openExternal({ href: LEAGUES_URL })');
   });
 
   it('refresh_leagues forwards the user auth and internal token to auth-worker', async () => {

--- a/workers/fantasy-mcp/src/mcp/tools.ts
+++ b/workers/fantasy-mcp/src/mcp/tools.ts
@@ -741,7 +741,7 @@ export function getUnifiedTools(): UnifiedTool[] {
           if (!hasLeagues) {
             sessionMessage = hasRawLeagues
               ? 'No current-season leagues found. Provider data exists, but every returned league is for a non-current season. Do not treat historical leagues as active; use get_ancient_history only when the user asks about past seasons.'
-              : 'No leagues configured. Please go to flaim.app/settings to add your fantasy platform credentials.';
+              : 'No leagues configured. Ask the user to open https://flaim.app/leagues and connect ESPN, Yahoo, or Sleeper before using Flaim for league-specific advice.';
           } else if (leagues.length === 1) {
             const league = leagues[0];
             sessionMessage = `Use platform="${league.platform}", sport="${league.sport}", leagueId="${league.leagueId}", teamId="${league.teamId || 'none'}", seasonYear=${league.seasonYear} for all tool calls.`;

--- a/workers/fantasy-mcp/src/widgets/user-session-widget.ts
+++ b/workers/fantasy-mcp/src/widgets/user-session-widget.ts
@@ -396,7 +396,7 @@ export const USER_SESSION_WIDGET_HTML = `<!DOCTYPE html>
       container.innerHTML =
         '<div class="empty-state">' +
         'Flaim is connected, but no fantasy leagues are set up yet.<br>' +
-        '<a href="https://flaim.app/leagues" target="_blank" rel="noopener" id="connect-league-link">Open My Leagues</a>' +
+        '<a href="' + LEAGUES_URL + '" target="_blank" rel="noopener" id="connect-league-link">Open My Leagues</a>' +
         '</div>';
       var connectLeagueLink = document.getElementById('connect-league-link');
       if (connectLeagueLink) connectLeagueLink.addEventListener('click', openLeagues);

--- a/workers/fantasy-mcp/src/widgets/user-session-widget.ts
+++ b/workers/fantasy-mcp/src/widgets/user-session-widget.ts
@@ -198,9 +198,17 @@ export const USER_SESSION_WIDGET_HTML = `<!DOCTYPE html>
     font-size: 13px;
   }
   .empty-state a {
-    color: #0b1222;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 32px;
+    margin-top: 12px;
+    padding: 6px 12px;
+    border-radius: 999px;
+    background: #0b1222;
+    color: #fff;
     font-weight: 600;
-    text-decoration: underline;
+    text-decoration: none;
   }
   .loading {
     text-align: center;
@@ -387,9 +395,11 @@ export const USER_SESSION_WIDGET_HTML = `<!DOCTYPE html>
     if (!data || !data.allLeagues || data.allLeagues.length === 0) {
       container.innerHTML =
         '<div class="empty-state">' +
-        'No leagues found.<br>' +
-        '<a href="https://flaim.app/leagues" target="_blank" rel="noopener">Connect a league</a>' +
+        'Flaim is connected, but no fantasy leagues are set up yet.<br>' +
+        '<a href="https://flaim.app/leagues" target="_blank" rel="noopener" id="connect-league-link">Open My Leagues</a>' +
         '</div>';
+      var connectLeagueLink = document.getElementById('connect-league-link');
+      if (connectLeagueLink) connectLeagueLink.addEventListener('click', openLeagues);
       hasRendered = true;
       queueSizeChanged();
       return;


### PR DESCRIPTION
## Summary

Fixes the new-user connector onboarding gap from FLA-158.

- clarifies the OAuth sign-in/sign-up copy so new users know a Flaim account still needs a connected league
- updates zero-league `get_user_session` instructions to send users to `https://flaim.app/leagues` instead of the stale settings path
- changes the ChatGPT widget empty state to say Flaim is connected but no leagues are set up yet
- wires the empty-state `Open My Leagues` CTA through the existing external-open helper

## Why

New users who start in ChatGPT can authorize Flaim before they have any leagues connected. The previous flow technically connected the app, but it did not clearly explain the remaining My Leagues setup step, and the empty widget CTA did not use the same external navigation path as the header edit link.

## Validation

- `corepack pnpm --dir workers/fantasy-mcp exec vitest run src/__tests__/tools.test.ts`
- `corepack pnpm --dir workers/fantasy-mcp exec vitest run -c vitest.integration.config.ts tests/integration/index.integration.test.ts`
- `corepack pnpm --dir workers/fantasy-mcp run type-check`
- `corepack pnpm --dir web exec eslint 'app/(site)/oauth/consent/page.tsx' components/site/connectors/ConsentScreen.tsx`
- `corepack pnpm --dir web exec tsc --noEmit`
- `git diff --check`
