### PR TITLE
Add API root metadata route

### DIFF
--- a/workers/README.md
+++ b/workers/README.md
@@ -160,6 +160,7 @@ corepack pnpm --dir workers/sleeper-client run deploy:preview                # o
 ```
 
 Workers use custom routes via `api.flaim.app`:
+- `/` → fantasy-mcp metadata response
 - `/auth/*` → auth-worker
 - `/fantasy/*` → fantasy-mcp (unified gateway)
 - `/mcp*` → fantasy-mcp (primary MCP endpoint, POST required; non-POST returns `405`)

--- a/workers/fantasy-mcp/README.md
+++ b/workers/fantasy-mcp/README.md
@@ -27,6 +27,7 @@ fantasy-mcp (this worker)
 
 | Endpoint | Method | Purpose |
 |----------|--------|---------|
+| `/` | GET/HEAD | API metadata response for `api.flaim.app` root |
 | `/health` | GET | Health check with binding status |
 | `/fantasy/health` | GET | Same (for routed access) |
 | `/.well-known/oauth-protected-resource` | GET | OAuth metadata (RFC 9728) |

--- a/workers/fantasy-mcp/src/index.ts
+++ b/workers/fantasy-mcp/src/index.ts
@@ -35,6 +35,17 @@ const API_ROBOTS_TXT = [
   '',
 ].join('\n');
 
+const API_ROOT_METADATA = {
+  service: 'Flaim API',
+  status: 'ok',
+  endpoints: {
+    mcp: 'https://api.flaim.app/mcp',
+    oauth_authorization_server: 'https://api.flaim.app/.well-known/oauth-authorization-server',
+    oauth_protected_resource: 'https://api.flaim.app/.well-known/oauth-protected-resource',
+    health: 'https://api.flaim.app/auth/health',
+  },
+};
+
 function robotsResponse(): Response {
   return new Response(API_ROBOTS_TXT, {
     status: 200,
@@ -42,6 +53,22 @@ function robotsResponse(): Response {
       'Content-Type': 'text/plain; charset=utf-8',
       'Cache-Control': 'public, max-age=3600',
     },
+  });
+}
+
+function apiRootMetadataResponse(method: string): Response {
+  const headers = {
+    'Content-Type': 'application/json',
+    'Cache-Control': 'public, max-age=3600',
+  };
+
+  if (method === 'HEAD') {
+    return new Response(null, { status: 200, headers });
+  }
+
+  return new Response(JSON.stringify(API_ROOT_METADATA), {
+    status: 200,
+    headers,
   });
 }
 
@@ -82,6 +109,8 @@ app.use('*', async (c, next) => {
   });
   return undefined;
 });
+
+app.on(['GET', 'HEAD'], '/', (c) => apiRootMetadataResponse(c.req.method));
 
 // Shared health check logic
 async function buildHealthData(env: Env) {

--- a/workers/fantasy-mcp/src/index.ts
+++ b/workers/fantasy-mcp/src/index.ts
@@ -42,7 +42,7 @@ const API_ROOT_METADATA = {
     mcp: 'https://api.flaim.app/mcp',
     oauth_authorization_server: 'https://api.flaim.app/.well-known/oauth-authorization-server',
     oauth_protected_resource: 'https://api.flaim.app/.well-known/oauth-protected-resource',
-    health: 'https://api.flaim.app/auth/health',
+    health: 'https://api.flaim.app/fantasy/health',
   },
 };
 

--- a/workers/fantasy-mcp/tests/integration/index.integration.test.ts
+++ b/workers/fantasy-mcp/tests/integration/index.integration.test.ts
@@ -158,6 +158,53 @@ function buildEnv(authFetch: (request: Request) => Promise<Response>): Env {
 }
 
 describe('fantasy-mcp gateway integration', () => {
+  it('serves controlled metadata at the API host root', async () => {
+    const authFetch = vi.fn(async () => new Response('unexpected', { status: 500 }));
+    const env = buildEnv(authFetch);
+
+    const response = await app.fetch(
+      new Request('https://api.flaim.app/'),
+      env,
+      mockExecutionContext()
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toContain('application/json');
+    expect(response.headers.get('Cache-Control')).toBe('public, max-age=3600');
+    const payload = await response.json() as {
+      service?: string;
+      status?: string;
+      endpoints?: Record<string, string>;
+    };
+    expect(payload).toMatchObject({
+      service: 'Flaim API',
+      status: 'ok',
+      endpoints: {
+        mcp: 'https://api.flaim.app/mcp',
+        oauth_authorization_server: 'https://api.flaim.app/.well-known/oauth-authorization-server',
+        oauth_protected_resource: 'https://api.flaim.app/.well-known/oauth-protected-resource',
+        health: 'https://api.flaim.app/auth/health',
+      },
+    });
+    expect(authFetch).not.toHaveBeenCalled();
+  });
+
+  it('handles HEAD at the API host root without an auth lookup', async () => {
+    const authFetch = vi.fn(async () => new Response('unexpected', { status: 500 }));
+    const env = buildEnv(authFetch);
+
+    const response = await app.fetch(
+      new Request('https://api.flaim.app/', { method: 'HEAD' }),
+      env,
+      mockExecutionContext()
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toContain('application/json');
+    expect(await response.text()).toBe('');
+    expect(authFetch).not.toHaveBeenCalled();
+  });
+
   it('rejects GET with 405 on MCP transport endpoints', async () => {
     const authFetch = vi.fn(async () => new Response('unexpected', { status: 500 }));
     const env = buildEnv(authFetch);

--- a/workers/fantasy-mcp/tests/integration/index.integration.test.ts
+++ b/workers/fantasy-mcp/tests/integration/index.integration.test.ts
@@ -183,7 +183,7 @@ describe('fantasy-mcp gateway integration', () => {
         mcp: 'https://api.flaim.app/mcp',
         oauth_authorization_server: 'https://api.flaim.app/.well-known/oauth-authorization-server',
         oauth_protected_resource: 'https://api.flaim.app/.well-known/oauth-protected-resource',
-        health: 'https://api.flaim.app/auth/health',
+        health: 'https://api.flaim.app/fantasy/health',
       },
     });
     expect(authFetch).not.toHaveBeenCalled();

--- a/workers/fantasy-mcp/wrangler.jsonc
+++ b/workers/fantasy-mcp/wrangler.jsonc
@@ -23,6 +23,10 @@
       },
       "routes": [
         {
+          "pattern": "api.flaim.app",
+          "zone_name": "flaim.app"
+        },
+        {
           "pattern": "api.flaim.app/fantasy/*",
           "zone_name": "flaim.app"
         },


### PR DESCRIPTION
## Summary
- add an exact Cloudflare route for the api.flaim.app root
- serve controlled JSON metadata from GET/HEAD /
- document the API root route and cover it in fantasy-mcp integration tests

## Why
The bare api.flaim.app host currently falls through to the configured origin and returns a Cloudflare 522. The actual API/MCP/OAuth routes are healthy, but the root response is misleading during manual checks and monitoring. This makes the root path explicit without broadening the route surface.

## Verification
- corepack pnpm --dir workers/fantasy-mcp exec vitest run -c vitest.integration.config.ts tests/integration/index.integration.test.ts
- corepack pnpm --dir workers/fantasy-mcp run type-check
- git diff --check
- corepack pnpm --dir workers/fantasy-mcp exec wrangler deploy --env prod --dry-run